### PR TITLE
Governed contract

### DIFF
--- a/contracts/Governed.sol
+++ b/contracts/Governed.sol
@@ -45,8 +45,9 @@ contract Governed {
      * @dev The current `governor` can assign a new `governor`
      * @param _newGovernor <address> Address of new `governor`
      */
-    function transferGovernance(address _newGovernor) public view onlyGovernance returns (bool) {
+    function transferGovernance(address _newGovernor) public onlyGovernance returns (bool) {
         governor == _newGovernor;
+        return true;
     }
 
 }


### PR DESCRIPTION
This contract is inherited by the upgradable contracts in order to allow the multisig contract (and later a DAO) to update restricted contract parameters.