### PR TITLE
GNS Interfaces

### DIFF
--- a/contracts/GNS.sol
+++ b/contracts/GNS.sol
@@ -153,7 +153,10 @@ contract GNS is Governed {
      * @param _subdomainHash <bytes32> - Name of the subdomain
      * @return subdomainSubgraphID <bytes32> - IPLD SubgraphID of the subdomain
      */
-    function getSubdomainSubgraphId (bytes32 _domainHash, bytes32 _subdomainHash) external returns (bytes32 subdomainSubgraphID);
+    function getSubdomainSubgraphId (
+        bytes32 _domainHash,
+        bytes32 _subdomainHash
+    ) external returns (bytes32 subdomainSubgraphID);
 
 
     /*


### PR DESCRIPTION
Initial run of interface functions for GNS contracts, follows modified CRUD pattern.
Allows for the transfer of domains and registering of subdomains.

QUESTION:
The GNS is removing all commit/reveal bidding functionality ala ENS correct?

#18 