### PR TITLE
Expose ERC20 token contract variables in Graph Token

### DIFF
--- a/contracts/GraphToken.sol
+++ b/contracts/GraphToken.sol
@@ -50,8 +50,8 @@ contract GraphToken is
     uint8 public decimals = 18;
 
     // ERC20 variables made public
-    mapping (address => uint256) public _balances;
-    uint256 public _totalSupply;
+    mapping (address => uint256) _balances;
+    uint256 _totalSupply;
 
     // Treasurers map to true
     mapping (address => bool) public treasurers;


### PR DESCRIPTION
While working with this contract in Truffle, I was unable to compile because the Open Zeppelin contract ERC20.sol declares `_balances`, `_allowed`, and `_totalSupply` as `private` but we are trying to access these in `GraphToken`. 
I declared `_balances` and `_totalSupply` as `public` in `GraphToken` to get it to compile.