### PR TITLE
Truffle prep: Remove revert from contract constructors

### DIFF
--- a/contracts/DisputeManager.sol
+++ b/contracts/DisputeManager.sol
@@ -68,10 +68,7 @@ contract DisputeManager is Governed {
 
     /* Contract Constructor */
     /* @param _governor <address> - Address of the multisig contract as Governor of this contract */
-    constructor (address _governor) public Governed(_governor)
-    {
-        revert();
-    }
+    constructor (address _governor) public Governed(_governor) {}
 
     /* Graph Protocol Functions */
     /**

--- a/contracts/GNS.sol
+++ b/contracts/GNS.sol
@@ -56,10 +56,7 @@ contract GNS is Governed {
 
     /* Contract Constructor */
     /* @param _governor <address> - Address of the multisig contract as Governor of this contract */
-    constructor (address _governor) public Governed (_governor)
-    {
-        revert();
-    }
+    constructor (address _governor) public Governed (_governor) {}
 
     /* Graph Protocol Functions */
 

--- a/contracts/RewardsManager.sol
+++ b/contracts/RewardsManager.sol
@@ -56,10 +56,7 @@ contract RewardsManager is Governed {
      * @dev Reward Manager Contract Constructor
      * @param _governor <address> - Address of the multisig contract as Governor of this contract
      */
-    constructor (address _governor) public Governed (_governor)
-    {
-        revert();
-    }
+    constructor (address _governor) public Governed (_governor) {}
 
     /* Graph Protocol Functions */
     /**

--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -25,10 +25,7 @@ contract ServiceRegistry is Governed {
 
     /* Contract Constructor */
     /* @param _governor <address> - Address of the multisig contract as Governor of this contract */
-    constructor (address _governor) public Governed (_governor)
-    {
-        revert();
-    }
+    constructor (address _governor) public Governed (_governor) {}
 
     /* Graph Protocol Functions */
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -87,10 +87,7 @@ contract Staking is Governed {
      * @dev Staking Contract Constructor
      * @param _governor <address> - Address of the multisig contract as Governor of this contract
      */
-    constructor (address _governor) public Governed (_governor)
-    {
-        revert();
-    }
+    constructor (address _governor) public Governed (_governor) {}
 
     /**
      * @dev Set the Minimum Staking Amount for Market Curators


### PR DESCRIPTION
Prepare contracts to deploy for use with Truffle tests.