### PR TITLE
Expose `removeToken` for mintable token tests

### DIFF
--- a/contracts/GraphToken.sol
+++ b/contracts/GraphToken.sol
@@ -54,10 +54,10 @@ contract GraphToken is
     }
 
     /**
-     * @dev Method to expose `removeToken` while using the `onlyMinter` modifier
+     * @dev Method to expose `removeToken` while using the `onlyGovernor` modifier
      * @param _account <address> Address of account to remove from `_minters`
      */
-    function removeMinter(address _account) public onlyMinter {
+    function removeMinter(address _account) public onlyGovernance {
         _removeMinter(_account);
     }
 


### PR DESCRIPTION
#59 requires `removeToken` to be reachable. This added function in `GraphToken.sol` fixes the tests in that branch.

Once this is merged to `master`, it will be rebased into #59 and that PR will be marked to review.