### PR TITLE
Rename `transfer` -> `transferWithData`

### DIFF
--- a/contracts/GraphToken.sol
+++ b/contracts/GraphToken.sol
@@ -80,8 +80,9 @@ contract GraphToken is
     /*
      * @dev Transfer Graph tokens to the Staking interface
      * @notice Interacts with Staking contract
+     * @notice Overriding `transfer` was not working with web3.js so we renamed to `transferWithData`
      */
-    function transfer(
+    function transferWithData(
         address _to,
         uint256 _amount,
         bytes memory _data


### PR DESCRIPTION
We were having issues getting `transfer(address,uint256,bytes)` override working with the test suite, so we renamed it to `transferWithData`. This should be okay as this function is only intended to work internally for the Graph protocol interactions and not with any exchanges or other external parties.