### PR TITLE
Rewards Managements

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -312,7 +312,7 @@ contract Staking is Governed, TokenReceiver
     {
         // Reserve Ratio must be within 0% to 100% (exclusive)
         require(_defaultReserveRatio > 0);
-        require(_defaultReserveRatio < MAX_PPM);
+        require(_defaultReserveRatio <= MAX_PPM);
         defaultReserveRatio = _defaultReserveRatio;
         return true;
     }


### PR DESCRIPTION
- Adds channel settlement to list of actions that `tokensReceived()` can process
- Channel settlement allocates portion of fees to curators based on shares (1 share = 1 basis point of fees earned)
- Curator fees are added to curation stake, to be reclaimed upon logout
- Indexing Nodes can withdraw fees through `withdrawFees()`
- All fees are withdrawn on log out
- All fees are sent to Governance on slashing (but Indexing Node can withdraw them)

Partially Fixes  #11