### PR TITLE
Fix Curation Tests

### DIFF
--- a/test/staking/curation.test.js
+++ b/test/staking/curation.test.js
@@ -18,7 +18,7 @@ contract('Staking (Curation)', ([
    * testing constants & variables
    */
   const minimumCurationStakingAmount = 100,
-    defaultReserveRatio = 10,
+    defaultReserveRatio = 500000,
     minimumIndexingStakingAmount = 100,
     maximumIndexers = 10,
     slashingPercent = 10,


### PR DESCRIPTION
I was sending the amount of tokens staked, not the number of shares issued. Fixed.

I removed the test for using the JS module. The module does make staking a little easier but we discussed deprecating it, as it was meant to become an NPM package that could be used isomorphically. I'll phase this module out and remove it if time permits. 