### PR TITLE
Disallow Curator purchase of more than 100% of Indexer rewards

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -556,6 +556,11 @@ contract Staking is Governed, TokenReceiver, BancorFormula
             // Update the amount of shares issued to _curator, and total amount issued
             curators[_curator][_subgraphId].subgraphShares += _newShares;
             subgraphs[_subgraphId].totalCurationShares += _newShares;
+
+            // Ensure curators cannot stake more than 100% in basis points
+            // Note: ensures that distributeChannelFees() does not revert
+            require(subgraphs[_subgraphId].totalCurationShares
+                    <= (MAX_PPM / BASIS_PT));
         }
 
         // Emit the CurationNodeStaked event (updating the running tally)


### PR DESCRIPTION
This fix ensures that this scenario is avoided.
Total number of shares must be equal to or less than 10,000 BPs (100%), if purchasing more then it will revert.

Ensures that `distributeChannelFees()` does not revert later on (blocking withdrawal)