### PR TITLE
Use `eth_sign` instead of `eth_signTypedData` as a hack until EIP-712 is in common use

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -707,7 +707,10 @@ contract Staking is Governed, TokenReceiver, BancorFormula
 
         // Obtain the hash of the fully-encoded message, per EIP-712 encoding
         bytes32 _disputeId = keccak256(abi.encode(
-                "\x19\x01", // EIP-191 encoding pad, EIP-712 version 1
+                // HACK: Remove this line until eth_signTypedData is in common use
+                //"\x19\x01", // EIP-191 encoding pad, EIP-712 version 1
+                "\x19Ethereum Signed Message:\n", 64, // 64 bytes (2 hashes)
+                // END HACK
                 keccak256(abi.encode( // EIP 712 domain separator
                         DOMAIN_TYPE_HASH,
                         DOMAIN_NAME_HASH,


### PR DESCRIPTION
Not every end-user library has `eth_signTypedData` implemented yet, so this PR modifies the Solidity contract assuming `eth_sign` Web3 API is used instead to generate the signature of the Attestation messages. It is drop-in replaceable for when EIP-712 APIs are made available, and is safe to use in production (if necessary).