### PR TITLE
Add owner to SubgraphCreated event

### DIFF
--- a/contracts/GNS.sol
+++ b/contracts/GNS.sol
@@ -50,7 +50,8 @@ contract GNS is Governed {
     event SubgraphCreated(
         bytes32 indexed topLevelDomainHash,
         bytes32 indexed registeredHash,
-        string subdomainName
+        string subdomainName,
+        address indexed owner
     );
     event SubgraphIDUpdated(bytes32 indexed domainHash, bytes32 indexed subgraphID);
     event DomainDeleted(bytes32 indexed domainHash);
@@ -126,7 +127,7 @@ contract GNS is Governed {
         // Note - subdomain name and IPFS hash are only emitted through the events.
         // Note - if the subdomain is blank, the domain hash ends up being the top level
         // domain hash, not the hash of a blank string.
-        emit SubgraphCreated(_topLevelDomainHash, domainHash, _subdomainName);
+        emit SubgraphCreated(_topLevelDomainHash, domainHash, _subdomainName, msg.sender);
         emit SubgraphMetadataChanged(domainHash, _ipfsHash);
     }
 


### PR DESCRIPTION
We consider a Subgraph to be 2 things:
1. The actual subgraph as we are used to
2. The owner of a subgraph, i.e. a user

So in case 2. I need an "owner" which will be the Ethereum address of a person who signed up in Explorer dapp. 