### PR TITLE
Enable ABIEncoderV2

### DIFF
--- a/contracts/DisputeManager.sol
+++ b/contracts/DisputeManager.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 /*
  * @title Dispute management

--- a/contracts/GNS.sol
+++ b/contracts/GNS.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 import "./Governed.sol";
 

--- a/contracts/GraphToken.sol
+++ b/contracts/GraphToken.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 /*
  * @title GraphToken contract

--- a/contracts/RewardsManager.sol
+++ b/contracts/RewardsManager.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 import "./Governed.sol";
 

--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 import "./Governed.sol";
 

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.6.4;
+pragma experimental ABIEncoderV2;
 
 /*
  * @title Staking contract


### PR DESCRIPTION
Enabled the pragma to compile contracts with new encoder. Now we can pass structs to function and also return them.

I didn't change how contracts work at this point, we can use this feature as we refactor.

Tried it on a test like
```
const disputeID = this.dispute.messageHash
console.log(
    await this.disputeManager.disputes(disputeID),
)
```

Work like a charm 🚀

Merge https://github.com/graphprotocol/contracts/pull/165 before this one.