### PR TITLE
Update fisherman minimum deposit to be a fixed amount

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,19 +1,20 @@
 ## Deploying the Solidity Smart Contracts via Truffle
 
 `/migrations/2_deploy_contracts.js` contains the parameters needed to deploy the contracts. Please edit these params as you see fit.
+
 ```
 const initialSupply = 1000000, // total supply of Graph Tokens at time of deployment
   minimumCurationStakingAmount = 100, // minimum amount allowed to be staked by Market Curators
   defaultReserveRatio = 500000, // reserve ratio (percent as PPM)
   minimumIndexingStakingAmount = 100, // minimum amount allowed to be staked by Indexing Nodes
   maximumIndexers = 10, // maximum number of Indexing Nodes staked higher than stake to consider
-  slashingPercent = 10, // percent of stake to slash in successful dispute
+  slashingPercentage = 10, // percent of stake to slash in successful dispute
   thawingPeriod = 60 * 60 * 24 * 7, // amount of seconds to wait until indexer can finish stake logout
   multiSigRequiredVote = 0, // votes required (setting a required amount here will override a formula used later)
   multiSigOwners = [] // add addresses of the owners of the multisig contract here
 ```
 
-The `MultiSigWallet` contract is deployed first in order to retain its address for use in deploying the remaining contracts. 
+The `MultiSigWallet` contract is deployed first in order to retain its address for use in deploying the remaining contracts.
 
 The `Staking` contract requires both the address of the `MultiSigWallet` and the `GraphToken`.
 

--- a/graphProtocol.js
+++ b/graphProtocol.js
@@ -107,11 +107,11 @@ module.exports = (options = {}) => {
     }
 
     /**
-     * @dev Getter for `slashingPercent`
-     * @returns {Number} Slashing percent
+     * @dev Getter for `slashingPercentage`
+     * @returns {Number} Slashing percentage
      */
-    static slashingPercent() {
-      return Staking.slashingPercent()
+    static slashingPercentage() {
+      return Staking.slashingPercentage()
     }
 
     /**

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -22,7 +22,7 @@ const minimumIndexingStakingAmount = new BN('100000000000000000000')
 // maximum number of Indexing Nodes staked higher than stake to consider
 const maximumIndexers = 10
 // percent of stake to slash in successful dispute
-// const slashingPercent = 10
+// const slashingPercentage = 10
 // amount of seconds to wait until indexer can finish stake logout
 const thawingPeriod = 60 * 60 * 24 * 7
 // votes required (setting a required amount here will override a formula used later)

--- a/test/lib/deployment.js
+++ b/test/lib/deployment.js
@@ -40,14 +40,17 @@ function deployDisputeManagerContract(
   staking,
   params,
 ) {
-  const slashingPercent = helpers.stakingConstants.slashingPercent
+  const slashingPercentage = helpers.stakingConstants.slashingPercentage
+  const minimumDisputeDepositAmount =
+    helpers.stakingConstants.minimumDisputeDepositAmount
 
   return DisputeManager.new(
     owner,
     graphToken,
     arbitrator,
     staking,
-    slashingPercent,
+    slashingPercentage,
+    minimumDisputeDepositAmount,
     params,
   )
 }

--- a/test/lib/testHelpers.js
+++ b/test/lib/testHelpers.js
@@ -297,11 +297,13 @@ module.exports = {
   stakingConstants: {
     // 100 * 10^18 minimum amount allowed to be staked by Market Curators
     minimumCurationStakingAmount: new BN('100000000000000000000'),
-    // 100 * 10^18 minimum amount allowed to be staked by Market Curators
+    // 100 * 10^18 minimum amount allowed to be staked by Indexers
     minimumIndexingStakingAmount: new BN('100000000000000000000'),
+    // 100 * 10^18 minimum amount required as deposit to create a Dispute
+    minimumDisputeDepositAmount: new BN('100000000000000000000'),
     defaultReserveRatio: 500000,
     maximumIndexers: 10,
-    slashingPercent: 1000,
+    slashingPercentage: 1000,
     thawingPeriod: 60 * 60 * 24 * 7, // In seconds
     thawingPeriodSimple: 0,
   },


### PR DESCRIPTION
Use a fixed minimumFishermanDeposit as a requirement when a Fisherman wants to create a new dispute.