### PR TITLE
staking: allocate use channel public key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9340,7 +9340,8 @@
         "prettier": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-          "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
+          "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+          "dev": true
         },
         "semver": {
           "version": "7.3.2",


### PR DESCRIPTION
- When allocating stake to subgraph the index node now must send the **public key** used in the payment channel.
- `Allocate()` advertises the **public key** in the AllocationCreated event so we can capture in our Network Subgraph, using that information consumers can route payments to the index node.
- `Allocate()` calculates the signer address of the index node in the payment channel by getting the Ethereum address from the public key.
- The signer address is used, as before, as one of the parties in the channel multisig and is validated to avoid reuse.

NOTE:
- This implementation uses a feature from Solidity 0.6 called array slices. https://solidity.readthedocs.io/en/v0.6.0/types.html#array-slices
- The linter and prettier still don't handle well that syntax.

Reported issues to both projects:
- https://github.com/duaraghav8/Ethlint/issues/284
- https://github.com/prettier-solidity/prettier-plugin-solidity/issues/269