### PR TITLE
GNS: cleanup and v1

### DIFF
--- a/contracts/GNS.sol
+++ b/contracts/GNS.sol
@@ -44,7 +44,7 @@ contract GNS is Governed {
     event SubgraphTransferred(bytes32 nameHash, address from, address to);
 
     modifier onlyRecordOwner(bytes32 _nameHash) {
-        require(msg.sender == records[_nameHash].owner, "Only record owner can call");
+        require(msg.sender == records[_nameHash].owner, "GNS: Only record owner can call");
         _;
     }
 
@@ -69,7 +69,7 @@ contract GNS is Governed {
         bytes32 nameHash = keccak256(bytes(_name));
         require(
             !isReserved(nameHash) || records[nameHash].owner == owner,
-            "Record reserved, only owner can publish"
+            "GNS: Record reserved, only record owner can publish"
         );
 
         records[nameHash] = Record(owner, _subgraphID, RecordType.GNS);
@@ -91,7 +91,8 @@ contract GNS is Governed {
      * @param _to Address of the new owner
      */
     function transfer(bytes32 _nameHash, address _to) external onlyRecordOwner(_nameHash) {
-        require(records[_nameHash].owner != _to, "Cannot transfer to itself");
+        require(_to != address(0), "GNS: Cannot transfer to empty address");
+        require(records[_nameHash].owner != _to, "GNS: Cannot transfer to itself");
         records[_nameHash].owner = _to;
         emit SubgraphTransferred(_nameHash, msg.sender, _to);
     }

--- a/test/curation.test.js
+++ b/test/curation.test.js
@@ -39,7 +39,7 @@ contract('Curation', ([me, other, governor, curator, staking]) => {
     await this.grt.approve(this.curation.address, this.curatorTokens, { from: staking })
 
     // Randomize a subgraphId
-    this.subgraphId = helpers.randomSubgraphIdHex0x()
+    this.subgraphId = helpers.randomSubgraphId()
   })
 
   describe('configuration', function() {
@@ -146,7 +146,7 @@ contract('Curation', ([me, other, governor, curator, staking]) => {
 
   context('> bonding curve', function() {
     beforeEach(function() {
-      this.subgraphId = helpers.randomSubgraphIdHex0x()
+      this.subgraphId = helpers.randomSubgraphId()
     })
 
     it('convert shares to tokens', async function() {

--- a/test/disputes.test.js
+++ b/test/disputes.test.js
@@ -205,7 +205,7 @@ contract('Disputes', ([me, other, governor, arbitrator, indexer, fisherman, othe
       const receipt = {
         requestCID: web3.utils.randomHex(32),
         responseCID: web3.utils.randomHex(32),
-        subgraphID: helpers.randomSubgraphIdHex0x(),
+        subgraphID: helpers.randomSubgraphId(),
       }
       this.dispute = await attestation.createDispute(
         receipt,

--- a/test/gns.test.js
+++ b/test/gns.test.js
@@ -1,7 +1,123 @@
-// const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
+const { utils } = require('ethers')
+const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 
-// // contracts
-// const GNS = artifacts.require('./GNS.sol')
-// const helpers = require('./lib/testHelpers')
+const deployment = require('./lib/deployment')
+const helpers = require('./lib/testHelpers')
 
-// contract('GNS', accounts => {})
+contract('GNS', ([me, other, governor]) => {
+  beforeEach(async function() {
+    this.gns = await deployment.deployGNS(governor, { from: me })
+    this.record = {
+      name: 'graph',
+      nameHash: utils.id('graph'),
+      subgraphID: helpers.randomSubgraphId(),
+      metadataHash: '0xeb50d096ba95573ae31640e38e4ef64fd02eec174f586624a37ea04e7bd8c751',
+    }
+
+    this.publish = params =>
+      this.gns.publish(this.record.name, this.record.subgraphID, this.record.metadataHash, params)
+    this.unpublish = params => this.gns.unpublish(this.record.nameHash, params)
+  })
+
+  describe('isReserved()', function() {
+    it('should return if the name is reserved', async function() {
+      expect(await this.gns.isReserved(this.record.nameHash)).to.be.eq(false)
+      await this.publish({ from: me })
+      expect(await this.gns.isReserved(this.record.nameHash)).to.be.eq(true)
+    })
+  })
+
+  describe('publish()', async function() {
+    it('should publish a version', async function() {
+      const { logs } = await this.publish({ from: me })
+
+      // State updated
+      const record = await this.gns.records(this.record.nameHash)
+      expect(record.owner).to.be.eq(me)
+      expect(record.subgraphID).to.be.eq(this.record.subgraphID)
+
+      // Event emitted
+      expectEvent.inLogs(logs, 'SubgraphPublished', {
+        name: this.record.name,
+        owner: me,
+        subgraphID: this.record.subgraphID,
+        metadataHash: this.record.metadataHash,
+      })
+    })
+
+    it('should allow re-publish', async function() {
+      await this.publish({ from: me })
+      await this.publish({ from: me })
+    })
+
+    it('reject publish if overwritting with different account', async function() {
+      await this.publish({ from: me })
+      await expectRevert(
+        this.publish({ from: other }),
+        'GNS: Record reserved, only record owner can publish',
+      )
+    })
+  })
+
+  describe('unpublish()', async function() {
+    it('should unpublish a name', async function() {
+      await this.publish({ from: me })
+      const { logs } = await this.unpublish({ from: me })
+
+      // State updated
+      const record = await this.gns.records(this.record.nameHash)
+      expect(record.owner).to.be.eq(helpers.zeroAddress())
+
+      // Event emitted
+      expectEvent.inLogs(logs, 'SubgraphUnpublished', {
+        nameHash: this.record.nameHash,
+      })
+    })
+
+    it('reject unpublish if not the owner', async function() {
+      await expectRevert(this.unpublish({ from: other }), 'GNS: Only record owner can call')
+    })
+  })
+
+  describe('transfer()', function() {
+    beforeEach(async function() {
+      await this.publish({ from: me })
+    })
+
+    it('should transfer to new owner', async function() {
+      const { logs } = await this.gns.transfer(this.record.nameHash, other, { from: me })
+
+      // State updated
+      const record = await this.gns.records(this.record.nameHash)
+      expect(record.owner).to.be.eq(other)
+
+      // Event emitted
+      expectEvent.inLogs(logs, 'SubgraphTransferred', {
+        nameHash: this.record.nameHash,
+        from: me,
+        to: other,
+      })
+    })
+
+    it('reject transfer if not owner', async function() {
+      await expectRevert(
+        this.gns.transfer(this.record.nameHash, other, { from: other }),
+        'GNS: Only record owner can call',
+      )
+    })
+
+    it('reject transfer to empty address', async function() {
+      await expectRevert(
+        this.gns.transfer(this.record.nameHash, helpers.zeroAddress(), { from: me }),
+        'GNS: Cannot transfer to empty address',
+      )
+    })
+
+    it('reject transfer to itself', async function() {
+      await expectRevert(
+        this.gns.transfer(this.record.nameHash, me, { from: me }),
+        'GNS: Cannot transfer to itself',
+      )
+    })
+  })
+})

--- a/test/lib/deployment.js
+++ b/test/lib/deployment.js
@@ -2,6 +2,7 @@
 const Curation = artifacts.require('./Curation.sol')
 const DisputeManager = artifacts.require('./DisputeManager')
 const EpochManager = artifacts.require('./EpochManager')
+const GNS = artifacts.require('./GNS')
 const GraphToken = artifacts.require('./GraphToken.sol')
 const ServiceRegisty = artifacts.require('./ServiceRegistry.sol')
 const Staking = artifacts.require('./Staking.sol')
@@ -40,6 +41,10 @@ function deployEpochManagerContract(owner, params) {
   return EpochManager.new(owner, defaults.epochs.lengthInBlocks, params)
 }
 
+function deployGNS(owner, params) {
+  return GNS.new(owner, params)
+}
+
 function deployServiceRegistry(owner) {
   return ServiceRegisty.new({ from: owner })
 }
@@ -56,6 +61,7 @@ module.exports = {
   deployCurationContract,
   deployDisputeManagerContract,
   deployEpochManagerContract,
+  deployGNS,
   deployGRT,
   deployServiceRegistry,
   deployStakingContract,

--- a/test/lib/testHelpers.js
+++ b/test/lib/testHelpers.js
@@ -1,9 +1,7 @@
 const BN = web3.utils.BN
 
 module.exports = {
-  randomSubgraphIdHex0x: () => web3.utils.randomHex(32),
-  randomSubgraphIdHex: hex => hex.substring(2),
-  randomSubgraphIdBytes: (hex = web3.utils.randomHex(32)) => web3.utils.hexToBytes(hex),
+  randomSubgraphId: () => web3.utils.randomHex(32),
   logStake: stakes =>
     Object.entries(stakes).map(([k, v]) => console.log(k, ':', web3.utils.fromWei(v))),
   zerobytes: () =>


### PR DESCRIPTION
I just went ahead and cleaned up the old GNS contract and drafted a new version for discussion.

The approach to this version was to create the simplest version I could (I like simple) that fulfills the requirement of the model drafted by dave in the graph subgraph.

**Features:**
- `publish()` a subgraphID under a subgraph name, including metadata in ipfs-hash bytes32 format. Each time someone publishes we relate a subgraphID to a subgraphName in what we can call a new `subgraphVersion`. Once a name is taken only the owner can publish new versions for that name.
- `unpublish()` a subgraph name.
- `transfer()` a subgraph name to a new owner.
- Emit events for use by the graph subgraph to index and create a model out of this information.

**Assumptions:**
- Flatten namespace, no hierarchical domain system.
- The GNS contract holds a mapping of records (like the DNS).
- Each record, stores the relationship: `nameHash -> Record(owner, subgraphID, nameSystem)`.
- A nameHash is the `keccak256(name)` of the subgraph name.
- A subgraphID can be related to many subgraph names.
- There are no restrictions in the number of times you can re-publish a subgraphID.
- When you unpublish a name it can be taken by other user.
- Only when publishing you pass the actual subgraph name. In contract state and the rest of the functions a `nameHash=keccak256(name)` is used for efficiency.

@davekaj @Zerim @Jannis 