### PR TITLE
curation: add a withdrawal fee

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -72,6 +72,10 @@ module.exports = async (deployer, network, accounts) => {
         '\t> Staking -> Set channelDisputeEpochs: ',
       )
       await executeAndLog(curation.setStaking(staking.address), '\t> Curation -> Set staking: ')
+      await executeAndLog(
+        curation.setWithdrawalFeePercentage(config.curation.withdrawalFeePercentage),
+        '\t> Curation -> Set withdrawalFeePercentage: ',
+      )
 
       // Summary
       log('\n')

--- a/migrations/deploy.config.js
+++ b/migrations/deploy.config.js
@@ -4,10 +4,9 @@ const TOKEN_UNIT = new BN('10').pow(new BN('18'))
 
 module.exports = {
   curation: {
-    // Reserve ratio to set bonding curve for curation (in PPM)
     reserveRatio: 500000,
-    // Minimum amount required to be staked by Curators
     minimumCurationStake: new BN('100').mul(TOKEN_UNIT),
+    withdrawalFeePercentage: 50000,
   },
   dispute: {
     minimumDeposit: new BN('100').mul(TOKEN_UNIT),

--- a/test/curation.test.js
+++ b/test/curation.test.js
@@ -9,6 +9,10 @@ const { defaults } = require('./lib/testHelpers')
 
 const MAX_PPM = 1000000
 
+function toGRT(value) {
+  return new BN(web3.utils.toWei(value))
+}
+
 contract('Curation', ([me, other, governor, curator, staking]) => {
   beforeEach(async function() {
     // Deploy graph token
@@ -22,24 +26,11 @@ contract('Curation', ([me, other, governor, curator, staking]) => {
     })
     await this.curation.setStaking(staking, { from: governor })
 
-    // Give some funds to the curator
-    this.curatorTokens = web3.utils.toWei(new BN('1000'))
-    await this.grt.mint(curator, this.curatorTokens, {
-      from: governor,
-    })
-    // Approve all curator's funds to be used in the curation contract
-    await this.grt.approve(this.curation.address, this.curatorTokens, { from: curator })
-
-    // Give some funds to the staking contract
-    this.tokensToCollect = web3.utils.toWei(new BN('1000'))
-    await this.grt.mint(staking, this.tokensToCollect, {
-      from: governor,
-    })
-    // Approve staking contract funds to be used in the curation contract
-    await this.grt.approve(this.curation.address, this.curatorTokens, { from: staking })
-
     // Randomize a subgraphId
-    this.subgraphId = helpers.randomSubgraphId()
+    this.subgraphID = helpers.randomSubgraphId()
+
+    // Test values
+    this.shareAmountFor1000Tokens = new BN(3)
   })
 
   describe('configuration', function() {
@@ -142,214 +133,281 @@ contract('Curation', ([me, other, governor, curator, staking]) => {
         )
       })
     })
-  })
 
-  context('> bonding curve', function() {
-    beforeEach(function() {
-      this.subgraphId = helpers.randomSubgraphId()
-    })
+    describe('withdrawalFeePercentage', function() {
+      it('should set `withdrawalFeePercentage`', async function() {
+        const withdrawalFeePercentage = defaults.curation.withdrawalFeePercentage
 
-    it('convert shares to tokens', async function() {
-      // Curate a subgraph
-      await this.curation.stake(this.subgraphId, this.curatorTokens, { from: curator })
-
-      // Conversion
-      const shares = (await this.curation.subgraphs(this.subgraphId)).shares
-      const tokens = await this.curation.sharesToTokens(this.subgraphId, shares)
-      expect(tokens).to.be.bignumber.eq(this.curatorTokens)
-    })
-
-    it('convert tokens to shares', async function() {
-      // Conversion
-      const tokens = web3.utils.toWei(new BN('1000'))
-      const shares = await this.curation.tokensToShares(this.subgraphId, tokens)
-      expect(shares).to.be.bignumber.eq(defaults.curation.shareAmountFor1000Tokens)
-    })
-  })
-
-  context('> when subgraph is not curated', function() {
-    it('should stake on a subgraph', async function() {
-      // Before balances
-      const curatorTokensBefore = await this.grt.balanceOf(curator)
-      const curatorSharesBefore = await this.curation.getCuratorShares(curator, this.subgraphId)
-      const subgraphBefore = await this.curation.subgraphs(this.subgraphId)
-      const totalBalanceBefore = await this.grt.balanceOf(this.curation.address)
-
-      // Curate a subgraph
-      // Staking the minimum required = 1 share
-      const tokensToStake = defaults.curation.minimumCurationStake
-      const sharesToReceive = new BN(1)
-      const { logs } = await this.curation.stake(this.subgraphId, tokensToStake, { from: curator })
-      expectEvent.inLogs(logs, 'Staked', {
-        curator: curator,
-        subgraphID: this.subgraphId,
-        tokens: tokensToStake,
-        shares: sharesToReceive,
+        // Set new value
+        await this.curation.setWithdrawalFeePercentage(0, { from: governor })
+        await this.curation.setWithdrawalFeePercentage(1, { from: governor })
+        await this.curation.setWithdrawalFeePercentage(withdrawalFeePercentage, {
+          from: governor,
+        })
       })
 
-      // After balances
-      const curatorTokensAfter = await this.grt.balanceOf(curator)
-      const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphId)
-      const subgraphAfter = await this.curation.subgraphs(this.subgraphId)
-      const totalBalanceAfter = await this.grt.balanceOf(this.curation.address)
+      it('reject set `withdrawalFeePercentage` if out of bounds', async function() {
+        await expectRevert(
+          this.curation.setWithdrawalFeePercentage(MAX_PPM + 1, {
+            from: governor,
+          }),
+          'Withdrawal fee percentage must be below or equal to MAX_PPM',
+        )
+      })
 
-      // Tokens transferred properly
-      expect(curatorTokensAfter).to.be.bignumber.eq(curatorTokensBefore.sub(tokensToStake))
-      expect(curatorSharesAfter).to.be.bignumber.eq(curatorSharesBefore.add(sharesToReceive))
-
-      // Subgraph allocated and balance updated
-      expect(subgraphAfter.tokens).to.be.bignumber.eq(subgraphBefore.tokens.add(tokensToStake))
-      expect(subgraphAfter.shares).to.be.bignumber.eq(subgraphBefore.shares.add(sharesToReceive))
-      expect(subgraphAfter.reserveRatio).to.be.bignumber.eq(defaults.curation.reserveRatio)
-
-      // Contract balance updated
-      expect(totalBalanceAfter).to.be.bignumber.eq(totalBalanceBefore.add(tokensToStake))
-    })
-
-    it('reject stake below minimum tokens required', async function() {
-      const tokensToStake = defaults.curation.minimumCurationStake.sub(new BN(1))
-      await expectRevert(
-        this.curation.stake(this.subgraphId, tokensToStake, { from: curator }),
-        'Curation stake is below minimum required',
-      )
-    })
-
-    it('reject redeem more than a curator owns', async function() {
-      await expectRevert(
-        this.curation.redeem(this.subgraphId, 1),
-        'Cannot redeem more shares than you own',
-      )
-    })
-
-    it('reject collect tokens distributed as fees for the subgraph', async function() {
-      // Source of tokens must be the staking for this to work
-      await expectRevert(
-        this.curation.collect(this.subgraphId, this.tokensToCollect, { from: staking }),
-        'Subgraph must be curated to collect fees',
-      )
+      it('reject set `withdrawalFeePercentage` if not allowed', async function() {
+        await expectRevert(
+          this.curation.setWithdrawalFeePercentage(0, { from: other }),
+          'Only Governor can call',
+        )
+      })
     })
   })
 
-  context('> when subgraph is curated', function() {
+  describe('curation', function() {
     beforeEach(async function() {
-      await this.curation.stake(this.subgraphId, this.curatorTokens, { from: curator })
+      // Give some funds to the curator
+      this.curatorTokens = toGRT('1000')
+      await this.grt.mint(curator, this.curatorTokens, {
+        from: governor,
+      })
+      // Approve all curator's funds to be used in the curation contract
+      await this.grt.approve(this.curation.address, this.curatorTokens, { from: curator })
+
+      // Give some funds to the staking contract
+      this.tokensToCollect = toGRT('1000')
+      await this.grt.mint(staking, this.tokensToCollect, {
+        from: governor,
+      })
+      // Approve staking contract funds to be used in the curation contract
+      await this.grt.approve(this.curation.address, this.curatorTokens, { from: staking })
     })
 
-    it('should create subgraph curation with default reserve ratio', async function() {
-      const defaultReserveRatio = await this.curation.defaultReserveRatio()
-      const subgraph = await this.curation.subgraphs(this.subgraphId)
-      expect(subgraph.reserveRatio).to.be.bignumber.eq(defaultReserveRatio)
+    describe('bonding curve', function() {
+      it('convert shares to tokens', async function() {
+        // Curate a subgraph
+        await this.curation.stake(this.subgraphID, this.curatorTokens, { from: curator })
+
+        // Conversion
+        const shares = (await this.curation.subgraphs(this.subgraphID)).shares
+        const tokens = await this.curation.sharesToTokens(this.subgraphID, shares)
+        expect(tokens).to.be.bignumber.eq(this.curatorTokens)
+      })
+
+      it('convert tokens to shares', async function() {
+        // Conversion
+        const tokens = toGRT('1000')
+        const shares = await this.curation.tokensToShares(this.subgraphID, tokens)
+        expect(shares).to.be.bignumber.eq(this.shareAmountFor1000Tokens)
+      })
     })
 
-    it('reject redeem zero shares from a subgraph', async function() {
-      await expectRevert(this.curation.redeem(this.subgraphId, 0), 'Cannot redeem zero shares')
+    context('> when subgraph is not curated', function() {
+      it('should stake on a subgraph', async function() {
+        // Before balances
+        const curatorTokensBefore = await this.grt.balanceOf(curator)
+        const curatorSharesBefore = await this.curation.getCuratorShares(curator, this.subgraphID)
+        const subgraphBefore = await this.curation.subgraphs(this.subgraphID)
+        const totalBalanceBefore = await this.grt.balanceOf(this.curation.address)
+
+        // Curate a subgraph
+        // Staking the minimum required = 1 share
+        const tokensToStake = defaults.curation.minimumCurationStake
+        const sharesToReceive = new BN(1)
+        const { logs } = await this.curation.stake(this.subgraphID, tokensToStake, {
+          from: curator,
+        })
+        expectEvent.inLogs(logs, 'Staked', {
+          curator: curator,
+          subgraphID: this.subgraphID,
+          tokens: tokensToStake,
+          shares: sharesToReceive,
+        })
+
+        // After balances
+        const curatorTokensAfter = await this.grt.balanceOf(curator)
+        const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphID)
+        const subgraphAfter = await this.curation.subgraphs(this.subgraphID)
+        const totalBalanceAfter = await this.grt.balanceOf(this.curation.address)
+
+        // Tokens transferred properly
+        expect(curatorTokensAfter).to.be.bignumber.eq(curatorTokensBefore.sub(tokensToStake))
+        expect(curatorSharesAfter).to.be.bignumber.eq(curatorSharesBefore.add(sharesToReceive))
+
+        // Subgraph allocated and balance updated
+        expect(subgraphAfter.tokens).to.be.bignumber.eq(subgraphBefore.tokens.add(tokensToStake))
+        expect(subgraphAfter.shares).to.be.bignumber.eq(subgraphBefore.shares.add(sharesToReceive))
+        expect(subgraphAfter.reserveRatio).to.be.bignumber.eq(defaults.curation.reserveRatio)
+
+        // Contract balance updated
+        expect(totalBalanceAfter).to.be.bignumber.eq(totalBalanceBefore.add(tokensToStake))
+      })
+
+      it('reject stake below minimum tokens required', async function() {
+        const tokensToStake = defaults.curation.minimumCurationStake.sub(new BN(1))
+        await expectRevert(
+          this.curation.stake(this.subgraphID, tokensToStake, { from: curator }),
+          'Curation stake is below minimum required',
+        )
+      })
+
+      it('reject redeem more than a curator owns', async function() {
+        await expectRevert(
+          this.curation.redeem(this.subgraphID, 1),
+          'Cannot redeem more shares than you own',
+        )
+      })
+
+      it('reject collect tokens distributed as fees for the subgraph', async function() {
+        // Source of tokens must be the staking for this to work
+        await expectRevert(
+          this.curation.collect(this.subgraphID, this.tokensToCollect, { from: staking }),
+          'Subgraph must be curated to collect fees',
+        )
+      })
     })
 
-    it('should assign the right amount of shares according to bonding curve', async function() {
-      // Shares should be the ones bought with minimum stake (1) + more shares
-      const curatorShares = await this.curation.getCuratorShares(curator, this.subgraphId)
-      expect(curatorShares).to.be.bignumber.eq(defaults.curation.shareAmountFor1000Tokens)
-    })
-
-    it('should allow to redeem *partially* on a subgraph', async function() {
-      // Before balances
-      const curatorTokensBefore = await this.grt.balanceOf(curator)
-      const curatorSharesBefore = await this.curation.getCuratorShares(curator, this.subgraphId)
-      const subgraphBefore = await this.curation.subgraphs(this.subgraphId)
-      const totalTokensBefore = await this.grt.balanceOf(this.curation.address)
-
-      // Redeem
-      const sharesToRedeem = new BN(1) // Curator want to sell 1 share
-      const tokensToReceive = await this.curation.sharesToTokens(this.subgraphId, sharesToRedeem)
-      const { logs } = await this.curation.redeem(this.subgraphId, sharesToRedeem, {
-        from: curator,
-      })
-      expectEvent.inLogs(logs, 'Redeemed', {
-        curator: curator,
-        subgraphID: this.subgraphId,
-        tokens: tokensToReceive,
-        shares: sharesToRedeem,
+    context('> when subgraph is curated', function() {
+      beforeEach(async function() {
+        await this.curation.stake(this.subgraphID, this.curatorTokens, { from: curator })
       })
 
-      // After balances
-      const curatorTokensAfter = await this.grt.balanceOf(curator)
-      const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphId)
-      const subgraphAfter = await this.curation.subgraphs(this.subgraphId)
-      const totalTokensAfter = await this.grt.balanceOf(this.curation.address)
-
-      // Curator balance updated
-      expect(curatorTokensAfter).to.be.bignumber.eq(curatorTokensBefore.add(tokensToReceive))
-      expect(curatorSharesAfter).to.be.bignumber.eq(curatorSharesBefore.sub(sharesToRedeem))
-
-      // Subgraph balance updated
-      expect(subgraphAfter.tokens).to.be.bignumber.eq(subgraphBefore.tokens.sub(tokensToReceive))
-      expect(subgraphAfter.shares).to.be.bignumber.eq(subgraphBefore.shares.sub(sharesToRedeem))
-
-      // Contract balance updated
-      expect(totalTokensAfter).to.be.bignumber.eq(totalTokensBefore.sub(tokensToReceive))
-    })
-
-    it('should allow to redeem *fully* on a subgraph', async function() {
-      // Before balances
-      const subgraphBefore = await this.curation.subgraphs(this.subgraphId)
-
-      // Redeem all shares
-      const sharesToRedeem = subgraphBefore.shares // we are selling all shares in the subgraph
-      const tokensToReceive = subgraphBefore.tokens // we are withdrawing all funds
-      const { logs } = await this.curation.redeem(this.subgraphId, sharesToRedeem, {
-        from: curator,
-      })
-      expectEvent.inLogs(logs, 'Redeemed', {
-        curator: curator,
-        subgraphID: this.subgraphId,
-        tokens: tokensToReceive,
-        shares: sharesToRedeem,
+      it('should create subgraph curation with default reserve ratio', async function() {
+        const defaultReserveRatio = await this.curation.defaultReserveRatio()
+        const subgraph = await this.curation.subgraphs(this.subgraphID)
+        expect(subgraph.reserveRatio).to.be.bignumber.eq(defaultReserveRatio)
       })
 
-      // After balances
-      const curatorTokensAfter = await this.grt.balanceOf(curator)
-      const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphId)
-      const subgraphAfter = await this.curation.subgraphs(this.subgraphId)
-      const totalTokensAfter = await this.grt.balanceOf(this.curation.address)
-
-      // Curator balance updated
-      expect(curatorTokensAfter).to.be.bignumber.eq(tokensToReceive)
-      expect(curatorSharesAfter).to.be.bignumber.eq(new BN(0))
-
-      // Subgraph deallocated
-      expect(subgraphAfter.tokens).to.be.bignumber.eq(new BN(0))
-      expect(subgraphAfter.shares).to.be.bignumber.eq(new BN(0))
-      expect(subgraphAfter.reserveRatio).to.be.bignumber.eq(new BN(0))
-
-      // Contract balance updated
-      expect(totalTokensAfter).to.be.bignumber.eq(new BN(0))
-    })
-
-    it('should collect tokens distributed as reserves for a subgraph', async function() {
-      // Before balances
-      const totalBalanceBefore = await this.grt.balanceOf(this.curation.address)
-      const subgraphBefore = await this.curation.subgraphs(this.subgraphId)
-
-      // Source of tokens must be the staking for this to work
-      const { logs } = await this.curation.collect(this.subgraphId, this.tokensToCollect, {
-        from: staking,
-      })
-      expectEvent.inLogs(logs, 'Collected', {
-        subgraphID: this.subgraphId,
-        tokens: this.tokensToCollect,
+      it('reject redeem zero shares from a subgraph', async function() {
+        await expectRevert(this.curation.redeem(this.subgraphID, 0), 'Cannot redeem zero shares')
       })
 
-      // After balances
-      const totalBalanceAfter = await this.grt.balanceOf(this.curation.address)
-      const subgraphAfter = await this.curation.subgraphs(this.subgraphId)
+      it('should assign the right amount of shares according to bonding curve', async function() {
+        // Shares should be the ones bought with minimum stake (1) + more shares
+        const curatorShares = await this.curation.getCuratorShares(curator, this.subgraphID)
+        expect(curatorShares).to.be.bignumber.eq(this.shareAmountFor1000Tokens)
+      })
 
-      // Subgraph balance updated
-      expect(subgraphAfter.tokens).to.be.bignumber.eq(
-        subgraphBefore.tokens.add(this.tokensToCollect),
-      )
+      it('should allow to redeem *partially* on a subgraph', async function() {
+        // Before balances
+        const tokenTotalSupplyBefore = await this.grt.totalSupply()
+        const curatorTokensBefore = await this.grt.balanceOf(curator)
+        const curatorSharesBefore = await this.curation.getCuratorShares(curator, this.subgraphID)
+        const subgraphBefore = await this.curation.subgraphs(this.subgraphID)
+        const totalTokensBefore = await this.grt.balanceOf(this.curation.address)
 
-      // Contract balance updated
-      expect(totalBalanceAfter).to.be.bignumber.eq(totalBalanceBefore.add(this.tokensToCollect))
+        // Redeem
+        const sharesToRedeem = new BN(1) // Curator want to sell 1 share
+        const tokensToRedeem = await this.curation.sharesToTokens(this.subgraphID, sharesToRedeem)
+        const withdrawalFeePercentage = await this.curation.withdrawalFeePercentage()
+        const withdrawalFees = withdrawalFeePercentage.mul(tokensToRedeem).div(new BN(MAX_PPM))
+        const tokensToReceive = tokensToRedeem.sub(withdrawalFees)
+
+        const { logs } = await this.curation.redeem(this.subgraphID, sharesToRedeem, {
+          from: curator,
+        })
+        expectEvent.inLogs(logs, 'Redeemed', {
+          curator: curator,
+          subgraphID: this.subgraphID,
+          tokens: tokensToReceive,
+          shares: sharesToRedeem,
+          withdrawalFees: withdrawalFees,
+        })
+
+        // After balances
+        const tokenTotalSupplyAfter = await this.grt.totalSupply()
+        const curatorTokensAfter = await this.grt.balanceOf(curator)
+        const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphID)
+        const subgraphAfter = await this.curation.subgraphs(this.subgraphID)
+        const totalTokensAfter = await this.grt.balanceOf(this.curation.address)
+
+        // Curator balance updated
+        expect(curatorTokensAfter).to.be.bignumber.eq(curatorTokensBefore.add(tokensToReceive))
+        expect(curatorSharesAfter).to.be.bignumber.eq(curatorSharesBefore.sub(sharesToRedeem))
+
+        // Subgraph balance updated
+        expect(subgraphAfter.tokens).to.be.bignumber.eq(subgraphBefore.tokens.sub(tokensToRedeem))
+        expect(subgraphAfter.shares).to.be.bignumber.eq(subgraphBefore.shares.sub(sharesToRedeem))
+
+        // Contract balance updated
+        expect(totalTokensAfter).to.be.bignumber.eq(totalTokensBefore.sub(tokensToRedeem))
+
+        // Withdrawal fees are burned
+        expect(tokenTotalSupplyAfter).to.be.bignumber.eq(tokenTotalSupplyBefore.sub(withdrawalFees))
+      })
+
+      it('should allow to redeem *fully* on a subgraph', async function() {
+        // Before balances
+        const tokenTotalSupplyBefore = await this.grt.totalSupply()
+        const subgraphBefore = await this.curation.subgraphs(this.subgraphID)
+
+        // Redeem all shares
+        const sharesToRedeem = subgraphBefore.shares // we are selling all shares in the subgraph
+        const tokensToRedeem = subgraphBefore.tokens // we are withdrawing all funds
+        const withdrawalFeePercentage = await this.curation.withdrawalFeePercentage()
+        const withdrawalFees = withdrawalFeePercentage.mul(tokensToRedeem).div(new BN(MAX_PPM))
+        const tokensToReceive = tokensToRedeem.sub(withdrawalFees)
+
+        const { logs } = await this.curation.redeem(this.subgraphID, sharesToRedeem, {
+          from: curator,
+        })
+        expectEvent.inLogs(logs, 'Redeemed', {
+          curator: curator,
+          subgraphID: this.subgraphID,
+          tokens: tokensToReceive,
+          shares: sharesToRedeem,
+          withdrawalFees: withdrawalFees,
+        })
+
+        // After balances
+        const tokenTotalSupplyAfter = await this.grt.totalSupply()
+        const curatorTokensAfter = await this.grt.balanceOf(curator)
+        const curatorSharesAfter = await this.curation.getCuratorShares(curator, this.subgraphID)
+        const subgraphAfter = await this.curation.subgraphs(this.subgraphID)
+        const totalTokensAfter = await this.grt.balanceOf(this.curation.address)
+
+        // Curator balance updated
+        expect(curatorTokensAfter).to.be.bignumber.eq(tokensToReceive)
+        expect(curatorSharesAfter).to.be.bignumber.eq(new BN(0))
+
+        // Subgraph deallocated
+        expect(subgraphAfter.tokens).to.be.bignumber.eq(new BN(0))
+        expect(subgraphAfter.shares).to.be.bignumber.eq(new BN(0))
+        expect(subgraphAfter.reserveRatio).to.be.bignumber.eq(new BN(0))
+
+        // Contract balance updated
+        expect(totalTokensAfter).to.be.bignumber.eq(new BN(0))
+
+        // Withdrawal fees are burned
+        expect(tokenTotalSupplyAfter).to.be.bignumber.eq(tokenTotalSupplyBefore.sub(withdrawalFees))
+      })
+
+      it('should collect tokens distributed as reserves for a subgraph', async function() {
+        // Before balances
+        const totalBalanceBefore = await this.grt.balanceOf(this.curation.address)
+        const subgraphBefore = await this.curation.subgraphs(this.subgraphID)
+
+        // Source of tokens must be the staking for this to work
+        const { logs } = await this.curation.collect(this.subgraphID, this.tokensToCollect, {
+          from: staking,
+        })
+        expectEvent.inLogs(logs, 'Collected', {
+          subgraphID: this.subgraphID,
+          tokens: this.tokensToCollect,
+        })
+
+        // After balances
+        const totalBalanceAfter = await this.grt.balanceOf(this.curation.address)
+        const subgraphAfter = await this.curation.subgraphs(this.subgraphID)
+
+        // Subgraph balance updated
+        expect(subgraphAfter.tokens).to.be.bignumber.eq(
+          subgraphBefore.tokens.add(this.tokensToCollect),
+        )
+
+        // Contract balance updated
+        expect(totalBalanceAfter).to.be.bignumber.eq(totalBalanceBefore.add(this.tokensToCollect))
+      })
     })
   })
 })

--- a/test/lib/deployment.js
+++ b/test/lib/deployment.js
@@ -14,14 +14,18 @@ function deployGRT(owner, params) {
   return GraphToken.new(owner, defaults.token.initialSupply, params)
 }
 
-function deployCurationContract(owner, graphToken, params) {
-  return Curation.new(
+async function deployCurationContract(owner, graphToken, params) {
+  const contract = await Curation.new(
     owner,
     graphToken,
     defaults.curation.reserveRatio,
     defaults.curation.minimumCurationStake,
     params,
   )
+  await contract.setWithdrawalFeePercentage(defaults.curation.withdrawalFeePercentage, {
+    from: owner,
+  })
+  return contract
 }
 
 function deployDisputeManagerContract(owner, graphToken, arbitrator, staking, params) {

--- a/test/lib/testHelpers.js
+++ b/test/lib/testHelpers.js
@@ -65,12 +65,9 @@ module.exports = {
   },
   defaults: {
     curation: {
-      // Reserve ratio to set bonding curve for curation (in PPM)
       reserveRatio: new BN('500000'),
-      // Minimum amount required to be staked by Curators
       minimumCurationStake: web3.utils.toWei(new BN('100')),
-      // When one user stakes 1000, they will get 3 shares returned, as per the Bancor formula
-      shareAmountFor1000Tokens: new BN(3),
+      withdrawalFeePercentage: new BN('50000'),
     },
     dispute: {
       minimumDeposit: web3.utils.toWei(new BN('100')),


### PR DESCRIPTION
Changes:

- Add a `withdrawalFeePercentage` parameter only set by governor.
- When a curator redeems shares for tokens, part of the tokens are kept as withdrawalFee and burned.