### PR TITLE
Staking, DisputeManager: Store public key on Channel

### DIFF
--- a/contracts/DisputeManager.sol
+++ b/contracts/DisputeManager.sol
@@ -423,12 +423,13 @@ contract DisputeManager is Governed {
         address channelID = _recoverAttestationSigner(attestation);
 
         // Get the indexer that created the channel and signed the attestation
-        (address indexer, bytes32 subgraphDeploymentID) = staking.channels(channelID);
+        (bytes memory publicKey, address indexer, bytes32 subgraphDeploymentID) = staking.channels(channelID);
         require(indexer != address(0), "Indexer cannot be found for the attestation");
         require(
             subgraphDeploymentID == attestation.subgraphDeploymentID,
             "Channel and attestation subgraphDeploymentID must match"
         );
+        require(keccak256(publicKey) != keccak256(""), "Public key cannot be found for the attestation");
 
         // Create a disputeID
         bytes32 disputeID = keccak256(

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -31,6 +31,7 @@ contract Staking is Governed {
     // -- Allocation and Channel --
 
     struct Channel {
+        bytes publicKey;
         address indexer;
         bytes32 subgraphDeploymentID;
     }
@@ -666,7 +667,7 @@ contract Staking is Governed {
         );
         alloc.channelID = channelID;
         alloc.createdAtEpoch = epochManager.currentEpoch();
-        channels[channelID] = Channel(indexer, _subgraphDeploymentID);
+        channels[channelID] = Channel(_channelPubKey, indexer, _subgraphDeploymentID);
         channelsProxy[_channelProxy] = channelID;
 
         emit AllocationCreated(


### PR DESCRIPTION
This stores the channel's public key on `Channel` structs in the staking contract, allowing to access it directly at a later time, as opposed to only being able to access it on `AllocationCreated` events.

I'm not happy with the use `keccak256()` in the `DisputeManager` but I got an `unused variable` compiler error without doing _something_ with the public key. @abarmat Perhaps you have a better idea?