### PR TITLE
NPM: Recreate dist/ directory from scratch every time

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && cp -R build dist",
+    "prepublishOnly": "npm run build && rm -rf dist && cp -R build dist",
     "build": "npm run compile && npm run flatten && npm run abi:extract && npm run typechain",
     "clean": "rm -rf build/ cache/",
     "compile": "buidler compile",


### PR DESCRIPTION
Without this, `build` is copied into `dist/build/` instead of `dist/` when `dist/` already exists. Which it may when making local changes and linking the package into e.g. the network subgraph locally using e.g. `yarn link`.