### PR TITLE
staking: init delegation params on first stake

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -23,7 +23,7 @@ contract Staking is StakingV1Storage, IStaking, Governed {
     using Rebates for Rebates.Pool;
 
     // 100% in parts per million
-    uint256 private constant MAX_PPM = 1000000;
+    uint32 private constant MAX_PPM = 1000000;
 
     // -- Events --
 
@@ -908,8 +908,18 @@ contract Staking is StakingV1Storage, IStaking, Governed {
      * @param _tokens Amount of tokens to stake
      */
     function _stake(address _indexer, uint256 _tokens) private {
+        // Deposit tokens into the indexer stake
         Stakes.Indexer storage indexerStake = stakes[_indexer];
         indexerStake.deposit(_tokens);
+
+        // Initialize the delegation pool the first time
+        DelegationPool storage pool = delegationPools[_indexer];
+        if (pool.updatedAtBlock == 0) {
+            pool.indexingRewardCut = MAX_PPM;
+            pool.queryFeeCut = MAX_PPM;
+            pool.updatedAtBlock = block.number;
+        }
+
         emit StakeDeposited(_indexer, _tokens);
     }
 

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -263,6 +263,25 @@ describe('Staking::Delegation', () => {
         expect(params.cooldownBlocks).eq(cooldownBlocks)
         expect(params.updatedAtBlock).eq(await latestBlock())
       })
+
+      it('should init delegation parameters on first stake', async function () {
+        // Before
+        const beforeParams = await staking.delegationPools(indexer.address)
+        expect(beforeParams.indexingRewardCut).eq(0)
+        expect(beforeParams.queryFeeCut).eq(0)
+        expect(beforeParams.cooldownBlocks).eq(0)
+        expect(beforeParams.updatedAtBlock).eq(0)
+
+        // Indexer stake tokens
+        await staking.connect(indexer.signer).stake(toGRT('200'))
+
+        // State updated
+        const afterParams = await staking.delegationPools(indexer.address)
+        expect(afterParams.indexingRewardCut).eq(MAX_PPM)
+        expect(afterParams.queryFeeCut).eq(MAX_PPM)
+        expect(afterParams.cooldownBlocks).eq(0)
+        expect(afterParams.updatedAtBlock).eq(await latestBlock())
+      })
     })
   })
 


### PR DESCRIPTION
### Issue

- By default both queryFeeCut and indexerRewardsCut are set to zero (uninitialised) in the Delegation Pool. 
- That means that indexer does not keep any fund if they are delegated.
- It should be the other way round, they should keep 100% if not explicitly set.

### Solution

- On first stake by an Indexer set the Delegation Pool both queryFeeCut and indexerRewardsCut to 100%.
- Allow the Indexer to change the delegation parameters without the cooldown period the first time.