### PR TITLE
Update to 0.4.5-testnet-phase1 npm, with rinkeby contracts for phase 1

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -1,68 +1,48 @@
 {
-  "42": {
+  "4": {
     "EpochManager": {
-      "address": "0xa65F267E7Da767268dC8ACf8CBBe1b2C8Fb81a1c",
+      "address": "0x95E400a43E36414fd97F142f32bd2b5D2270AEC9",
       "initArgs": [
         {
           "name": "lengthInBlocks",
           "value": 5760
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0x990d78aa1a42b3c14bf7b894754d2a2f89c22da5bb973b015a6508bb19fbbdcd",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0xb641a04eae9b5ce2865fc5effb234d8f46fdc98bf477fd01eeceb8b2ea440777",
       "proxy": true,
       "implementation": {
-        "address": "0x192151EA65e210a3567A779aDF423a23ceA0644d",
-        "creationCodeHash": "0x31165a28dbee9a7d2aa7cc428addc4577200f275f9009274ea7cb4714f60639b",
-        "runtimeCodeHash": "0xc84171160811639a39b9139df9522e566fcfe0864927ce1cffb5e4a96a3a5f39",
-        "txHash": "0x44c07ed5e3007adec6987d5babdfd1ba6eb895c38492cf6a99626ec4625ca503"
+        "address": "0x370f1daB2e591255c77d1796d3D02038b50099DF",
+        "creationCodeHash": "0xc764fe90813568d932cad7d341d040abd785903ebd640c23e1d2e2d716185601",
+        "runtimeCodeHash": "0x989a7a5836821d5b6b76cfe416d3d8dda82d5979578827110612d69de1cb9315",
+        "txHash": "0x8f12bb980dc48cd3fee1cba85f3a036ea911e191190a2e2f11dc446505e50c35"
       }
     },
-    "GNS": {
-      "address": "0xa19Dea85457c22dfCA62F1A5Caeb4A9c8F0cE523",
-      "constructorArgs": [
-        {
-          "name": "didRegistry",
-          "value": "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b"
-        },
-        {
-          "name": "curation",
-          "value": "0xeb10Fb85a52129dD8243F2F0A671e1ba8BAeE2D5"
-        },
-        {
-          "name": "token",
-          "value": "0x6863Ca246A98b5777C058a6ebCdd99155a2f4e23"
-        }
-      ],
-      "creationCodeHash": "0x4688c106d6ebf4ceaf11a5fe3014ecf6c3481a23db19d3ad86d38c373274f536",
-      "runtimeCodeHash": "0xdbe2eb22c668e7b2b21f1a0a010c798dbdcaa163bfa55009c6faf33f77d7765b",
-      "txHash": "0x80b35d13b7466ac957bc5c9434757953278f47029d06d0f643f1c28be82f7c1c"
-    },
     "GraphToken": {
-      "address": "0x6863Ca246A98b5777C058a6ebCdd99155a2f4e23",
+      "address": "0xeEff25515DeE946F62DdCE1F00F78C2Ad0aBAb3f",
       "constructorArgs": [
         {
           "name": "initialSupply",
           "value": "10000000000000000000000000"
         }
       ],
-      "creationCodeHash": "0x42ecc02676d4db7323556709ef5014d9499c02930bdbff3c0c64892a7c2adff8",
-      "runtimeCodeHash": "0x6bd1f7ba249970bf7fb28da7b836a546d09c71e26ce7804b8989bcb680798fb9",
-      "txHash": "0x439d125d02618b11243b401362e75f120191fa1364bf10991f65bb60e6bc9bf5"
+      "creationCodeHash": "0x0d1ae32ca17fff3ee9048a1af0e04dc01af0c19bfa390fd9b689dbfc461f7325",
+      "runtimeCodeHash": "0x21ad62ab6defc6720c3f2a721c240c3f92f1f88cca0919ea3403a0b31e9a8774",
+      "txHash": "0xb4dfa5b093cc13747df5f28c656b60ae70f284a9beb08ba53674c150cdb3baa4"
     },
     "ServiceRegistry": {
-      "address": "0x940DB7B10392d175a2D635ea81Bf62F7D21F2F6f",
+      "address": "0xee063C8D1D20A73461b6d6921A1a8122B9FE776B",
       "creationCodeHash": "0xc2bd8e7492bb3bbe975004091e2f76943f04261783cb4d0bcc6de4d4b05f1db2",
       "runtimeCodeHash": "0x400ec2dfd9237d62c8fbd82e916fb1c2d9f9c2530a98a6862e249400e199f4ea",
-      "txHash": "0xecbf7643f5424b74e2142ee480e7018033e760c164a03aa7213eb94fd25dc51a"
+      "txHash": "0x0b9934a810e4f27308f73902c71a89f2fcbb30eaeaae2c21d11d693f2eeaa7fa"
     },
     "Curation": {
-      "address": "0xeb10Fb85a52129dD8243F2F0A671e1ba8BAeE2D5",
+      "address": "0x77E8997a50aeD85b5d087a6B291878a172f68fA3",
       "initArgs": [
         {
           "name": "token",
-          "value": "0x6863Ca246A98b5777C058a6ebCdd99155a2f4e23"
+          "value": "0xeEff25515DeE946F62DdCE1F00F78C2Ad0aBAb3f"
         },
         {
           "name": "reserveRatio",
@@ -73,48 +53,68 @@
           "value": "100000000000000000000"
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0xd63ecfe52ad421cb81b1f48680aa127222538e0cf04276a0e4e0e6b0430a967c",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0x87de075d2ea58364f05eb8e9455edd23c8e2712662f169917c6a8f86a5e82f65",
       "proxy": true,
       "implementation": {
-        "address": "0xa937a32Ca3bAc36bd8081cbee13c65F7f87b7a34",
-        "creationCodeHash": "0xc24a6ea1c30765de52dd053d4a631e145536504b61da049cf0ea59557635575c",
-        "runtimeCodeHash": "0x0b3f65b8d156b14dc56546769efe9709f431b204691bfdb52482fe3e23a31e20",
-        "txHash": "0x71271d8894f9b9337824f35df2038519fca801bd1594bc8a2e520ccedc2e1665"
+        "address": "0xC0F3ddB5732Dec002eBB92cBc04B24ac274dE71F",
+        "creationCodeHash": "0xafb00b7a40495425e241c4561f6e16028a223df68562bb0c80a7826a0920663b",
+        "runtimeCodeHash": "0x24611199cc37f79df764dbca84fe37a64a5a2ad1f8ad7550af3c7a20ff817899",
+        "txHash": "0xd0719466c6dd224339b64ea81688c2cfe37a7d3ee452efc9e9bd5d85883c09a3"
       }
     },
+    "GNS": {
+      "address": "0xF80f4a382A5321ef8E60b2695080674FeE7f8dcE",
+      "constructorArgs": [
+        {
+          "name": "didRegistry",
+          "value": "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b"
+        },
+        {
+          "name": "curation",
+          "value": "0x77E8997a50aeD85b5d087a6B291878a172f68fA3"
+        },
+        {
+          "name": "token",
+          "value": "0xeEff25515DeE946F62DdCE1F00F78C2Ad0aBAb3f"
+        }
+      ],
+      "creationCodeHash": "0xfa7965b46c48db6c5e42be46a711e1e467a95ecca6b3e6ac0a48419cfa53c058",
+      "runtimeCodeHash": "0x708faf3cabe8aeb28609579a9bcd0012d065b583ec52646175cc6838572b9621",
+      "txHash": "0xe18d90463ee73e3ba6f9110801904082d1e8b6aa2e3a8385f7bb5cb1123d6b55"
+    },
     "RewardsManager": {
-      "address": "0x36704cA0E466FD6a3Be03bF8CCa9721226f6BA80",
-      "creationCodeHash": "0x7499addf981a9582f77bdbf1230942d20eb13fd00cd2154a345725a5bf96aa27",
-      "runtimeCodeHash": "0x1634973cdaa3ade7866fbf2161e136a4d7684239ce50be5dbf9061adf87ec251",
-      "txHash": "0xf3919b49bf98094899424776684912d7fee7fb64622b7c2bc9fa7a18c2f3d845"
+      "address": "0xD8Bcd1e5458Ae6d17F5A1508511c01e1937Cb7E9",
+      "creationCodeHash": "0x8706481646b1b72f5659bf21edf29cee3bba80b1d4cd523f125f35c642c4d414",
+      "runtimeCodeHash": "0x92f5875ce7d0a6c858785b6f62888666f6aab8668360e5a09bb24194ad2c20df",
+      "txHash": "0xbd1c0899e4f1f4281bc7e7f08c4e4709f066610fc4209849237dd37751d8bf5f"
     },
     "Staking": {
-      "address": "0xA08a2f4721e832aACd71904bFaf6b6A9c5CAa72c",
+      "address": "0x661A0eD099Bb3Fe9AA0b293d136dBCAA21B04B4C",
       "initArgs": [
         {
           "name": "token",
-          "value": "0x6863Ca246A98b5777C058a6ebCdd99155a2f4e23"
+          "value": "0xeEff25515DeE946F62DdCE1F00F78C2Ad0aBAb3f"
         },
         {
           "name": "epochManager",
-          "value": "0xa65F267E7Da767268dC8ACf8CBBe1b2C8Fb81a1c"
+          "value": "0x95E400a43E36414fd97F142f32bd2b5D2270AEC9"
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0x95c03903c8af0fee8abbc53ce215e4d06d71b3ae3ee450150c59fa40cafe9a2d",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0xf9d55c01f2210c6544997197a3cf13a1e67ae766f596adb722f0aef5a3e0ec4f",
       "proxy": true,
       "implementation": {
-        "address": "0x2028A0ca32809C43809d1030144e11c5bc9A6637",
-        "creationCodeHash": "0x69ae575623fec68c5ee99723d860f8efbe753e971cf8711b6b4cf7d13c034d2b",
-        "runtimeCodeHash": "0xb26897d28b397cf9c6a4cd8b175cd811dad67a68f909653721207783ecb6635a",
-        "txHash": "0x7c09d61bb9a6c24a81e250e8281989bfe1d9b14e7235052429b3e521207f4f9a"
+        "address": "0x7fa086526fF44681af012628162Bcf10f18cB62c",
+        "creationCodeHash": "0x7169c0547950a86c1b87b23debf5f3c8770a8737124abd91023d2e1d03ffb730",
+        "runtimeCodeHash": "0xefa9621c602da597b62eb5ce4b027a2d842a0858cbee4e17f93774c530e0d2af",
+        "txHash": "0xe2516edfcfcf7e45a17072d1c39b378bd2170d1dd7d76a0418c6b13aad7d893b"
       }
     },
     "DisputeManager": {
-      "address": "0xd67fE33E31Ca682afdCA5040Ff69aEBB6679a809",
+      "address": "0x62c5191b39d993A68Dc9348a4a15454C60cb6C9C",
       "constructorArgs": [
         {
           "name": "arbitrator",
@@ -122,11 +122,11 @@
         },
         {
           "name": "token",
-          "value": "0x6863Ca246A98b5777C058a6ebCdd99155a2f4e23"
+          "value": "0xeEff25515DeE946F62DdCE1F00F78C2Ad0aBAb3f"
         },
         {
           "name": "staking",
-          "value": "0xA08a2f4721e832aACd71904bFaf6b6A9c5CAa72c"
+          "value": "0x661A0eD099Bb3Fe9AA0b293d136dBCAA21B04B4C"
         },
         {
           "name": "minimumDeposit",
@@ -141,36 +141,36 @@
           "value": 50000
         }
       ],
-      "creationCodeHash": "0x68c8441db86d14a492489a051157f9dc99c412be14e9870705cbc3a18ed6c10e",
-      "runtimeCodeHash": "0x378073d02efeec4e0d67195c91234e025885f9cd69ff23f20b63696a2beb09de",
-      "txHash": "0x7bf6de578e5d0c526b55bf84ab3ee0ee5f85663c6480b42c9cc27b6e52b77c75"
+      "creationCodeHash": "0x31b4f9cd88c4d9993726621d1c80e91f98386c145dc5e4c8633d24c91001f0ba",
+      "runtimeCodeHash": "0x9e434cf728277747bf784ee560ef83070b085f43770ece4a6834e24caed150d8",
+      "txHash": "0x0806b1c5add9a9b52d85f3dc1617f88108a84568658be5122659482be1a0060b"
     },
     "IndexerCTDT": {
-      "address": "0x6f1a6A16bB0B5E711615Cf495bFa1F82612C33B4",
-      "creationCodeHash": "0x8deb4534bd649685131bebe0e8f2b33e133efb76617b2566f7e90d91ded9f6d4",
-      "runtimeCodeHash": "0x046741c41299ff98f975f430277c3e62a181210f63109e2a59b414adf6287b7b",
-      "txHash": "0xfc396e1ad6198f18acf9fa4c2cdfd7845b32ed3acf85d0fed6438bbfcfee80c0"
+      "address": "0x18AcA2F7579cCf850EaD8Ac4Ad848080A8C895F4",
+      "creationCodeHash": "0x52480acb4d15affb1dd76809185743d89cd9015403b290524adccf7e9ce52a21",
+      "runtimeCodeHash": "0x640b70794fdeec2931983e3d5a8c2f2acdc76813f8f84a7c19922ef64f0299ac",
+      "txHash": "0x51e8ccfbd9754e34efe73d3f24fbaf99e82b6ed9f9256c3169740cfd0b21a0f9"
     },
     "IndexerSingleAssetInterpreter": {
-      "address": "0x1A777305a461D3390273e29b66946593A8272804",
-      "creationCodeHash": "0x4029a72d7804bb2f1ab39b05a6f9cecbef21a744524453f7e7c904aab59ece4f",
-      "runtimeCodeHash": "0xadb67db5a9afd8596dce145277b1327bfc04592108a6aed404fd20857a52a84a",
-      "txHash": "0x81aba949dea66927d9e45e732aafe87b24cb29e8e8254f23e528b7b06ae7f4ce"
+      "address": "0x85bcdBf4d77f33625C4a88CB4BB80C726865dD25",
+      "creationCodeHash": "0x2d10bd750ee966473242ff3fbd957a794fe899a54ccc7817a3c5061fac15d327",
+      "runtimeCodeHash": "0x89e0bb47f925842b3101493787cec8c0a44d7b80310d0d8ea114212f191d3b5e",
+      "txHash": "0x3c71dee1910a98b08eb812a293143b46213dc7f4da3c203650151943aa867e18"
     },
     "IndexerMultiAssetInterpreter": {
-      "address": "0xcfa5eE9BE8b8E43f106a1b3AB99b55d32D44DC24",
-      "creationCodeHash": "0xd92e432a74dbe545b610819ae634cc031906b986239d3f07685e1be5c50a8ed3",
-      "runtimeCodeHash": "0x9b66e29446dd9e92dd26064346c56c504f754a1294ccdcbdd499d7e7860bc85c",
-      "txHash": "0xd1aa5435eac68c6bcd6590f59aeff176d4d1f21d26c6fcec25be8ad2517400c7"
+      "address": "0x33AF9a8CAcae99b439F20E8c9Fe8Ed488FBEbBa2",
+      "creationCodeHash": "0xf2481cd39da5dcff1bf6487a14b845fac0a39210c0fa492ac0cdeac07ba48d06",
+      "runtimeCodeHash": "0xb1762eb1178731fc915e0f3c686f0acf4297405e5f21a2e6e5ec6c02d55719b0",
+      "txHash": "0x117e5c80b1fc49de40a9565a4bb8200bdf1632ad63556ff9ecce762b73f01071"
     },
     "IndexerWithdrawInterpreter": {
-      "address": "0x11d92863e8344C87E0a4df1559496E9142ae06eE",
-      "creationCodeHash": "0xe3115209e2cd3e22dc079e7b16a7b6633af0e74b086c149b364cae56fd7f2e5d",
-      "runtimeCodeHash": "0xc19f5b5b769296e95f969e758b31aa24991b5cc8779038e8e84a5fed69b8fd7e",
-      "txHash": "0x4d0baf2946fa6e250d3352d54405009397675ee98cbf8d6121e9a2648f29e0f8"
+      "address": "0xa1E7fBFD569E766E7568A38d80B01595635949d8",
+      "creationCodeHash": "0x3697f927460d5afb4b5138d464026cddf452d2d2842b5e2a0490a32059a5408b",
+      "runtimeCodeHash": "0x4c4f0c06724368cf8234494370aea5ab21b53fb8a3f012a67282d8d310f4c037",
+      "txHash": "0x3ff5266a1b0e7f2663e2fe550dcfb968b25256e5461cbcc4dcaefcb104621fc9"
     },
     "MinimumViableMultisig": {
-      "address": "0xeDF16993608357B4028EB47Af2239660A57DFAf7",
+      "address": "0xD8530C664521919B65D6378146EfAaD2eB4E6852",
       "constructorArgs": [
         {
           "name": "node",
@@ -178,52 +178,255 @@
         },
         {
           "name": "staking",
-          "value": "0xA08a2f4721e832aACd71904bFaf6b6A9c5CAa72c"
+          "value": "0x661A0eD099Bb3Fe9AA0b293d136dBCAA21B04B4C"
         },
         {
           "name": "CTDT",
-          "value": "0x6f1a6A16bB0B5E711615Cf495bFa1F82612C33B4"
+          "value": "0x18AcA2F7579cCf850EaD8Ac4Ad848080A8C895F4"
         },
         {
           "name": "singleAssetInterpreter",
-          "value": "0x1A777305a461D3390273e29b66946593A8272804"
+          "value": "0x85bcdBf4d77f33625C4a88CB4BB80C726865dD25"
         },
         {
           "name": "multiAssetInterpreter",
-          "value": "0xcfa5eE9BE8b8E43f106a1b3AB99b55d32D44DC24"
+          "value": "0x33AF9a8CAcae99b439F20E8c9Fe8Ed488FBEbBa2"
         },
         {
           "name": "withdrawInterpreter",
-          "value": "0x11d92863e8344C87E0a4df1559496E9142ae06eE"
+          "value": "0xa1E7fBFD569E766E7568A38d80B01595635949d8"
         }
       ],
-      "creationCodeHash": "0xf22b68f30dd0ec350089fe28c74fd3700b765da9650abe09ef5719f10825d9ee",
-      "runtimeCodeHash": "0xcef6b12b9620ef40dac997cd0dcedaa2e4b48d8d3a66d34991401ae46967eb15",
-      "txHash": "0x05e77f0de805f54d69a626a306ffadf2fa0537e93f255773fe4ff5458a2d3300"
+      "creationCodeHash": "0x8aebe8c07edbc6109698c621fb99eb087e957e0030d3dc68d89c3c58ba59fa04",
+      "runtimeCodeHash": "0x5dafaf0b2872f7f80c75369a358a2fdadd68149e33f9ec31eb5ca33e8b7029e0",
+      "txHash": "0x1b1c2db5a922ae95560b9ed44cd2955f079556e504c60a4905ef89a193c4b021"
     }
   },
-  "1337": {
+  "42": {
     "EpochManager": {
-      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
+      "address": "0x6CAfB9BFf2a3a2c4CEE43E9D32273254823eE8D1",
       "initArgs": [
         {
           "name": "lengthInBlocks",
           "value": 5760
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0x3dae6f32b5f2eb18abab2c3b5178f911636cf82d3d60c42bfb9c414f131d8dfd",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0xe72e7eedb959381be0cf811c5f4585db3b8b07585388d75f63fafabbb1ab6b56",
       "proxy": true,
       "implementation": {
-        "address": "0x5b1869D9A4C187F2EAa108f3062412ecf0526b24",
-        "creationCodeHash": "0x31165a28dbee9a7d2aa7cc428addc4577200f275f9009274ea7cb4714f60639b",
-        "runtimeCodeHash": "0xc84171160811639a39b9139df9522e566fcfe0864927ce1cffb5e4a96a3a5f39",
-        "txHash": "0xf0bc52b02c4afa0f6d1334cf1cebd96da7c88d8855985bdcef3139a578cbfdf9"
+        "address": "0x042114912aC84eD7e4F49EBff2f4F1B7e885aeA3",
+        "creationCodeHash": "0xc764fe90813568d932cad7d341d040abd785903ebd640c23e1d2e2d716185601",
+        "runtimeCodeHash": "0x989a7a5836821d5b6b76cfe416d3d8dda82d5979578827110612d69de1cb9315",
+        "txHash": "0x7c34c871b9dcb08d01f2d121d296bf1502ac66dc87b8e0a0f89117207c3561c2"
       }
     },
     "GNS": {
-      "address": "0x9b1f7F645351AF3631a656421eD2e40f2802E6c0",
+      "address": "0x8CAB8e3ccf1Dca2d4173272E516D8981a5833238",
+      "constructorArgs": [
+        {
+          "name": "didRegistry",
+          "value": "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b"
+        },
+        {
+          "name": "curation",
+          "value": "0xF4061Af18E397B05909098E1895184d7049e115C"
+        },
+        {
+          "name": "token",
+          "value": "0x45650e899F2b25844d5ad7f0020159729341Cf27"
+        }
+      ],
+      "creationCodeHash": "0xfa7965b46c48db6c5e42be46a711e1e467a95ecca6b3e6ac0a48419cfa53c058",
+      "runtimeCodeHash": "0x708faf3cabe8aeb28609579a9bcd0012d065b583ec52646175cc6838572b9621",
+      "txHash": "0xc77576428a2d46637ebc5a2031a9f45a7c69ea6848837e329f41526bb142b740"
+    },
+    "GraphToken": {
+      "address": "0x45650e899F2b25844d5ad7f0020159729341Cf27",
+      "constructorArgs": [
+        {
+          "name": "initialSupply",
+          "value": "10000000000000000000000000"
+        }
+      ],
+      "creationCodeHash": "0x0d1ae32ca17fff3ee9048a1af0e04dc01af0c19bfa390fd9b689dbfc461f7325",
+      "runtimeCodeHash": "0x21ad62ab6defc6720c3f2a721c240c3f92f1f88cca0919ea3403a0b31e9a8774",
+      "txHash": "0x57ca9785cfa65e632040479dde74caf087f298f1bf92b3ac085fe936b139cc72"
+    },
+    "ServiceRegistry": {
+      "address": "0x0AD791CBC700eAecd34f017A6e40E3516daC61fE",
+      "creationCodeHash": "0xc2bd8e7492bb3bbe975004091e2f76943f04261783cb4d0bcc6de4d4b05f1db2",
+      "runtimeCodeHash": "0x400ec2dfd9237d62c8fbd82e916fb1c2d9f9c2530a98a6862e249400e199f4ea",
+      "txHash": "0xe04411910fb9c6445854ebe4df34980c60930bf4fb1c2864ae9ffa58b70860f0"
+    },
+    "Curation": {
+      "address": "0xF4061Af18E397B05909098E1895184d7049e115C",
+      "initArgs": [
+        {
+          "name": "token",
+          "value": "0x45650e899F2b25844d5ad7f0020159729341Cf27"
+        },
+        {
+          "name": "reserveRatio",
+          "value": 500000
+        },
+        {
+          "name": "minimumCurationStake",
+          "value": "100000000000000000000"
+        }
+      ],
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0x008d2ee1fd56715f69a25c87556d080af39b43d52f3bec50dc9faf05c3ed78d3",
+      "proxy": true,
+      "implementation": {
+        "address": "0x03c071eEdA8266809a28d5af55D95562110d2530",
+        "creationCodeHash": "0xafb00b7a40495425e241c4561f6e16028a223df68562bb0c80a7826a0920663b",
+        "runtimeCodeHash": "0x24611199cc37f79df764dbca84fe37a64a5a2ad1f8ad7550af3c7a20ff817899",
+        "txHash": "0x6b910c537d5623bef19c2852f947ff38464c3ae8a18e9fe66eb43060cb836518"
+      }
+    },
+    "RewardsManager": {
+      "address": "0x023E5A34A4b569Ec655c2dE429945E703Af2aE2a",
+      "creationCodeHash": "0x8706481646b1b72f5659bf21edf29cee3bba80b1d4cd523f125f35c642c4d414",
+      "runtimeCodeHash": "0x92f5875ce7d0a6c858785b6f62888666f6aab8668360e5a09bb24194ad2c20df",
+      "txHash": "0xc434e9a085209e4bbde31f799dd929afae0a6db787bae478c9bb91bbba5d131c"
+    },
+    "Staking": {
+      "address": "0x65c72ab13Ba6805414c1eCBeA34bb95e1e58515F",
+      "initArgs": [
+        {
+          "name": "token",
+          "value": "0x45650e899F2b25844d5ad7f0020159729341Cf27"
+        },
+        {
+          "name": "epochManager",
+          "value": "0x6CAfB9BFf2a3a2c4CEE43E9D32273254823eE8D1"
+        }
+      ],
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0x5bd549ee5afa6c544c6dc349c2f851de8b6a7008052ffac492b6296ec1aeb283",
+      "proxy": true,
+      "implementation": {
+        "address": "0x6971f1B5e0Ae0AB87de6F3078551e1D6038878Ee",
+        "creationCodeHash": "0x7169c0547950a86c1b87b23debf5f3c8770a8737124abd91023d2e1d03ffb730",
+        "runtimeCodeHash": "0xefa9621c602da597b62eb5ce4b027a2d842a0858cbee4e17f93774c530e0d2af",
+        "txHash": "0x3eb0819ca9fce4bee033b25a55d06e55b356286a6cd95bc1292cdb7445b87a2d"
+      }
+    },
+    "DisputeManager": {
+      "address": "0xecFaddaA75de349F85a7998E3F3b0C85E24c14a3",
+      "constructorArgs": [
+        {
+          "name": "arbitrator",
+          "value": "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+        },
+        {
+          "name": "token",
+          "value": "0x45650e899F2b25844d5ad7f0020159729341Cf27"
+        },
+        {
+          "name": "staking",
+          "value": "0x65c72ab13Ba6805414c1eCBeA34bb95e1e58515F"
+        },
+        {
+          "name": "minimumDeposit",
+          "value": "100000000000000000000"
+        },
+        {
+          "name": "fishermanRewardPercentage",
+          "value": 100000
+        },
+        {
+          "name": "slashingPercentage",
+          "value": 50000
+        }
+      ],
+      "creationCodeHash": "0x31b4f9cd88c4d9993726621d1c80e91f98386c145dc5e4c8633d24c91001f0ba",
+      "runtimeCodeHash": "0x9e434cf728277747bf784ee560ef83070b085f43770ece4a6834e24caed150d8",
+      "txHash": "0xef207adda8a968df331db50ee59baead4a45150bf3748ee353b4e8dadfb35ed3"
+    },
+    "IndexerCTDT": {
+      "address": "0xc09Fa3b1311a98D03B6e29587f7C8dd0a8a890C5",
+      "creationCodeHash": "0x52480acb4d15affb1dd76809185743d89cd9015403b290524adccf7e9ce52a21",
+      "runtimeCodeHash": "0x640b70794fdeec2931983e3d5a8c2f2acdc76813f8f84a7c19922ef64f0299ac",
+      "txHash": "0x09990d3f66dd95744ec69a7a91cedc5cbacc0fefe12f10c737bf61bcac2032ab"
+    },
+    "IndexerSingleAssetInterpreter": {
+      "address": "0x3CF75A1a39605Af89585663954362895EcB93b0A",
+      "creationCodeHash": "0x2d10bd750ee966473242ff3fbd957a794fe899a54ccc7817a3c5061fac15d327",
+      "runtimeCodeHash": "0x89e0bb47f925842b3101493787cec8c0a44d7b80310d0d8ea114212f191d3b5e",
+      "txHash": "0xb42c8e0461daa8147f4f3509f0b91b7a5dffa24f6f076b93752b6bea61f0c709"
+    },
+    "IndexerMultiAssetInterpreter": {
+      "address": "0xb9FC7FBEc5b48dD3E410102a876637b8F88DFFc7",
+      "creationCodeHash": "0xf2481cd39da5dcff1bf6487a14b845fac0a39210c0fa492ac0cdeac07ba48d06",
+      "runtimeCodeHash": "0xb1762eb1178731fc915e0f3c686f0acf4297405e5f21a2e6e5ec6c02d55719b0",
+      "txHash": "0xd0d4bc009ba6b9ab009879e8549d483960b2921e567155ece2004db398e5c07c"
+    },
+    "IndexerWithdrawInterpreter": {
+      "address": "0x5a473C32e535717401DF6f7b3E058C01856853aC",
+      "creationCodeHash": "0x3697f927460d5afb4b5138d464026cddf452d2d2842b5e2a0490a32059a5408b",
+      "runtimeCodeHash": "0x4c4f0c06724368cf8234494370aea5ab21b53fb8a3f012a67282d8d310f4c037",
+      "txHash": "0x85a1972258f6894bb3a5377a4d5b1bfe28ff91ee4fdcbe7c22c0dd1c0b6d6d71"
+    },
+    "MinimumViableMultisig": {
+      "address": "0xeD8C226e0070E74008F946f0DaE3c770FAEB76fe",
+      "constructorArgs": [
+        {
+          "name": "node",
+          "value": "0x0000000000000000000000000000000000000000"
+        },
+        {
+          "name": "staking",
+          "value": "0x65c72ab13Ba6805414c1eCBeA34bb95e1e58515F"
+        },
+        {
+          "name": "CTDT",
+          "value": "0xc09Fa3b1311a98D03B6e29587f7C8dd0a8a890C5"
+        },
+        {
+          "name": "singleAssetInterpreter",
+          "value": "0x3CF75A1a39605Af89585663954362895EcB93b0A"
+        },
+        {
+          "name": "multiAssetInterpreter",
+          "value": "0xb9FC7FBEc5b48dD3E410102a876637b8F88DFFc7"
+        },
+        {
+          "name": "withdrawInterpreter",
+          "value": "0x5a473C32e535717401DF6f7b3E058C01856853aC"
+        }
+      ],
+      "creationCodeHash": "0x8aebe8c07edbc6109698c621fb99eb087e957e0030d3dc68d89c3c58ba59fa04",
+      "runtimeCodeHash": "0x5dafaf0b2872f7f80c75369a358a2fdadd68149e33f9ec31eb5ca33e8b7029e0",
+      "txHash": "0xb02f148606bc263e5e49b7ff63e105acc8de1cbd05c77eaf697c23a5a37df662"
+    }
+  },
+  "1337": {
+    "EpochManager": {
+      "address": "0x5b1869D9A4C187F2EAa108f3062412ecf0526b24",
+      "initArgs": [
+        {
+          "name": "lengthInBlocks",
+          "value": 5760
+        }
+      ],
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0x2b447968f5dd03e497d879440ef97cd8f644a3cbeb9950fd433776d14b29b391",
+      "proxy": true,
+      "implementation": {
+        "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
+        "creationCodeHash": "0xc764fe90813568d932cad7d341d040abd785903ebd640c23e1d2e2d716185601",
+        "runtimeCodeHash": "0x989a7a5836821d5b6b76cfe416d3d8dda82d5979578827110612d69de1cb9315",
+        "txHash": "0x53d790c8dc646683aa90d50ed4f379f2e4f97e024c01deb52f29fc989f6e30a9"
+      }
+    },
+    "GNS": {
+      "address": "0x59d3631c86BbE35EF041872d502F218A39FBa150",
       "constructorArgs": [
         {
           "name": "didRegistry",
@@ -235,37 +438,37 @@
         },
         {
           "name": "token",
-          "value": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+          "value": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
         }
       ],
-      "creationCodeHash": "0x4688c106d6ebf4ceaf11a5fe3014ecf6c3481a23db19d3ad86d38c373274f536",
-      "runtimeCodeHash": "0xdbe2eb22c668e7b2b21f1a0a010c798dbdcaa163bfa55009c6faf33f77d7765b",
-      "txHash": "0x4719985a0c41d8be2aa2357a7f830ecbb417e3c50147b2b1a047208d45e98b49"
+      "creationCodeHash": "0xfa7965b46c48db6c5e42be46a711e1e467a95ecca6b3e6ac0a48419cfa53c058",
+      "runtimeCodeHash": "0x708faf3cabe8aeb28609579a9bcd0012d065b583ec52646175cc6838572b9621",
+      "txHash": "0xf712203a2da24ac0c310ed9103123ae248335ca529b532eb71349546e86a7b09"
     },
     "GraphToken": {
-      "address": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550",
+      "address": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B",
       "constructorArgs": [
         {
           "name": "initialSupply",
           "value": "10000000000000000000000000"
         }
       ],
-      "creationCodeHash": "0x42ecc02676d4db7323556709ef5014d9499c02930bdbff3c0c64892a7c2adff8",
-      "runtimeCodeHash": "0x6bd1f7ba249970bf7fb28da7b836a546d09c71e26ce7804b8989bcb680798fb9",
-      "txHash": "0xc813608155712a7a63656aca95ee4457cc60f4df6cedcc929e4ec2f0a286781d"
+      "creationCodeHash": "0x0d1ae32ca17fff3ee9048a1af0e04dc01af0c19bfa390fd9b689dbfc461f7325",
+      "runtimeCodeHash": "0x21ad62ab6defc6720c3f2a721c240c3f92f1f88cca0919ea3403a0b31e9a8774",
+      "txHash": "0x7cf64ee5e708670499dda7de3536375292d62520cc6e2128647314c0374f71c4"
     },
     "ServiceRegistry": {
-      "address": "0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb",
+      "address": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550",
       "creationCodeHash": "0xc2bd8e7492bb3bbe975004091e2f76943f04261783cb4d0bcc6de4d4b05f1db2",
       "runtimeCodeHash": "0x400ec2dfd9237d62c8fbd82e916fb1c2d9f9c2530a98a6862e249400e199f4ea",
-      "txHash": "0x1ca22d19350bdc516e2ba5d3699e78b0392db5f450e8e47e7eda9abbc5fee793"
+      "txHash": "0xadb704a4bf9bb2b32212bdf8715713e54cf93252d5749648837fa9f738871bf5"
     },
     "Curation": {
       "address": "0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7",
       "initArgs": [
         {
           "name": "token",
-          "value": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+          "value": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
         },
         {
           "name": "reserveRatio",
@@ -276,48 +479,48 @@
           "value": "100000000000000000000"
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0x98d89ebbc5ce9e91310a928fa0b95ce6eb543a83a0aa9242a279c48ee0274e12",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0xb92f66e75295a22543ebecc6221f69f7de51b0b31121a23e42ce94bafc8720e3",
       "proxy": true,
       "implementation": {
-        "address": "0xe982E462b094850F12AF94d21D470e21bE9D0E9C",
-        "creationCodeHash": "0xc24a6ea1c30765de52dd053d4a631e145536504b61da049cf0ea59557635575c",
-        "runtimeCodeHash": "0x0b3f65b8d156b14dc56546769efe9709f431b204691bfdb52482fe3e23a31e20",
-        "txHash": "0x4a43fabe685f85e77f80efbac5ac3a4e83c69d2d784cda0ee9edcc89e033af59"
+        "address": "0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb",
+        "creationCodeHash": "0xafb00b7a40495425e241c4561f6e16028a223df68562bb0c80a7826a0920663b",
+        "runtimeCodeHash": "0x24611199cc37f79df764dbca84fe37a64a5a2ad1f8ad7550af3c7a20ff817899",
+        "txHash": "0x3e5e77f79aec6531d589af7e20aa6ca1f62a107ce3d3190bd2bdc882d3718b7f"
       }
     },
     "RewardsManager": {
-      "address": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
-      "creationCodeHash": "0x7499addf981a9582f77bdbf1230942d20eb13fd00cd2154a345725a5bf96aa27",
-      "runtimeCodeHash": "0x1634973cdaa3ade7866fbf2161e136a4d7684239ce50be5dbf9061adf87ec251",
-      "txHash": "0x82218f684804b16092269da746cb1e3e3ba79be29cfe6bfe60f0ff7d21281f43"
+      "address": "0x0290FB167208Af455bB137780163b7B7a9a10C16",
+      "creationCodeHash": "0x8706481646b1b72f5659bf21edf29cee3bba80b1d4cd523f125f35c642c4d414",
+      "runtimeCodeHash": "0x92f5875ce7d0a6c858785b6f62888666f6aab8668360e5a09bb24194ad2c20df",
+      "txHash": "0x17b56250fc9f5ae21879528d953cc85bb93aaaf07c8d437e9b0fcf1947df8017"
     },
     "Staking": {
-      "address": "0x2612Af3A521c2df9EAF28422Ca335b04AdF3ac66",
+      "address": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
       "initArgs": [
         {
           "name": "token",
-          "value": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+          "value": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
         },
         {
           "name": "epochManager",
-          "value": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab"
+          "value": "0x5b1869D9A4C187F2EAa108f3062412ecf0526b24"
         }
       ],
-      "creationCodeHash": "0x3b538be0a3ab549cf59597328009b163d1ed633404c3705bbe37d75d5fbea037",
-      "runtimeCodeHash": "0xd356453c7271dfee72289743debac9bb3530104607a4c4b17c596ac1386336fd",
-      "txHash": "0xba48970779e182477c4a8f2bb28fc55e57cff05721a977c9fac50e93969d9546",
+      "creationCodeHash": "0xbd95843475b4fb2195b431c12ebf08f4938c3245964d4a4dc6564aeceb9df14d",
+      "runtimeCodeHash": "0x8d402c1fc89106a6129860cdcde576340c941a57b70f9ca7983e421aa00bbd6c",
+      "txHash": "0x469892a60965fcb3e44f5e78feb9d0df53150ea4559b02f44e8a89910e11da64",
       "proxy": true,
       "implementation": {
-        "address": "0xA57B8a5584442B467b4689F1144D269d096A3daF",
-        "creationCodeHash": "0x69ae575623fec68c5ee99723d860f8efbe753e971cf8711b6b4cf7d13c034d2b",
-        "runtimeCodeHash": "0xb26897d28b397cf9c6a4cd8b175cd811dad67a68f909653721207783ecb6635a",
-        "txHash": "0xaf7b349f91487c41d6c406bb35cb2bac8438e2df47887e482de38f9cb38ecf67"
+        "address": "0x9b1f7F645351AF3631a656421eD2e40f2802E6c0",
+        "creationCodeHash": "0x7169c0547950a86c1b87b23debf5f3c8770a8737124abd91023d2e1d03ffb730",
+        "runtimeCodeHash": "0xefa9621c602da597b62eb5ce4b027a2d842a0858cbee4e17f93774c530e0d2af",
+        "txHash": "0x260d10c4824ea3f87535c5e1fd2408a026fa4e9ee946c7a5837090b1c457d02a"
       }
     },
     "DisputeManager": {
-      "address": "0x0E696947A06550DEf604e82C26fd9E493e576337",
+      "address": "0xA57B8a5584442B467b4689F1144D269d096A3daF",
       "constructorArgs": [
         {
           "name": "arbitrator",
@@ -325,11 +528,11 @@
         },
         {
           "name": "token",
-          "value": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+          "value": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
         },
         {
           "name": "staking",
-          "value": "0x2612Af3A521c2df9EAF28422Ca335b04AdF3ac66"
+          "value": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e"
         },
         {
           "name": "minimumDeposit",
@@ -344,36 +547,36 @@
           "value": 50000
         }
       ],
-      "creationCodeHash": "0x68c8441db86d14a492489a051157f9dc99c412be14e9870705cbc3a18ed6c10e",
-      "runtimeCodeHash": "0x378073d02efeec4e0d67195c91234e025885f9cd69ff23f20b63696a2beb09de",
-      "txHash": "0x8e12387e224a4035d19964dc2bc843190a2e5d9a25d4298adffbd72645ba1253"
+      "creationCodeHash": "0x31b4f9cd88c4d9993726621d1c80e91f98386c145dc5e4c8633d24c91001f0ba",
+      "runtimeCodeHash": "0x9e434cf728277747bf784ee560ef83070b085f43770ece4a6834e24caed150d8",
+      "txHash": "0x519e8a881fe78a289098c00004748df23a11fead1ec802fd6c9bd92448b1cff4"
     },
     "IndexerCTDT": {
-      "address": "0xDb56f2e9369E0D7bD191099125a3f6C370F8ed15",
-      "creationCodeHash": "0x8deb4534bd649685131bebe0e8f2b33e133efb76617b2566f7e90d91ded9f6d4",
-      "runtimeCodeHash": "0x046741c41299ff98f975f430277c3e62a181210f63109e2a59b414adf6287b7b",
-      "txHash": "0x5173af240c56f2f39f5f950ae3706dcccac08b6472b1eeb14871b1b76e109963"
+      "address": "0x26b4AFb60d6C903165150C6F0AA14F8016bE4aec",
+      "creationCodeHash": "0x52480acb4d15affb1dd76809185743d89cd9015403b290524adccf7e9ce52a21",
+      "runtimeCodeHash": "0x640b70794fdeec2931983e3d5a8c2f2acdc76813f8f84a7c19922ef64f0299ac",
+      "txHash": "0x2d8f370e9ae5478f152fa25d106e225dd102f07ae167a6e550c08dbab6b5ad4a"
     },
     "IndexerSingleAssetInterpreter": {
-      "address": "0xA94B7f0465E98609391C623d0560C5720a3f2D33",
-      "creationCodeHash": "0x4029a72d7804bb2f1ab39b05a6f9cecbef21a744524453f7e7c904aab59ece4f",
-      "runtimeCodeHash": "0xadb67db5a9afd8596dce145277b1327bfc04592108a6aed404fd20857a52a84a",
-      "txHash": "0xc4945c0370a047ff13806d2046bff908ae5028800a17de80ac8befca3d1a4bed"
+      "address": "0x630589690929E9cdEFDeF0734717a9eF3Ec7Fcfe",
+      "creationCodeHash": "0x2d10bd750ee966473242ff3fbd957a794fe899a54ccc7817a3c5061fac15d327",
+      "runtimeCodeHash": "0x89e0bb47f925842b3101493787cec8c0a44d7b80310d0d8ea114212f191d3b5e",
+      "txHash": "0x80dcba53592225c10b293c8ae003114fa08bff9ab5330db38515aac989ab26ae"
     },
     "IndexerMultiAssetInterpreter": {
-      "address": "0x6eD79Aa1c71FD7BdBC515EfdA3Bd4e26394435cC",
-      "creationCodeHash": "0xd92e432a74dbe545b610819ae634cc031906b986239d3f07685e1be5c50a8ed3",
-      "runtimeCodeHash": "0x9b66e29446dd9e92dd26064346c56c504f754a1294ccdcbdd499d7e7860bc85c",
-      "txHash": "0x706bb587f7c7d889739e443544d9e92aec86566fe6b598ea560ba64d70be02f8"
+      "address": "0x0E696947A06550DEf604e82C26fd9E493e576337",
+      "creationCodeHash": "0xf2481cd39da5dcff1bf6487a14b845fac0a39210c0fa492ac0cdeac07ba48d06",
+      "runtimeCodeHash": "0xb1762eb1178731fc915e0f3c686f0acf4297405e5f21a2e6e5ec6c02d55719b0",
+      "txHash": "0xba20b52e5bfda751a723b4fb4ad48408093549f56839709cd4fa76fbb69ffb11"
     },
     "IndexerWithdrawInterpreter": {
-      "address": "0xb09bCc172050fBd4562da8b229Cf3E45Dc3045A6",
-      "creationCodeHash": "0xe3115209e2cd3e22dc079e7b16a7b6633af0e74b086c149b364cae56fd7f2e5d",
-      "runtimeCodeHash": "0xc19f5b5b769296e95f969e758b31aa24991b5cc8779038e8e84a5fed69b8fd7e",
-      "txHash": "0xaec539bb7354964a353da139e79a58105f7fb37a710d747eb5b8bdc38efd0743"
+      "address": "0xDb56f2e9369E0D7bD191099125a3f6C370F8ed15",
+      "creationCodeHash": "0x3697f927460d5afb4b5138d464026cddf452d2d2842b5e2a0490a32059a5408b",
+      "runtimeCodeHash": "0x4c4f0c06724368cf8234494370aea5ab21b53fb8a3f012a67282d8d310f4c037",
+      "txHash": "0x48ce9905d158ec806528db4e27aad6c77676e57d420ab5bf13e2b6feda1f896b"
     },
     "MinimumViableMultisig": {
-      "address": "0xFC628dd79137395F3C9744e33b1c5DE554D94882",
+      "address": "0xA94B7f0465E98609391C623d0560C5720a3f2D33",
       "constructorArgs": [
         {
           "name": "node",
@@ -381,28 +584,28 @@
         },
         {
           "name": "staking",
-          "value": "0x2612Af3A521c2df9EAF28422Ca335b04AdF3ac66"
+          "value": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e"
         },
         {
           "name": "CTDT",
-          "value": "0xDb56f2e9369E0D7bD191099125a3f6C370F8ed15"
+          "value": "0x26b4AFb60d6C903165150C6F0AA14F8016bE4aec"
         },
         {
           "name": "singleAssetInterpreter",
-          "value": "0xA94B7f0465E98609391C623d0560C5720a3f2D33"
+          "value": "0x630589690929E9cdEFDeF0734717a9eF3Ec7Fcfe"
         },
         {
           "name": "multiAssetInterpreter",
-          "value": "0x6eD79Aa1c71FD7BdBC515EfdA3Bd4e26394435cC"
+          "value": "0x0E696947A06550DEf604e82C26fd9E493e576337"
         },
         {
           "name": "withdrawInterpreter",
-          "value": "0xb09bCc172050fBd4562da8b229Cf3E45Dc3045A6"
+          "value": "0xDb56f2e9369E0D7bD191099125a3f6C370F8ed15"
         }
       ],
-      "creationCodeHash": "0xf22b68f30dd0ec350089fe28c74fd3700b765da9650abe09ef5719f10825d9ee",
-      "runtimeCodeHash": "0xcef6b12b9620ef40dac997cd0dcedaa2e4b48d8d3a66d34991401ae46967eb15",
-      "txHash": "0x21bf68df5054b8c2ec8c536f8b13bce1c0981104df0409f948f7b6493d98c5d6"
+      "creationCodeHash": "0x8aebe8c07edbc6109698c621fb99eb087e957e0030d3dc68d89c3c58ba59fa04",
+      "runtimeCodeHash": "0x5dafaf0b2872f7f80c75369a358a2fdadd68149e33f9ec31eb5ca33e8b7029e0",
+      "txHash": "0xf604d8ef2caa365588a1292f76b15b98003f21825b914e84fcea34aed52a746c"
     }
   },
   "kovan": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/contracts",
-  "version": "0.4.4",
+  "version": "0.4.5-testnet-phase1",
   "description": "Contracts for the Graph Protocol",
   "directories": {
     "test": "test"
@@ -69,7 +69,9 @@
     "clean": "rm -rf build/ cache/ dist/",
     "compile": "buidler compile",
     "deploy": "buidler migrate",
+    "deploy-ganache": "npm run deploy -- --force",
     "deploy-kovan": "npm run deploy -- --force --network kovan",
+    "deploy-rinkeby": "npm run deploy -- --force --network rinkeby",
     "test": "scripts/test",
     "test:gas": "RUN_EVM=true REPORT_GAS=true scripts/test",
     "coverage": "scripts/coverage",


### PR DESCRIPTION
Updates both rinkeby and kovan contracts, and updates a package for testnet phase1