### PR TITLE
curation: explicit error when token to signal called on uninitialized subgraph

### DIFF
--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -313,6 +313,10 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration, Governed {
 
         // Init curation pool
         if (curationPool.tokens == 0) {
+            require(
+                newTokens >= minimumCurationDeposit,
+                "Tokens cannot be under minimum curation deposit when curve not initialized"
+            );
             newTokens = newTokens.sub(minimumCurationDeposit);
             curTokens = minimumCurationDeposit;
             curSignal = SIGNAL_PER_MINIMUM_DEPOSIT;

--- a/test/curation/curation.test.ts
+++ b/test/curation/curation.test.ts
@@ -225,6 +225,16 @@ describe('Curation', () => {
       const signal = await curation.tokensToSignal(subgraphDeploymentID, tokens)
       expect(signal).eq(signalAmountFor1000Tokens)
     })
+
+    it('convert tokens to signal if non-curated subgraph', async function () {
+      // Conversion
+      const nonCuratedSubgraphDeploymentID = randomHexBytes()
+      const tokens = toGRT('1')
+      const tx = curation.tokensToSignal(nonCuratedSubgraphDeploymentID, tokens)
+      await expect(tx).revertedWith(
+        'Tokens cannot be under minimum curation deposit when curve not initialized',
+      )
+    })
   })
 
   describe('curate', async function () {


### PR DESCRIPTION
If tokens to signal is called on unitialized subgraph with tokens below minimum it throws an overflow error, this is the right behaviour, but now adding an explicit error for ease of debugging in the future.