### PR TITLE
curation: update GST symbol and make the owner transferrable

### DIFF
--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -454,8 +454,7 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration, Governed {
 
             // If no signal token for the pool - create one
             if (address(curationPool.gst) == address(0)) {
-                string memory symbol = string(abi.encodePacked("GST-", _subgraphDeploymentID));
-                curationPool.gst = new GraphSignalToken(symbol, address(this));
+                curationPool.gst = new GraphSignalToken("GST", address(this));
             }
         }
 

--- a/contracts/curation/GraphSignalToken.sol
+++ b/contracts/curation/GraphSignalToken.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.6.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
+import "../governance/Governed.sol";
+
 /**
  * @title GraphSignalToken contract
  * @dev This is the implementation of the Curation Signal ERC20 token (GST).
@@ -10,7 +12,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
  * burn them. GST tokens are transferrable and their holders can do any action allowed
  * in a standard ERC20 token implementation except for burning them.
  */
-contract GraphSignalToken is ERC20 {
+contract GraphSignalToken is ERC20, Governed {
     address public owner;
 
     modifier onlyOwner {
@@ -24,7 +26,7 @@ contract GraphSignalToken is ERC20 {
      * @param _owner Address of the contract issuing this token
      */
     constructor(string memory _symbol, address _owner) public ERC20("Graph Signal Token", _symbol) {
-        owner = _owner;
+        Governed._initialize(_owner);
     }
 
     /**
@@ -32,7 +34,7 @@ contract GraphSignalToken is ERC20 {
      * @param _to Address to send the newly minted tokens
      * @param _amount Amount of tokens to mint
      */
-    function mint(address _to, uint256 _amount) public onlyOwner {
+    function mint(address _to, uint256 _amount) public onlyGovernor {
         _mint(_to, _amount);
     }
 
@@ -41,7 +43,7 @@ contract GraphSignalToken is ERC20 {
      * @param _account Address from where tokens will be burned
      * @param _amount Amount of tokens to burn
      */
-    function burnFrom(address _account, uint256 _amount) public onlyOwner {
+    function burnFrom(address _account, uint256 _amount) public onlyGovernor {
         _burn(_account, _amount);
     }
 }


### PR DESCRIPTION
- update GST tokens symbol to be just GST
- make the GST owner transferrable in case we want to migrate the curation contract