### PR TITLE
Introduce a static code analyzer (slither)

### DIFF
--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -172,7 +172,7 @@ const config = {
     enabled: process.env.REPORT_GAS ? true : false,
     showTimeSpent: true,
     currency: 'USD',
-    outputFile: 'gas-report.log',
+    outputFile: 'reports/gas-report.log',
   },
 }
 

--- a/contracts/connext/test-fixtures/AppWithAction.sol
+++ b/contracts/connext/test-fixtures/AppWithAction.sol
@@ -33,7 +33,8 @@ contract AppWithAction is CounterfactualApp {
         returns (address)
     {
         State memory state = abi.decode(encodedState, (State));
-        return participants[state.counter > 0 ? 0 : 1];
+        uint256 p = state.counter > 0 ? 0 : 1;
+        return participants[p];
     }
 
     /// @dev NOTE: there is a slight difference here vs. the connext

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "prettier": "npm run prettier:ts && npm run prettier:sol",
     "prettier:ts": "prettier --write 'test/**/*.ts'",
     "prettier:sol": "prettier --write 'contracts/*.sol'",
+    "analyze": "scripts/analyze",
     "flatten": "scripts/flatten",
     "abi:extract": "truffle-abi -d ./build/contracts -o ./build/abis/ -v",
     "typechain": "typechain --target ethers-v5 --outDir build/typechain/contracts 'build/abis/*.json'",

--- a/scripts/analyze
+++ b/scripts/analyze
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## Before running:
+# This tool requires to have solc installed.
+# Ensure that you have the binaries installed by pip3 in your path.
+# Install: https://github.com/crytic/slither#how-to-install
+# Usage: https://github.com/crytic/slither/wiki/Usage
+
+mkdir -p reports
+
+pip3 install --user slither-analyzer && \
+npm run build && \
+
+echo "Analyzing contracts..."
+slither . \
+    --filter-paths "staking/libs/abdk-libraries-solidity/*|connext/test-fixtures/*|bancor/*" \
+    &> reports/analyzer-report.log && \
+slither-check-erc build/flatten/GraphToken.sol GraphToken &> reports/analyzer-report-erc.log
+
+echo "Done!"

--- a/scripts/flatten
+++ b/scripts/flatten
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OUT_DIR="build/full"
+OUT_DIR="build/flatten"
 
 echo ${OUT_DIR}/contracts
 mkdir -p ${OUT_DIR}/contracts
@@ -17,4 +17,4 @@ for path in $files; do
     truffle-flattener "${path}" > "${OUT_DIR}/${name}"
 done
 
-echo "Done."
+echo "Done!"

--- a/scripts/test
+++ b/scripts/test
@@ -35,6 +35,8 @@ fi
 
 ### Main
 
+mkdir -p reports
+
 npm run compile
 npm run typechain
 


### PR DESCRIPTION
### Motivation

Catch errors and vulnerabilities as a first pass so we can fix issues before human auditors check the code.

### How to run 

To run the analyzer use `npm run analyzer`. It will write a report in the /reports folder. The analyzer will check all the contracts for vulnerabilities and also the ERC20 for conformity tests.

The analyzer is run by a bash script in `scripts/analyzer` that ensure to build the project before running.

