### PR TITLE
Add a parameter for required indexer minimum stake before disputing

### DIFF
--- a/graph.config.yml
+++ b/graph.config.yml
@@ -24,6 +24,9 @@ contracts:
       minimumDeposit: "100000000000000000000" # 100 GRT (in wei)
       fishermanRewardPercentage: 100000 # 10% (in basis points)
       slashingPercentage: 100000 # 10% (in basis points)
+    calls:
+      - fn: "setMinimumIndexerStake"
+        minimumIndexerStake: "1000000000000000000" # 1 GRT (in wei)
   EpochManager:
     init:
       lengthInBlocks: 275 # ~1 hour (in blocks)

--- a/test/disputes/configuration.test.ts
+++ b/test/disputes/configuration.test.ts
@@ -6,7 +6,7 @@ import { Staking } from '../../build/typechain/contracts/Staking'
 
 import { defaults } from '../lib/deployment'
 import { NetworkFixture } from '../lib/fixtures'
-import { getAccounts, toBN, Account } from '../lib/testHelpers'
+import { getAccounts, toBN, toGRT, Account } from '../lib/testHelpers'
 
 const MAX_PPM = 1000000
 
@@ -84,6 +84,26 @@ describe('DisputeManager:Config', () => {
       it('reject set `minimumDeposit` if not allowed', async function () {
         const newValue = toBN('1')
         const tx = disputeManager.connect(me.signer).setMinimumDeposit(newValue)
+        await expect(tx).revertedWith('Only Governor can call')
+      })
+    })
+
+    describe('minimumIndexerStake', function () {
+      it('should set `minimumIndexerStake`', async function () {
+        const oldValue = defaults.dispute.minimumIndexerStake
+        const newValue = toGRT('100')
+
+        // Set right in the constructor
+        expect(await disputeManager.minimumIndexerStake()).eq(oldValue)
+
+        // Set new value
+        await disputeManager.connect(governor.signer).setMinimumIndexerStake(newValue)
+        expect(await disputeManager.minimumIndexerStake()).eq(newValue)
+      })
+
+      it('reject set `minimumIndexerStake` if not allowed', async function () {
+        const newValue = toGRT('100')
+        const tx = disputeManager.connect(me.signer).setMinimumIndexerStake(newValue)
         await expect(tx).revertedWith('Only Governor can call')
       })
     })

--- a/test/disputes/disputes.test.ts
+++ b/test/disputes/disputes.test.ts
@@ -200,9 +200,9 @@ describe('DisputeManager', async () => {
       await expect(tx).revertedWith('Indexer cannot be found for the attestation')
     })
 
-    it('reject create a dispute if indexer has no stake', async function () {
-      // This tests reproduce the case when someones present a dispute after
-      // an indexer removed his stake completely and find nothing to slash
+    it('reject create a dispute if indexer below stake', async function () {
+      // This tests reproduce the case when someones present a dispute for
+      // an indexer that is under the minimum required staked amount
 
       const indexerCollectedTokens = toGRT('10')
 
@@ -240,7 +240,7 @@ describe('DisputeManager', async () => {
       const tx = disputeManager
         .connect(fisherman.signer)
         .createDispute(dispute.encodedAttestation, fishermanDeposit)
-      await expect(tx).revertedWith('Dispute has no stake by the indexer')
+      await expect(tx).revertedWith('Dispute under minimum indexer stake amount')
     })
 
     context('> when indexer has staked', function () {

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -45,6 +45,7 @@ export const defaults = {
   },
   dispute: {
     minimumDeposit: toGRT('100'),
+    minimumIndexerStake: toGRT('1'),
     fishermanRewardPercentage: toBN('1000'), // in basis points
     slashingPercentage: toBN('1000'), // in basis points
   },
@@ -118,7 +119,8 @@ export async function deployDisputeManager(
   arbitrator: string,
   staking: string,
 ): Promise<DisputeManager> {
-  return deployContract(
+  // Deploy
+  const contract = (await deployContract(
     'DisputeManager',
     owner,
     arbitrator,
@@ -127,7 +129,12 @@ export async function deployDisputeManager(
     defaults.dispute.minimumDeposit,
     defaults.dispute.fishermanRewardPercentage,
     defaults.dispute.slashingPercentage,
-  ) as Promise<DisputeManager>
+  )) as DisputeManager
+
+  // Config
+  await contract.connect(owner).setMinimumIndexerStake(defaults.dispute.minimumIndexerStake)
+
+  return contract
 }
 
 export async function deployEpochManager(owner: Signer): Promise<EpochManager> {


### PR DESCRIPTION
Governance can set a minimum amount the indexer needs to have staked to be disputed to avoid using conflicting attestations to avoid depositing.