### PR TITLE
Proof of indexing disputes

### DIFF
--- a/contracts/upgrades/GraphUpgradeable.sol
+++ b/contracts/upgrades/GraphUpgradeable.sol
@@ -16,6 +16,7 @@ contract GraphUpgradeable is GraphProxyStorage {
         require(msg.sender == _proxy.admin(), "Caller must be the proxy admin");
         _;
     }
+
     /**
      * @dev Check if the caller is the implementation.
      */

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -1,0 +1,207 @@
+import { expect } from 'chai'
+import { constants, utils, Wallet } from 'ethers'
+
+import { DisputeManager } from '../../build/typechain/contracts/DisputeManager'
+import { EpochManager } from '../../build/typechain/contracts/EpochManager'
+import { GraphToken } from '../../build/typechain/contracts/GraphToken'
+import { Staking } from '../../build/typechain/contracts/Staking'
+
+import { NetworkFixture } from '../lib/fixtures'
+import {
+  advanceToNextEpoch,
+  deriveChannelKey,
+  getAccounts,
+  getChainID,
+  randomHexBytes,
+  toBN,
+  toGRT,
+  Account,
+} from '../lib/testHelpers'
+
+const { AddressZero } = constants
+const { defaultAbiCoder: abi, arrayify, concat, hexlify, keccak256 } = utils
+
+const MAX_PPM = 1000000
+
+describe('DisputeManager:POI', async () => {
+  let me: Account
+  let other: Account
+  let governor: Account
+  let arbitrator: Account
+  let indexer: Account
+  let fisherman: Account
+  let indexer2: Account
+  let assetHolder: Account
+
+  let fixture: NetworkFixture
+
+  let disputeManager: DisputeManager
+  let epochManager: EpochManager
+  let grt: GraphToken
+  let staking: Staking
+
+  // Derive some channel keys for each indexer used to sign attestations
+  const indexerChannelKey = deriveChannelKey()
+
+  // Test values
+  const fishermanTokens = toGRT('100000')
+  const fishermanDeposit = toGRT('1000')
+  const indexerTokens = toGRT('100000')
+  const indexerAllocatedTokens = toGRT('10000')
+  const allocationID = indexerChannelKey.address
+  const subgraphDeploymentID = randomHexBytes(32)
+  const poi = randomHexBytes(32) // proof of indexing
+
+  async function setupIndexers() {
+    // Dispute manager is allowed to slash
+    await staking.connect(governor.signer).setSlasher(disputeManager.address, true)
+
+    // Stake
+    const indexerList = [{ wallet: indexer, pubKey: indexerChannelKey.pubKey }]
+    for (const activeIndexer of indexerList) {
+      const indexerWallet = activeIndexer.wallet
+      const indexerPubKey = activeIndexer.pubKey
+
+      // Give some funds to the indexer
+      await grt.connect(governor.signer).mint(indexerWallet.address, indexerTokens)
+      await grt.connect(indexerWallet.signer).approve(staking.address, indexerTokens)
+
+      // Indexer stake funds
+      await staking.connect(indexerWallet.signer).stake(indexerTokens)
+      await staking
+        .connect(indexerWallet.signer)
+        .allocate(
+          subgraphDeploymentID,
+          indexerAllocatedTokens,
+          indexerPubKey,
+          assetHolder.address,
+          toBN('0'),
+        )
+    }
+  }
+
+  before(async function () {
+    ;[
+      me,
+      other,
+      governor,
+      arbitrator,
+      indexer,
+      fisherman,
+      indexer2,
+      assetHolder,
+    ] = await getAccounts()
+
+    fixture = new NetworkFixture()
+    ;({ disputeManager, epochManager, grt, staking } = await fixture.load(
+      governor.signer,
+      other.signer,
+      arbitrator.signer,
+    ))
+
+    // Give some funds to the fisherman
+    await grt.connect(governor.signer).mint(fisherman.address, fishermanTokens)
+    await grt.connect(fisherman.signer).approve(disputeManager.address, fishermanTokens)
+  })
+
+  beforeEach(async function () {
+    await fixture.setUp()
+  })
+
+  afterEach(async function () {
+    await fixture.tearDown()
+  })
+
+  describe('disputes', function () {
+    it('reject create a dispute if allocation does not exist', async function () {
+      const invalidAllocationID = randomHexBytes(20)
+
+      // Create dispute
+      const tx = disputeManager
+        .connect(fisherman.signer)
+        .createIndexingDispute(invalidAllocationID, fishermanDeposit)
+      await expect(tx).revertedWith('Dispute allocation must exist')
+    })
+
+    it('reject create a dispute if indexer below stake', async function () {
+      // This tests reproduce the case when someones present a dispute for
+      // an indexer that is under the minimum required staked amount
+
+      const indexerCollectedTokens = toGRT('10')
+
+      // Give some funds to the indexer
+      await grt.connect(governor.signer).mint(indexer.address, indexerTokens)
+      await grt.connect(indexer.signer).approve(staking.address, indexerTokens)
+
+      // Give some funds to the channel
+      await grt.connect(governor.signer).mint(assetHolder.address, indexerCollectedTokens)
+      await grt.connect(assetHolder.signer).approve(staking.address, indexerCollectedTokens)
+
+      // Set the thawing period to zero to make the test easier
+      await staking.connect(governor.signer).setThawingPeriod(toBN('0'))
+
+      // Indexer stake funds, allocate, settle, unstake and withdraw the stake fully
+      await staking.connect(indexer.signer).stake(indexerTokens)
+      const tx1 = await staking
+        .connect(indexer.signer)
+        .allocate(
+          subgraphDeploymentID,
+          indexerAllocatedTokens,
+          indexerChannelKey.pubKey,
+          assetHolder.address,
+          toBN('0'),
+        )
+      const receipt1 = await tx1.wait()
+      const event1 = staking.interface.parseLog(receipt1.logs[0]).args
+      await advanceToNextEpoch(epochManager) // wait the required one epoch to settle
+      await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
+      await staking.connect(indexer.signer).settle(event1.allocationID, poi)
+      await staking.connect(indexer.signer).unstake(indexerTokens)
+      await staking.connect(indexer.signer).withdraw() // no thawing period so we are good
+
+      // Create dispute
+      const tx = disputeManager
+        .connect(fisherman.signer)
+        .createIndexingDispute(event1.allocationID, fishermanDeposit)
+      await expect(tx).revertedWith('Dispute under minimum indexer stake amount')
+    })
+
+    context('> when indexer is staked', function () {
+      beforeEach(async function () {
+        await setupIndexers()
+      })
+
+      it('should create a dispute', async function () {
+        // Create dispute
+        const tx = disputeManager
+          .connect(fisherman.signer)
+          .createIndexingDispute(allocationID, fishermanDeposit)
+        await expect(tx)
+          .emit(disputeManager, 'IndexingDisputeCreated')
+          .withArgs(
+            keccak256(allocationID),
+            indexer.address,
+            fisherman.address,
+            fishermanDeposit,
+            allocationID,
+          )
+      })
+
+      context('> when dispute is created', function () {
+        beforeEach(async function () {
+          // Create dispute
+          await disputeManager
+            .connect(fisherman.signer)
+            .createIndexingDispute(allocationID, fishermanDeposit)
+        })
+
+        it('reject create duplicated dispute', async function () {
+          const tx = disputeManager
+            .connect(fisherman.signer)
+            .createIndexingDispute(allocationID, fishermanDeposit)
+          await expect(tx).revertedWith('Dispute already created')
+        })
+      })
+    })
+  })
+})

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -1,4 +1,4 @@
-import { providers, utils, BigNumber, Signer } from 'ethers'
+import { providers, utils, BigNumber, Signer, Wallet } from 'ethers'
 import buidler from '@nomiclabs/buidler'
 
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
@@ -86,3 +86,16 @@ export const advanceToNextEpoch = async (epochManager: EpochManager): Promise<vo
 
 export const evmSnapshot = async (): Promise<number> => provider().send('evm_snapshot', [])
 export const evmRevert = async (id: number): Promise<boolean> => provider().send('evm_revert', [id])
+
+// Allocation keys
+
+interface ChannelKey {
+  privKey: string
+  pubKey: string
+  address: string
+}
+
+export const deriveChannelKey = (): ChannelKey => {
+  const w = Wallet.createRandom()
+  return { privKey: w.privateKey, pubKey: w.publicKey, address: utils.computeAddress(w.publicKey) }
+}

--- a/truffle.js
+++ b/truffle.js
@@ -6,7 +6,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 500,
+          runs: 200,
         },
       },
     },


### PR DESCRIPTION
### Motivation

https://www.notion.so/thegraph/Indexing-and-Query-Disputes-Arbitration-26d0ee96f6254c3f8fec6032c295f03a#a736573e5c004ebd987f0ecdefcb9ef6

### Implements

- Two types of disputes: query disputes using attestations and indexing disputes using allocationID.
- Disputes have common logic for accept, reject and draw.
- Challenger create a dispute with allocationID for the arbitrator to resolve.
- Only one dispute can be submitted for the same allocationID.
- Only distribute rewards if a POI is presented when closing an allocation.
- Update event attributes to avoid re-emitting multiple times the subgraph ID (it was unnecessary, only emitted on create) and reduced the footprint of the Dispute struct - @davekaj this could require some changes in the subgraph.
