### PR TITLE
rewards: fix visibility of isDenied to view

### DIFF
--- a/contracts/rewards/IRewardsManager.sol
+++ b/contracts/rewards/IRewardsManager.sol
@@ -11,7 +11,7 @@ interface IRewardsManager {
 
     function setDenied(bytes32 _subgraphDeploymentID, bool _deny) external;
 
-    function isDenied(bytes32 _subgraphDeploymentID) external returns (bool);
+    function isDenied(bytes32 _subgraphDeploymentID) external view returns (bool);
 
     // -- Getters --
 

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -102,7 +102,7 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
      * @dev Tells if subgraph is in deny list
      * @param _subgraphDeploymentID Subgraph deployment ID to check
      */
-    function isDenied(bytes32 _subgraphDeploymentID) public override returns (bool) {
+    function isDenied(bytes32 _subgraphDeploymentID) public override view returns (bool) {
         return denylist[_subgraphDeploymentID] > 0;
     }
 


### PR DESCRIPTION
The `isDenied` function had wrong visibility. Set to non-view when it should be view.