### PR TITLE
staking: rename concept "settle" from allocation to "close" allocation

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -47,12 +47,12 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   )
 }
 
-export const settle = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
-  const channelID = cliArgs.channelID
+export const closeAllocation = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
+  const allocationID = cliArgs.allocationID
   const staking = cli.contracts.Staking
 
-  logger.log(`Settling allocation with channelID ${channelID}...`)
-  await sendTransaction(cli.wallet, staking, 'settle', ...[channelID])
+  logger.log(`Closing allocation with allocationID ${allocationID}...`)
+  await sendTransaction(cli.wallet, staking, 'close', ...[allocationID])
 }
 
 export const collect = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -186,18 +186,18 @@ export const stakingCommand = {
         },
       })
       .command({
-        command: 'settle',
-        describe: 'Settle an allocation',
+        command: 'close-allocation',
+        describe: 'Close an allocation',
         builder: (yargs: Argv) => {
           return yargs.option('channelID', {
-            description: 'The channel / allocation being settled',
+            description: 'The channel / allocation being closed',
             type: 'string',
             requiresArg: true,
             demandOption: true,
           })
         },
         handler: async (argv: CLIArgs): Promise<void> => {
-          return settle(await loadEnv(argv), argv)
+          return closeAllocation(await loadEnv(argv), argv)
         },
       })
       .command({

--- a/cli/commands/simulations/baseSimulation.ts
+++ b/cli/commands/simulations/baseSimulation.ts
@@ -242,7 +242,7 @@
 // // Unstake for a few users, then withdraw
 // // Set epochs to one block
 // // Create 10 allocations
-// // Settle 5 allocations (Settle is called by the proxies)
+// // Close 5 allocations (Close is called by the proxies)
 // // Set back thawing period and epoch manager to default
 // const populateStaking = async (network: string, signers: Array<Wallet>, proxies: Array<Wallet>) => {
 //   console.log('Running staking contract calls...')
@@ -299,7 +299,7 @@
 
 //   console.log('Run Epoch....')
 //   await executeTransaction(epochManager.runEpoch(), network)
-//   console.log('Settle 5 allocations...')
+//   console.log('Close 5 allocations...')
 //   for (let i = 0; i < 5; i++) {
 //     // Note that the array of proxy wallets is used, not the signers
 //     const connectedGT = new ConnectedGraphToken(network, proxies[i])
@@ -312,7 +312,7 @@
 //       network,
 //     )
 //     console.log('Settling a channel...')
-//     await executeTransaction(staking.settleWithDecimals(stakeAmount), network)
+//     await executeTransaction(staking.closeWithDecimals(stakeAmount), network)
 //   }
 //   const defaultThawingPeriod = 20
 //   const defaultEpochLength = 5760

--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -58,7 +58,7 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration {
 
     /**
      * @dev Emitted when `tokens` amount were collected for `subgraphDeploymentID` as part of fees
-     * distributed by an indexer from the settlement of query fees.
+     * distributed by an indexer from query fees received from state channels.
      */
     event Collected(bytes32 indexed subgraphDeploymentID, uint256 tokens);
 

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -257,7 +257,7 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
     /**
      * @dev Triggers an update of rewards for a subgraph.
      * Must be called before allocation on a subgraph changes.
-     * NOTE: Hook called from the Staking contract on allocate() and settle()
+     * NOTE: Hook called from the Staking contract on allocate() and close()
      *
      * TODO: Some staticcalls can be optimized by making the Staking contract pass
      * more information in the call
@@ -333,7 +333,7 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
 
         // Do not do rewards on denied subgraph deployments ID
         if (isDenied(alloc.subgraphDeploymentID)) {
-            emit RewardsDenied(alloc.indexer, _allocationID, alloc.settledAtEpoch);
+            emit RewardsDenied(alloc.indexer, _allocationID, alloc.closedAtEpoch);
             return 0;
         }
 
@@ -349,7 +349,7 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
         // assign in proportion to each stakeholder incentive
         graphToken.mint(address(staking), rewards);
 
-        emit RewardsAssigned(alloc.indexer, _allocationID, alloc.settledAtEpoch, rewards);
+        emit RewardsAssigned(alloc.indexer, _allocationID, alloc.closedAtEpoch, rewards);
 
         return rewards;
     }

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -9,11 +9,11 @@ interface IStaking {
      * States:
      * - Null = indexer == address(0)
      * - Active = not Null && tokens > 0
-     * - Settled = Active && settledAtEpoch != 0
-     * - Finalized = Settling && settledAtEpoch + channelDisputeEpochs > now()
+     * - Closed = Active && closedAtEpoch != 0
+     * - Finalized = Closed && closedAtEpoch + channelDisputeEpochs > now()
      * - Claimed = not Null && tokens == 0
      */
-    enum AllocationState { Null, Active, Settled, Finalized, Claimed }
+    enum AllocationState { Null, Active, Closed, Finalized, Claimed }
 
     /**
      * @dev Allocate GRT tokens for the purpose of serving queries of a subgraph deployment
@@ -24,9 +24,9 @@ interface IStaking {
         bytes32 subgraphDeploymentID;
         uint256 tokens; // Tokens allocated to a SubgraphDeployment
         uint256 createdAtEpoch; // Epoch when it was created
-        uint256 settledAtEpoch; // Epoch when it was settled
+        uint256 closedAtEpoch; // Epoch when it was closed
         uint256 collectedFees; // Collected fees for the allocation
-        uint256 effectiveAllocation; // Effective allocation when settled
+        uint256 effectiveAllocation; // Effective allocation when closed
         address assetHolder; // Authorized caller address of the collect() function
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
     }
@@ -129,7 +129,7 @@ interface IStaking {
         uint256 _price
     ) external;
 
-    function settle(address _allocationID, bytes32 _poi) external;
+    function closeAllocation(address _allocationID, bytes32 _poi) external;
 
     function collect(uint256 _tokens, address _allocationID) external;
 

--- a/contracts/staking/libs/Rebates.sol
+++ b/contracts/staking/libs/Rebates.sol
@@ -15,11 +15,13 @@ library Rebates {
     using ABDKMathQuad for uint256;
     using ABDKMathQuad for bytes16;
 
-    // Tracks allocation settlements in a Pool per epoch
+    // Tracks allocations closed on an epoch for claiming
+    // The pool also keeps tracks of total query fees collected and stake used
+    // It is intended to have one pool per epoch
     struct Pool {
         uint256 fees; // total fees in the rebate pool
         uint256 allocation; // total effective allocation accumulated
-        uint256 settlementsCount;
+        uint256 unclaimedAllocationsCount; // amount of unclaimed allocations
     }
 
     /**
@@ -34,7 +36,7 @@ library Rebates {
     ) internal {
         pool.fees = pool.fees.add(_tokens);
         pool.allocation = pool.allocation.add(_allocation);
-        pool.settlementsCount += 1;
+        pool.unclaimedAllocationsCount += 1;
     }
 
     /**
@@ -55,7 +57,7 @@ library Rebates {
             pool.allocation,
             pool.fees
         );
-        pool.settlementsCount -= 1;
+        pool.unclaimedAllocationsCount -= 1;
         return tokens;
     }
 

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -140,7 +140,7 @@ describe('DisputeManager:POI', async () => {
       // Set the thawing period to zero to make the test easier
       await staking.connect(governor.signer).setThawingPeriod(toBN('0'))
 
-      // Indexer stake funds, allocate, settle, unstake and withdraw the stake fully
+      // Indexer stake funds, allocate, close, unstake and withdraw the stake fully
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
@@ -153,9 +153,9 @@ describe('DisputeManager:POI', async () => {
         )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
-      await advanceToNextEpoch(epochManager) // wait the required one epoch to settle
+      await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
-      await staking.connect(indexer.signer).settle(event1.allocationID, poi)
+      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
       await staking.connect(indexer.signer).unstake(indexerTokens)
       await staking.connect(indexer.signer).withdraw() // no thawing period so we are good
 

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -208,7 +208,7 @@ describe('DisputeManager:Query', async () => {
       // Set the thawing period to zero to make the test easier
       await staking.connect(governor.signer).setThawingPeriod(toBN('0'))
 
-      // Indexer stake funds, allocate, settle, unstake and withdraw the stake fully
+      // Indexer stake funds, allocate, close allocation, unstake and withdraw the stake fully
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
@@ -221,9 +221,9 @@ describe('DisputeManager:Query', async () => {
         )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
-      await advanceToNextEpoch(epochManager) // wait the required one epoch to settle
+      await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
-      await staking.connect(indexer.signer).settle(event1.allocationID, poi)
+      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
       await staking.connect(indexer.signer).unstake(indexerTokens)
       await staking.connect(indexer.signer).withdraw() // no thawing period so we are good
 

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -509,7 +509,7 @@ describe('Rewards', () => {
         )
     }
 
-    it('should distribute rewards on allocation settled', async function () {
+    it('should distribute rewards on closed allocation', async function () {
       // Setup
       await setupIndexerAllocation()
 
@@ -522,8 +522,10 @@ describe('Rewards', () => {
 
       const expectedIndexingRewards = toGRT('1471954234')
 
-      // Settle allocation. At this point rewards should be collected for that indexer
-      const tx = await staking.connect(indexer1.signer).settle(allocationID, randomHexBytes())
+      // Close allocation. At this point rewards should be collected for that indexer
+      const tx = await staking
+        .connect(indexer1.signer)
+        .closeAllocation(allocationID, randomHexBytes())
       const receipt = await tx.wait()
       const event = rewardsManager.interface.parseLog(receipt.logs[1]).args
       expect(event.indexer).eq(indexer1.address)
@@ -545,7 +547,7 @@ describe('Rewards', () => {
       expect(toRound(afterTokenSupply)).eq(toRound(expectedTokenSupply))
     })
 
-    it('should distribute rewards on allocation settled w/delegators', async function () {
+    it('should distribute rewards on closed allocation w/delegators', async function () {
       // Setup
       const delegationParams = {
         indexingRewardCut: toBN('50000'), // 5%
@@ -565,8 +567,8 @@ describe('Rewards', () => {
       const beforeDelegationPool = await staking.delegationPools(indexer1.address)
       const beforeIndexer1Stake = await staking.getIndexerStakedTokens(indexer1.address)
 
-      // Settle allocation. At this point rewards should be collected for that indexer
-      await staking.connect(indexer1.signer).settle(allocationID, randomHexBytes())
+      // Close allocation. At this point rewards should be collected for that indexer
+      await staking.connect(indexer1.signer).closeAllocation(allocationID, randomHexBytes())
 
       // After state
       const afterTokenSupply = await grt.totalSupply()
@@ -602,8 +604,8 @@ describe('Rewards', () => {
       // Jump
       await advanceBlocks(await epochManager.epochLength())
 
-      // Settle allocation. At this point rewards should be collected for that indexer
-      const tx = staking.connect(indexer1.signer).settle(allocationID, randomHexBytes())
+      // Close allocation. At this point rewards should be collected for that indexer
+      const tx = staking.connect(indexer1.signer).closeAllocation(allocationID, randomHexBytes())
       await expect(tx)
         .emit(rewardsManager, 'RewardsDenied')
         .withArgs(indexer1.address, allocationID, await epochManager.currentEpoch())

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -487,16 +487,16 @@ describe('Staking::Delegation', () => {
       // Collect some funds
       await staking.connect(channelProxy.signer).collect(tokensToCollect, channelID)
 
-      // Advance blocks to get the channel in epoch where it can be settled
+      // Advance blocks to get the channel in epoch where it can be closed
       await advanceToNextEpoch(epochManager)
 
-      // Settle
-      await staking.connect(indexer.signer).settle(channelID, poi)
+      // Close allocation
+      await staking.connect(indexer.signer).closeAllocation(channelID, poi)
 
       // Advance blocks to get the channel in epoch where it can be claimed
       await advanceToNextEpoch(epochManager)
 
-      // Delegation pool before settlement
+      // Delegation pool before allocation closed
       const beforeDelegationPool = await staking.delegationPools(indexer.address)
 
       // Calculate tokens to claim and expected delegation fees
@@ -514,7 +514,7 @@ describe('Staking::Delegation', () => {
           subgraphDeploymentID,
           channelID,
           currentEpoch,
-          beforeAlloc.settledAtEpoch,
+          beforeAlloc.closedAtEpoch,
           tokensToClaim,
           toBN('0'),
           delegationFees,


### PR DESCRIPTION
### Motivation

An allocation can settle payments for a period of time after it is closed. 
For that reason it was confusing to settle() in the contract while off-chain payments were still being collected.

### Notes

@davekaj this will affect the network subgraph as I renamed the AllocationSettled event to AllocationClosed.

It might be worth also looking at if you rely on any of the variable names that were changed.