### PR TITLE
staking: rotate allocation

### DIFF
--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -131,6 +131,17 @@ interface IStaking {
 
     function closeAllocation(address _allocationID, bytes32 _poi) external;
 
+    function closeAndAllocate(
+        address _oldAllocationID,
+        bytes32 _poi,
+        address _indexer,
+        bytes32 _subgraphDeploymentID,
+        uint256 _tokens,
+        bytes calldata _channelPubKey,
+        address _assetHolder,
+        uint256 _price
+    ) external;
+
     function collect(uint256 _tokens, address _allocationID) external;
 
     function claim(address _allocationID, bool _restake) external;


### PR DESCRIPTION
### Implements

A function that allows a caller to close an Active allocation and then allocate again, all on the same transaction.

### Motivation

Making it easier (and faster) for scripts managing indexer's resources to close and allocate using a single transaction avoiding delays and gaps during setup.

@Jannis you might be interested in this. Open to feedback about naming.