### PR TITLE
staking: replace price when allocating and instead use an IPFS Hash for extended metadata

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -34,8 +34,8 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const subgraphDeploymentID = cliArgs.subgraphDeploymentID
   const amount = parseGRT(cliArgs.amount)
   const channelPubKey = cliArgs.channelPubKey
-  const channelProxy = cliArgs.channelProxy
-  const price = cliArgs.price
+  const assetHolder = cliArgs.assetHolder
+  const metadata = cliArgs.metadata
   const staking = cli.contracts.Staking
 
   logger.log(`Allocating ${cliArgs.amount} tokens on ${subgraphDeploymentID}...`)
@@ -43,7 +43,7 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
     cli.wallet,
     staking,
     'allocate',
-    ...[subgraphDeploymentID, amount, channelPubKey, channelProxy, price],
+    ...[subgraphDeploymentID, amount, channelPubKey, assetHolder, metadata],
   )
 }
 
@@ -168,14 +168,14 @@ export const stakingCommand = {
               requiresArg: true,
               demandOption: true,
             })
-            .option('channelProxy', {
-              description: 'Address of the multisig proxy used to hold channel funds',
+            .option('assetHolder', {
+              description: 'Address of the contract that hold channel funds',
               type: 'string',
               requiresArg: true,
               demandOption: true,
             })
-            .option('price', {
-              description: 'Price the indexer will charge for serving queries of the subgraphID',
+            .option('metadata', {
+              description: 'IPFS hash of the metadata for the allocation',
               type: 'string',
               requiresArg: true,
               demandOption: true,

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -117,7 +117,7 @@ interface IStaking {
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external;
 
     function allocateFrom(
@@ -126,7 +126,7 @@ interface IStaking {
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external;
 
     function closeAllocation(address _allocationID, bytes32 _poi) external;
@@ -139,7 +139,7 @@ interface IStaking {
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external;
 
     function collect(uint256 _tokens, address _allocationID) external;

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -94,7 +94,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * during `epoch`.
      * `allocationID` indexer derived address used to identify the allocation.
      * `channelPubKey` is the public key used for routing payments to the indexer channel.
-     * `price` price the `indexer` will charge for serving queries of the `subgraphDeploymentID`.
+     * `metadata` additional information related to the allocation.
      */
     event AllocationCreated(
         address indexed indexer,
@@ -103,7 +103,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 tokens,
         address allocationID,
         bytes channelPubKey,
-        uint256 price,
+        bytes32 metadata,
         address assetHolder
     );
 
@@ -667,16 +667,23 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _tokens Amount of tokens to allocate
      * @param _channelPubKey The public key used to route payments
      * @param _assetHolder Authorized sender address of collected funds
-     * @param _price Price the `indexer` will charge for serving queries of the `subgraphDeploymentID`
+     * @param _metadata IPFS hash for additional information about the allocation
      */
     function allocate(
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external override notPaused {
-        _allocate(msg.sender, _subgraphDeploymentID, _tokens, _channelPubKey, _assetHolder, _price);
+        _allocate(
+            msg.sender,
+            _subgraphDeploymentID,
+            _tokens,
+            _channelPubKey,
+            _assetHolder,
+            _metadata
+        );
     }
 
     /**
@@ -686,7 +693,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _tokens Amount of tokens to allocate
      * @param _channelPubKey The public key used to route payments
      * @param _assetHolder Authorized sender address of collected funds
-     * @param _price Price the `indexer` will charge for serving queries of the `subgraphDeploymentID`
+     * @param _metadata IPFS hash for additional information about the allocation
      */
     function allocateFrom(
         address _indexer,
@@ -694,9 +701,16 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external override notPaused {
-        _allocate(_indexer, _subgraphDeploymentID, _tokens, _channelPubKey, _assetHolder, _price);
+        _allocate(
+            _indexer,
+            _subgraphDeploymentID,
+            _tokens,
+            _channelPubKey,
+            _assetHolder,
+            _metadata
+        );
     }
 
     /**
@@ -721,7 +735,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _tokens Amount of tokens to allocate
      * @param _channelPubKey The public key used to route payments
      * @param _assetHolder Authorized sender address of collected funds
-     * @param _price Price the `indexer` will charge for serving queries of the `subgraphDeploymentID`
+     * @param _metadata IPFS hash for additional information about the allocation
      */
     function closeAndAllocate(
         address _closingAllocationID,
@@ -731,10 +745,17 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 _tokens,
         bytes calldata _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) external override notPaused {
         _closeAllocation(_closingAllocationID, _poi);
-        _allocate(_indexer, _subgraphDeploymentID, _tokens, _channelPubKey, _assetHolder, _price);
+        _allocate(
+            _indexer,
+            _subgraphDeploymentID,
+            _tokens,
+            _channelPubKey,
+            _assetHolder,
+            _metadata
+        );
     }
 
     /**
@@ -862,7 +883,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _tokens Amount of tokens to allocate
      * @param _channelPubKey The public key used by the indexer to setup the off-chain channel
      * @param _assetHolder Authorized sender address of collected funds
-     * @param _price Price the `indexer` will charge for serving queries of the `subgraphDeploymentID`
+     * @param _metadata Metadata related to the allocation
      */
     function _allocate(
         address _indexer,
@@ -870,7 +891,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 _tokens,
         bytes memory _channelPubKey,
         address _assetHolder,
-        uint256 _price
+        bytes32 _metadata
     ) internal {
         require(_onlyAuth(_indexer), "Caller must be authorized");
 
@@ -931,7 +952,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
             alloc.tokens,
             allocationID,
             _channelPubKey,
-            _price,
+            _metadata,
             _assetHolder
         );
     }

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { constants, utils, Wallet } from 'ethers'
+import { utils } from 'ethers'
 
 import { DisputeManager } from '../../build/typechain/contracts/DisputeManager'
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
@@ -11,17 +11,13 @@ import {
   advanceToNextEpoch,
   deriveChannelKey,
   getAccounts,
-  getChainID,
   randomHexBytes,
   toBN,
   toGRT,
   Account,
 } from '../lib/testHelpers'
 
-const { AddressZero } = constants
-const { defaultAbiCoder: abi, arrayify, concat, hexlify, keccak256 } = utils
-
-const MAX_PPM = 1000000
+const { keccak256 } = utils
 
 describe('DisputeManager:POI', async () => {
   let me: Account
@@ -50,6 +46,7 @@ describe('DisputeManager:POI', async () => {
   const indexerAllocatedTokens = toGRT('10000')
   const allocationID = indexerChannelKey.address
   const subgraphDeploymentID = randomHexBytes(32)
+  const metadata = randomHexBytes(32)
   const poi = randomHexBytes(32) // proof of indexing
 
   async function setupIndexers() {
@@ -75,7 +72,7 @@ describe('DisputeManager:POI', async () => {
           indexerAllocatedTokens,
           indexerPubKey,
           assetHolder.address,
-          toBN('0'),
+          metadata,
         )
     }
   }
@@ -149,7 +146,7 @@ describe('DisputeManager:POI', async () => {
           indexerAllocatedTokens,
           indexerChannelKey.pubKey,
           assetHolder.address,
-          toBN('0'),
+          metadata,
         )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -19,7 +19,7 @@ import {
   Account,
 } from '../lib/testHelpers'
 
-const { AddressZero } = constants
+const { AddressZero, HashZero } = constants
 const { defaultAbiCoder: abi, arrayify, concat, hexlify, solidityKeccak256 } = utils
 
 const MAX_PPM = 1000000
@@ -86,6 +86,7 @@ describe('DisputeManager:Query', async () => {
   const fishermanDeposit = toGRT('1000')
   const indexerTokens = toGRT('100000')
   const indexerAllocatedTokens = toGRT('10000')
+  const metadata = HashZero
 
   const poi = randomHexBytes()
 
@@ -133,7 +134,7 @@ describe('DisputeManager:Query', async () => {
           indexerAllocatedTokens,
           indexerPubKey,
           assetHolder.address,
-          toBN('0'),
+          metadata,
         )
     }
   }
@@ -217,7 +218,7 @@ describe('DisputeManager:Query', async () => {
           indexerAllocatedTokens,
           indexer1ChannelKey.pubKey,
           assetHolder.address,
-          toBN('0'),
+          metadata,
         )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -23,6 +23,8 @@ import {
 
 const MAX_PPM = 1000000
 
+const { HashZero, WeiPerEther } = constants
+
 const toFloat = (n: BigNumber) => parseFloat(formatGRT(n))
 const toRound = (n: BigNumber) => Math.round(toFloat(n))
 
@@ -49,6 +51,7 @@ describe('Rewards', () => {
   const allocationID = '0x6367E9dD7641e0fF221740b57B8C730031d72530'
   const channelPubKey =
     '0x0456708870bfd5d8fc956fe33285dcf59b075cd7a25a21ee00834e480d3754bcda180e670145a290bb4bebca8e105ea7776a7b39e16c4df7d4d1083260c6f05d53'
+  const metadata = HashZero
 
   const ISSUANCE_RATE_PERIODS = 4 // blocks required to issue 5% rewards
   const ISSUANCE_RATE_PER_BLOCK = toBN('1012272234429039270') // % increase every block
@@ -315,8 +318,8 @@ describe('Rewards', () => {
       // Calculate rewards
       const rewardsPerSignal1 = await tracker1.accumulated
       const rewardsPerSignal2 = await tracker2.accumulated
-      const expectedRewardsSG1 = rewardsPerSignal1.mul(signalled1).div(constants.WeiPerEther)
-      const expectedRewardsSG2 = rewardsPerSignal2.mul(signalled2).div(constants.WeiPerEther)
+      const expectedRewardsSG1 = rewardsPerSignal1.mul(signalled1).div(WeiPerEther)
+      const expectedRewardsSG2 = rewardsPerSignal2.mul(signalled2).div(WeiPerEther)
 
       // Get rewards from contract
       const contractRewardsSG1 = await rewardsManager.getAccRewardsForSubgraph(
@@ -350,7 +353,7 @@ describe('Rewards', () => {
       const contractRewardsSG1 = (await rewardsManager.subgraphs(subgraphDeploymentID1))
         .accRewardsForSubgraph
       const rewardsPerSignal1 = await tracker1.accruedGRT()
-      const expectedRewardsSG1 = rewardsPerSignal1.mul(signalled1).div(constants.WeiPerEther)
+      const expectedRewardsSG1 = rewardsPerSignal1.mul(signalled1).div(WeiPerEther)
       expect(toRound(expectedRewardsSG1)).eq(toRound(contractRewardsSG1))
 
       const contractAccrued = await rewardsManager.accRewardsPerSignal()
@@ -379,7 +382,7 @@ describe('Rewards', () => {
           tokensToAllocate,
           channelPubKey,
           assetHolder.address,
-          toGRT('0.1'),
+          metadata,
         )
 
       // Jump
@@ -392,7 +395,7 @@ describe('Rewards', () => {
         subgraphDeploymentID1,
       )
       const accruedRewardsSG1 = accRewardsForSubgraphSG1.sub(sg1.accRewardsForSubgraphSnapshot)
-      const expectedRewardsAT1 = accruedRewardsSG1.mul(constants.WeiPerEther).div(tokensToAllocate)
+      const expectedRewardsAT1 = accruedRewardsSG1.mul(WeiPerEther).div(tokensToAllocate)
       const contractRewardsAT1 = (
         await rewardsManager.getAccRewardsPerAllocatedToken(subgraphDeploymentID1)
       )[0]
@@ -416,7 +419,7 @@ describe('Rewards', () => {
           tokensToAllocate,
           channelPubKey,
           assetHolder.address,
-          toGRT('0.1'),
+          metadata,
         )
 
       // Jump
@@ -459,7 +462,7 @@ describe('Rewards', () => {
           tokensToAllocate,
           channelPubKey,
           assetHolder.address,
-          toGRT('0.1'),
+          metadata,
         )
 
       // Jump
@@ -474,7 +477,7 @@ describe('Rewards', () => {
         await rewardsManager.getAccRewardsPerAllocatedToken(subgraphDeploymentID1)
       )[0]
 
-      const expectedRewards = contractRewardsAT1.mul(tokensToAllocate).div(constants.WeiPerEther)
+      const expectedRewards = contractRewardsAT1.mul(tokensToAllocate).div(WeiPerEther)
       expect(expectedRewards).eq(contractRewards)
     })
   })
@@ -523,7 +526,7 @@ describe('Rewards', () => {
           tokensToAllocate,
           channelPubKey,
           assetHolder.address,
-          toGRT('0.1'),
+          metadata,
         )
     }
 

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -63,14 +63,14 @@ describe('Staking:Allocation', () => {
   const channelKey = deriveChannelKey()
   const allocationID = channelKey.address
   const channelPubKey = channelKey.pubKey
-  const price = toGRT('0.01')
+  const metadata = randomHexBytes(32)
   const poi = randomHexBytes()
 
   // Helpers
   const allocate = (tokens: BigNumber) => {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, channelPubKey, assetHolder.address, price)
+      .allocate(subgraphDeploymentID, tokens, channelPubKey, assetHolder.address, metadata)
   }
 
   before(async function () {
@@ -151,7 +151,7 @@ describe('Staking:Allocation', () => {
           tokensToAllocate,
           allocationID,
           channelPubKey,
-          price,
+          metadata,
           assetHolder.address,
         )
 
@@ -187,7 +187,7 @@ describe('Staking:Allocation', () => {
           tokensToAllocate,
           invalidChannelPubKey,
           assetHolder.address,
-          price,
+          metadata,
         )
       await expect(tx).revertedWith('Invalid channel public key')
     })
@@ -223,7 +223,7 @@ describe('Staking:Allocation', () => {
             tokensToAllocate,
             channelPubKey,
             assetHolder.address,
-            price,
+            metadata,
           )
         await expect(tx1).revertedWith('Caller must be authorized')
 
@@ -237,7 +237,7 @@ describe('Staking:Allocation', () => {
             tokensToAllocate,
             channelPubKey,
             assetHolder.address,
-            price,
+            metadata,
           )
       })
 
@@ -532,7 +532,7 @@ describe('Staking:Allocation', () => {
           tokensToAllocate,
           deriveChannelKey().pubKey,
           assetHolder.address,
-          price,
+          metadata,
         )
       await tx
     })

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -33,7 +33,7 @@ describe('Staking:Stakes', () => {
   let indexer: Account
   let slasher: Account
   let fisherman: Account
-  let channelProxy: Account
+  let assetHolder: Account
 
   let fixture: NetworkFixture
 
@@ -46,13 +46,13 @@ describe('Staking:Stakes', () => {
   const subgraphDeploymentID = randomHexBytes()
   const channelPubKey =
     '0x0456708870bfd5d8fc956fe33285dcf59b075cd7a25a21ee00834e480d3754bcda180e670145a290bb4bebca8e105ea7776a7b39e16c4df7d4d1083260c6f05d53'
-  const price = toGRT('0.01')
+  const metadata = randomHexBytes(32)
 
   // Allocate with test values
   const allocate = function (tokens: BigNumber) {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, channelPubKey, channelProxy.address, price)
+      .allocate(subgraphDeploymentID, tokens, channelPubKey, assetHolder.address, metadata)
   }
 
   // Stake and verify state change
@@ -75,7 +75,7 @@ describe('Staking:Stakes', () => {
   }
 
   before(async function () {
-    ;[me, governor, indexer, slasher, fisherman, channelProxy] = await getAccounts()
+    ;[me, governor, indexer, slasher, fisherman, assetHolder] = await getAccounts()
 
     fixture = new NetworkFixture()
     ;({ grt, staking } = await fixture.load(governor.signer, slasher.signer))


### PR DESCRIPTION
### Motivation

Allow extensibility for additional information the indexer wants to communicate when allocating by using an IPFS hash of a JSON file format.