### PR TITLE
[C04] curation: remove totalTokens accounting and use balanceOf()

### DIFF
--- a/contracts/curation/CurationStorage.sol
+++ b/contracts/curation/CurationStorage.sol
@@ -18,9 +18,6 @@ contract CurationV1Storage is Managed {
     // This is the `startPoolBalance` for the bonding curve
     uint256 public minimumCurationDeposit;
 
-    // Total tokens in held as reserves received from curators deposits
-    uint256 internal totalTokens;
-
     // Bonding curve formula
     address public bondingCurve;
 

--- a/contracts/curation/ICuration.sol
+++ b/contracts/curation/ICuration.sol
@@ -13,8 +13,6 @@ interface ICuration {
 
     // -- Configuration --
 
-    function getTotalTokens() external view returns (uint256);
-
     function setDefaultReserveRatio(uint32 _defaultReserveRatio) external;
 
     function setMinimumCurationDeposit(uint256 _minimumCurationDeposit) external;

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -165,6 +165,8 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
      * @return newly accrued rewards per signal since last update
      */
     function getNewRewardsPerSignal() public override view returns (uint256) {
+        IGraphToken graphToken = graphToken();
+
         // Calculate time steps
         uint256 t = block.number.sub(accRewardsPerSignalLastBlockUpdated);
         // Optimization to skip calculations if zero time steps elapsed
@@ -178,16 +180,16 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
         }
 
         // Zero issuance if no signalled tokens
-        uint256 signalledTokens = curation().getTotalTokens();
+        uint256 signalledTokens = graphToken.balanceOf(address(curation()));
         if (signalledTokens == 0) {
             return 0;
         }
 
         uint256 r = issuanceRate;
-        uint256 p = graphToken().totalSupply();
+        uint256 p = graphToken.totalSupply();
         uint256 a = p.mul(_pow(r, t, TOKEN_DECIMALS)).div(TOKEN_DECIMALS);
 
-        // New issuance per signal during time steps
+        // New issuance per signalled token during time steps
         uint256 x = a.sub(p);
 
         // We multiply the decimals to keep the precision as fixed-point number

--- a/test/curation/curation.test.ts
+++ b/test/curation/curation.test.ts
@@ -324,6 +324,22 @@ describe('Curation', () => {
         await shouldCollect(toGRT('200'))
         await shouldCollect(toGRT('500.25'))
       })
+
+      it('should collect tokens and then unsignal all', async function () {
+        await controller
+          .connect(governor.signer)
+          .setContractProxy(utils.id('Staking'), stakingMock.address)
+
+        // Collect increase the pool reserves
+        await shouldCollect(toGRT('100'))
+
+        // When we burn signal we should get more tokens than initially curated
+        const signalToRedeem = await curation.getCuratorSignal(
+          curator.address,
+          subgraphDeploymentID,
+        )
+        await shouldRedeem(signalToRedeem, toGRT('1100'))
+      })
     })
   })
 

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -78,7 +78,7 @@ describe('Rewards', () => {
     async snapshot() {
       this.accumulated = this.accumulated.add(await this.accruedGRT())
       this.totalSupply = await grt.totalSupply()
-      this.totalSignalled = await curation.getTotalTokens()
+      this.totalSignalled = await grt.balanceOf(curation.address)
       this.lastUpdatedBlock = await latestBlock()
       return this
     }


### PR DESCRIPTION
### Implements
This commit implements the use of `balanceOf(Curation)` from the `RewardsManager` to get `totalTokens` used for Curation.

### Motivation
Initially we decided to use our own tracking of tokens used for curation to exclude tokens that might have been sent directly to the contract that could distort the rewards calculation.

We had an issue in the `totalTokens` accounting that didn't account for the collected tokens. This lead to a mismatch in rewards proportional to total collected funds, but a bigger issue was that it could make the `burn()` function to fail as more tokens were in the contract than the expected in our own accounting.

### Solution

We find that there is no big incentive to send tokens directly to the contract to distort those calculations and it is both more gas-efficient and safer to use `balanceOf()` to get the signalled tokens from the Curation contract when querying from RewardsManager.

**Fixed: [C04]**