### PR TITLE
governance: provide a way to zero the governor

### DIFF
--- a/contracts/governance/Governed.sol
+++ b/contracts/governance/Governed.sol
@@ -31,6 +31,18 @@ contract Governed {
     }
 
     /**
+     * @dev Leaves the contract without governor. It will not be possible to call
+     * `onlyGovernor` functions anymore. Can only be called by the current governor.
+     *
+     * NOTE: Renouncing ownership will leave the contract without a governor,
+     * thereby removing any functionality that is only available to the governor.
+     */
+    function renounceOwnership() external onlyGovernor {
+        emit NewOwnership(governor, address(0));
+        governor = address(0);
+    }
+
+    /**
      * @dev Admin function to begin change of governor. The `_newGovernor` must call
      * `acceptOwnership` to finalize the transfer.
      * @param _newGovernor Address of new `governor`

--- a/test/governance/governed.test.ts
+++ b/test/governance/governed.test.ts
@@ -20,7 +20,7 @@ describe('Governed', () => {
     governed = ((await factory.connect(governor.signer).deploy()) as unknown) as Governed
   })
 
-  it('should reject transfer if not allowed', async function () {
+  it('reject transfer if not allowed', async function () {
     const tx = governed.connect(me.signer).transferOwnership(me.address)
     await expect(tx).revertedWith('Only Governor can call')
   })
@@ -41,5 +41,16 @@ describe('Governed', () => {
 
     // Clean pending governor
     expect(await governed.pendingGovernor()).eq(AddressZero)
+  })
+
+  it('reject renounce ownership if not allowed', async function () {
+    const tx = governed.connect(me.signer).renounceOwnership()
+    expect(tx).revertedWith('Only Governor can call')
+  })
+
+  it('should renounce ownership', async function () {
+    const tx1 = governed.connect(governor.signer).renounceOwnership()
+    await expect(tx1).emit(governed, 'NewOwnership').withArgs(governor.address, AddressZero)
+    expect(await governed.governor()).eq(AddressZero)
   })
 })


### PR DESCRIPTION
This PR expose a function so the governor can renounce and let the contract be without governor.
This might be necessary for example in the future if we want to remove the governor from having the power to mint tokens, add minters, etc.

I'll leave this PR here in case we want to have it we can merge.

@Zerim @davekaj 