### PR TITLE
staking: rename delegationCapacity to delegationRatio

### DIFF
--- a/cli/commands/protocol/get.ts
+++ b/cli/commands/protocol/get.ts
@@ -15,7 +15,7 @@ export const gettersList = {
   'staking-thawing-period': { contract: 'Staking', name: 'thawingPeriod' },
   'staking-dispute-epochs': { contract: 'Staking', name: 'channelDisputeEpochs' },
   'staking-max-allocation-epochs': { contract: 'Staking', name: 'maxAllocationEpochs' },
-  'staking-delegation-capacity': { contract: 'Staking', name: 'delegationCapacity' },
+  'staking-delegation-ratio': { contract: 'Staking', name: 'delegationRatio' },
   'staking-delegation-parameters-cooldown': {
     contract: 'Staking',
     name: 'delegationParametersCooldown',

--- a/cli/commands/protocol/set.ts
+++ b/cli/commands/protocol/set.ts
@@ -15,7 +15,7 @@ export const settersList = {
   'staking-dispute-epochs': { contract: 'Staking', name: 'setChannelDisputeEpochs' },
   'staking-max-allocation-epochs': { contract: 'Staking', name: 'setMaxAllocationEpochs' },
   'staking-protocol-percentage': { contract: 'Staking', name: 'setProtocolPercentage' },
-  'staking-delegation-capacity': { contract: 'Staking', name: 'setDelegationCapacity' },
+  'staking-delegation-ratio': { contract: 'Staking', name: 'setDelegationRatio' },
   'staking-delegation-parameters-cooldown': {
     contract: 'Staking',
     name: 'setDelegationParametersCooldown',

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -69,7 +69,7 @@ interface IStaking {
 
     function setRebateRatio(uint32 _alphaNumerator, uint32 _alphaDenominator) external;
 
-    function setDelegationCapacity(uint32 _delegationCapacity) external;
+    function setDelegationRatio(uint32 _delegationRatio) external;
 
     function setDelegationParameters(
         uint32 _indexingRewardCut,

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -279,12 +279,14 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
     }
 
     /**
-     * @dev Set the delegation capacity multiplier.
-     * @param _delegationCapacity Delegation capacity multiplier
+     * @dev Set the delegation ratio.
+     * If set to 10 it means the indexer can use up to 10x the indexer staked amount
+     * from their delegated tokens
+     * @param _delegationRatio Delegation capacity multiplier
      */
-    function setDelegationCapacity(uint32 _delegationCapacity) external override onlyGovernor {
-        delegationCapacity = _delegationCapacity;
-        emit ParameterUpdated("delegationCapacity");
+    function setDelegationRatio(uint32 _delegationRatio) external override onlyGovernor {
+        delegationRatio = _delegationRatio;
+        emit ParameterUpdated("delegationRatio");
     }
 
     /**
@@ -468,7 +470,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         Stakes.Indexer memory indexerStake = stakes[_indexer];
         DelegationPool memory pool = delegationPools[_indexer];
 
-        uint256 tokensDelegatedMax = indexerStake.tokensStaked.mul(uint256(delegationCapacity));
+        uint256 tokensDelegatedMax = indexerStake.tokensStaked.mul(uint256(delegationRatio));
         uint256 tokensDelegated = (pool.tokens < tokensDelegatedMax)
             ? pool.tokens
             : tokensDelegatedMax;
@@ -480,7 +482,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         // This means the indexer doesn't have available capacity to create new allocations.
         // We can reach this state when the indexer has funds allocated and then any
         // of these conditions happen:
-        // - The delegationCapacity ratio is reduced.
+        // - The delegationRatio ratio is reduced.
         // - The indexer stake is slashed.
         // - A delegator removes enough stake.
         if (tokensUsed > tokensCapacity) {

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -49,10 +49,10 @@ contract StakingV1Storage is Managed {
 
     // -- Delegation --
 
-    // Set the delegation capacity multiplier
-    // If delegation capacity is 100 GRT, and an Indexer has staked 5 GRT,
-    // then they can accept 500 GRT as delegated stake
-    uint32 public delegationCapacity;
+    // Set the delegation capacity multiplier defined by the delegation ratio
+    // If delegation ratio is 100, and an Indexer has staked 5 GRT,
+    // then they can use up to 500 GRT from the delegated stake
+    uint32 public delegationRatio;
 
     // Time in blocks an indexer needs to wait to change delegation parameters
     uint32 public delegationParametersCooldown;

--- a/graph.config.yml
+++ b/graph.config.yml
@@ -76,8 +76,8 @@ contracts:
         maxAllocationEpochs: 24 # Based on epoch length this is ~1 day (in epochs)
       - fn: "setThawingPeriod"
         thawingPeriod: 275 # ~1 hour (in blocks)
-      - fn: "setDelegationCapacity"
-        delegationCapacity: 1 # 100% (multiplier)
+      - fn: "setDelegationRatio"
+        delegationRatio: 1 # 100% (multiplier)
       - fn: "setProtocolPercentage"
         protocolPercentage: 10000 # 1% (in basis points)
       - fn: "setRebateRatio"

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -191,16 +191,16 @@ describe('Staking::Delegation', () => {
   })
 
   describe('configuration', function () {
-    describe('delegationCapacity', function () {
-      const delegationCapacity = 5
+    describe('delegationRatio', function () {
+      const delegationRatio = 5
 
-      it('should set `delegationCapacity`', async function () {
-        await staking.connect(governor.signer).setDelegationCapacity(delegationCapacity)
-        expect(await staking.delegationCapacity()).eq(delegationCapacity)
+      it('should set `delegationRatio`', async function () {
+        await staking.connect(governor.signer).setDelegationRatio(delegationRatio)
+        expect(await staking.delegationRatio()).eq(delegationRatio)
       })
 
-      it('reject set `delegationCapacity` if not allowed', async function () {
-        const tx = staking.connect(me.signer).setDelegationCapacity(delegationCapacity)
+      it('reject set `delegationRatio` if not allowed', async function () {
+        const tx = staking.connect(me.signer).setDelegationRatio(delegationRatio)
         await expect(tx).revertedWith('Caller must be Controller governor')
       })
     })
@@ -438,7 +438,7 @@ describe('Staking::Delegation', () => {
 
     it('revert allocate when capacity is not enough', async function () {
       // 1:2 delegation capacity
-      await staking.connect(governor.signer).setDelegationCapacity(2)
+      await staking.connect(governor.signer).setDelegationRatio(2)
 
       // Delegate
       await staking.connect(delegator.signer).delegate(indexer.address, tokensToDelegate)
@@ -452,7 +452,7 @@ describe('Staking::Delegation', () => {
 
     it('should allocate using full delegation capacity', async function () {
       // 1:10 delegation capacity
-      await staking.connect(governor.signer).setDelegationCapacity(10)
+      await staking.connect(governor.signer).setDelegationRatio(10)
 
       // Delegate
       await staking.connect(delegator.signer).delegate(indexer.address, tokensToDelegate)
@@ -469,7 +469,7 @@ describe('Staking::Delegation', () => {
 
     it('should send delegation cut of query fees to delegation pool', async function () {
       // 1:10 delegation capacity
-      await staking.connect(governor.signer).setDelegationCapacity(10)
+      await staking.connect(governor.signer).setDelegationRatio(10)
 
       // Set delegation rules for the indexer
       const indexingRewardCut = toBN('800000') // indexer keep 80%


### PR DESCRIPTION
This is to avoid confusions between the ratio and the actual capacity.