### PR TITLE
staking: remove channel public key from the allocate call

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -33,7 +33,7 @@ export const withdraw = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
 export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const subgraphDeploymentID = cliArgs.subgraphDeploymentID
   const amount = parseGRT(cliArgs.amount)
-  const channelPubKey = cliArgs.channelPubKey
+  const allocationID = cliArgs.allocationID
   const assetHolder = cliArgs.assetHolder
   const metadata = cliArgs.metadata
   const staking = cli.contracts.Staking
@@ -43,7 +43,7 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
     cli.wallet,
     staking,
     'allocate',
-    ...[subgraphDeploymentID, amount, channelPubKey, assetHolder, metadata],
+    ...[subgraphDeploymentID, amount, allocationID, assetHolder, metadata],
   )
 }
 
@@ -162,8 +162,8 @@ export const stakingCommand = {
               requiresArg: true,
               demandOption: true,
             })
-            .option('channelPubKey', {
-              description: 'The public key used by the indexer to setup the off-chain channel',
+            .option('allocationID', {
+              description: 'Address used by the indexer as destination of funds of state channel',
               type: 'string',
               requiresArg: true,
               demandOption: true,

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -117,7 +117,7 @@ interface IStaking {
     function allocate(
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
-        bytes calldata _channelPubKey,
+        address _allocationID,
         address _assetHolder,
         bytes32 _metadata
     ) external;
@@ -126,7 +126,7 @@ interface IStaking {
         address _indexer,
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
-        bytes calldata _channelPubKey,
+        address _allocationID,
         address _assetHolder,
         bytes32 _metadata
     ) external;
@@ -139,7 +139,7 @@ interface IStaking {
         address _indexer,
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
-        bytes calldata _channelPubKey,
+        address _allocationID,
         address _assetHolder,
         bytes32 _metadata
     ) external;

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -53,11 +53,11 @@ describe('DisputeManager:POI', async () => {
     // Dispute manager is allowed to slash
     await staking.connect(governor.signer).setSlasher(disputeManager.address, true)
 
-    // Stake
-    const indexerList = [{ wallet: indexer, pubKey: indexerChannelKey.pubKey }]
+    // Stake & allocate
+    const indexerList = [{ wallet: indexer, allocationID: indexerChannelKey.address }]
     for (const activeIndexer of indexerList) {
       const indexerWallet = activeIndexer.wallet
-      const indexerPubKey = activeIndexer.pubKey
+      const indexerAllocationID = activeIndexer.allocationID
 
       // Give some funds to the indexer
       await grt.connect(governor.signer).mint(indexerWallet.address, indexerTokens)
@@ -70,7 +70,7 @@ describe('DisputeManager:POI', async () => {
         .allocate(
           subgraphDeploymentID,
           indexerAllocatedTokens,
-          indexerPubKey,
+          indexerAllocationID,
           assetHolder.address,
           metadata,
         )
@@ -144,7 +144,7 @@ describe('DisputeManager:POI', async () => {
         .allocate(
           subgraphDeploymentID,
           indexerAllocatedTokens,
-          indexerChannelKey.pubKey,
+          allocationID,
           assetHolder.address,
           metadata,
         )

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -114,12 +114,12 @@ describe('DisputeManager:Query', async () => {
 
     // Stake
     const indexerList = [
-      { wallet: indexer, pubKey: indexer1ChannelKey.pubKey },
-      { wallet: indexer2, pubKey: indexer2ChannelKey.pubKey },
+      { wallet: indexer, allocationID: indexer1ChannelKey.address },
+      { wallet: indexer2, allocationID: indexer2ChannelKey.address },
     ]
     for (const activeIndexer of indexerList) {
       const indexerWallet = activeIndexer.wallet
-      const indexerPubKey = activeIndexer.pubKey
+      const indexerAllocationID = activeIndexer.allocationID
 
       // Give some funds to the indexer
       await grt.connect(governor.signer).mint(indexerWallet.address, indexerTokens)
@@ -132,7 +132,7 @@ describe('DisputeManager:Query', async () => {
         .allocate(
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
-          indexerPubKey,
+          indexerAllocationID,
           assetHolder.address,
           metadata,
         )
@@ -216,7 +216,7 @@ describe('DisputeManager:Query', async () => {
         .allocate(
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
-          indexer1ChannelKey.pubKey,
+          indexer1ChannelKey.address,
           assetHolder.address,
           metadata,
         )
@@ -433,11 +433,11 @@ describe('DisputeManager:Query', async () => {
               .withArgs(dispute.id, dispute.indexerAddress, fisherman.address, fishermanDeposit)
 
             // After state
-            const afterTishermanBalance = await grt.balanceOf(fisherman.address)
+            const afterFishermanBalance = await grt.balanceOf(fisherman.address)
             const afterTotalSupply = await grt.totalSupply()
 
             // No change in fisherman balance
-            expect(afterTishermanBalance).eq(beforeFishermanBalance)
+            expect(afterFishermanBalance).eq(beforeFishermanBalance)
             // Burn fisherman deposit
             const burnedTokens = fishermanDeposit
             expect(afterTotalSupply).eq(beforeTotalSupply.sub(burnedTokens))

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -49,8 +49,6 @@ describe('Rewards', () => {
   const subgraphDeploymentID1 = randomHexBytes()
   const subgraphDeploymentID2 = randomHexBytes()
   const allocationID = '0x6367E9dD7641e0fF221740b57B8C730031d72530'
-  const channelPubKey =
-    '0x0456708870bfd5d8fc956fe33285dcf59b075cd7a25a21ee00834e480d3754bcda180e670145a290bb4bebca8e105ea7776a7b39e16c4df7d4d1083260c6f05d53'
   const metadata = HashZero
 
   const ISSUANCE_RATE_PERIODS = 4 // blocks required to issue 5% rewards
@@ -380,7 +378,7 @@ describe('Rewards', () => {
         .allocate(
           subgraphDeploymentID1,
           tokensToAllocate,
-          channelPubKey,
+          allocationID,
           assetHolder.address,
           metadata,
         )
@@ -417,7 +415,7 @@ describe('Rewards', () => {
         .allocate(
           subgraphDeploymentID1,
           tokensToAllocate,
-          channelPubKey,
+          allocationID,
           assetHolder.address,
           metadata,
         )
@@ -460,7 +458,7 @@ describe('Rewards', () => {
         .allocate(
           subgraphDeploymentID1,
           tokensToAllocate,
-          channelPubKey,
+          allocationID,
           assetHolder.address,
           metadata,
         )
@@ -524,7 +522,7 @@ describe('Rewards', () => {
         .allocate(
           subgraphDeploymentID1,
           tokensToAllocate,
-          channelPubKey,
+          allocationID,
           assetHolder.address,
           metadata,
         )

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { constants, utils, BigNumber } from 'ethers'
+import { constants, BigNumber } from 'ethers'
 
 import { Curation } from '../../build/typechain/contracts/Curation'
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
@@ -18,7 +18,6 @@ import {
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
-const { computePublicKey } = utils
 
 const MAX_PPM = toBN('1000000')
 
@@ -62,7 +61,6 @@ describe('Staking:Allocation', () => {
   const subgraphDeploymentID = randomHexBytes()
   const channelKey = deriveChannelKey()
   const allocationID = channelKey.address
-  const channelPubKey = channelKey.pubKey
   const metadata = randomHexBytes(32)
   const poi = randomHexBytes()
 
@@ -70,7 +68,7 @@ describe('Staking:Allocation', () => {
   const allocate = (tokens: BigNumber) => {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, channelPubKey, assetHolder.address, metadata)
+      .allocate(subgraphDeploymentID, tokens, allocationID, assetHolder.address, metadata)
   }
 
   before(async function () {
@@ -150,7 +148,6 @@ describe('Staking:Allocation', () => {
           currentEpoch,
           tokensToAllocate,
           allocationID,
-          channelPubKey,
           metadata,
           assetHolder.address,
         )
@@ -178,18 +175,17 @@ describe('Staking:Allocation', () => {
       await expect(tx).revertedWith('Cannot allocate zero tokens')
     })
 
-    it('reject allocate with invalid public key', async function () {
-      const invalidChannelPubKey = computePublicKey(channelPubKey, true)
+    it('reject allocate with invalid allocationID', async function () {
       const tx = staking
         .connect(indexer.signer)
         .allocate(
           subgraphDeploymentID,
           tokensToAllocate,
-          invalidChannelPubKey,
+          AddressZero,
           assetHolder.address,
           metadata,
         )
-      await expect(tx).revertedWith('Invalid channel public key')
+      await expect(tx).revertedWith('Invalid allocationID')
     })
 
     it('reject allocate if no tokens staked', async function () {
@@ -221,7 +217,7 @@ describe('Staking:Allocation', () => {
             indexer.address,
             subgraphDeploymentID,
             tokensToAllocate,
-            channelPubKey,
+            allocationID,
             assetHolder.address,
             metadata,
           )
@@ -235,7 +231,7 @@ describe('Staking:Allocation', () => {
             indexer.address,
             subgraphDeploymentID,
             tokensToAllocate,
-            channelPubKey,
+            allocationID,
             assetHolder.address,
             metadata,
           )
@@ -534,7 +530,7 @@ describe('Staking:Allocation', () => {
           indexer.address,
           subgraphDeploymentID,
           tokensToAllocate,
-          deriveChannelKey().pubKey,
+          deriveChannelKey().address,
           assetHolder.address,
           metadata,
         )

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -8,6 +8,7 @@ import { NetworkFixture } from '../lib/fixtures'
 
 import {
   advanceBlockTo,
+  deriveChannelKey,
   getAccounts,
   randomHexBytes,
   latestBlock,
@@ -44,15 +45,15 @@ describe('Staking:Stakes', () => {
   const indexerTokens = toGRT('1000')
   const tokensToStake = toGRT('100')
   const subgraphDeploymentID = randomHexBytes()
-  const channelPubKey =
-    '0x0456708870bfd5d8fc956fe33285dcf59b075cd7a25a21ee00834e480d3754bcda180e670145a290bb4bebca8e105ea7776a7b39e16c4df7d4d1083260c6f05d53'
+  const channelKey = deriveChannelKey()
+  const allocationID = channelKey.address
   const metadata = randomHexBytes(32)
 
   // Allocate with test values
   const allocate = function (tokens: BigNumber) {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, channelPubKey, assetHolder.address, metadata)
+      .allocate(subgraphDeploymentID, tokens, allocationID, assetHolder.address, metadata)
   }
 
   // Stake and verify state change


### PR DESCRIPTION
### Implements

Remove `channelPublicKey` from the allocate call and pass the `allocationID`. 
It was used to emit in the `AllocationCreated` event to allow for clients to route payments but now is deprecated.

### Motivation

The state channel framework is no longer using a public key to route payments.

**BREAKING CHANGES**

@Jannis take into account when setting up allocations that the `allocate()` signature changed
@davekaj the `AllocationCreated` event is emitting one less parameter