### PR TITLE
[H01] staking: enforce funds collected from allowed asset holder

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -34,7 +34,6 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const subgraphDeploymentID = cliArgs.subgraphDeploymentID
   const amount = parseGRT(cliArgs.amount)
   const allocationID = cliArgs.allocationID
-  const assetHolder = cliArgs.assetHolder
   const metadata = cliArgs.metadata
   const staking = cli.contracts.Staking
 
@@ -43,7 +42,7 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
     cli.wallet,
     staking,
     'allocate',
-    ...[subgraphDeploymentID, amount, allocationID, assetHolder, metadata],
+    ...[subgraphDeploymentID, amount, allocationID, metadata],
   )
 }
 
@@ -186,12 +185,6 @@ export const stakingCommand = {
             })
             .option('allocationID', {
               description: 'Address used by the indexer as destination of funds of state channel',
-              type: 'string',
-              requiresArg: true,
-              demandOption: true,
-            })
-            .option('assetHolder', {
-              description: 'Address of the contract that hold channel funds',
               type: 'string',
               requiresArg: true,
               demandOption: true,

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -27,7 +27,6 @@ interface IStaking {
         uint256 closedAtEpoch; // Epoch when it was closed
         uint256 collectedFees; // Collected fees for the allocation
         uint256 effectiveAllocation; // Effective allocation when closed
-        address assetHolder; // Authorized caller address of the collect() function
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
     }
 
@@ -83,6 +82,8 @@ interface IStaking {
 
     function setSlasher(address _slasher, bool _allowed) external;
 
+    function setAssetHolder(address _assetHolder, bool _allowed) external;
+
     // -- Operation --
 
     function setOperator(address _operator, bool _allowed) external;
@@ -118,7 +119,6 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external;
 
@@ -127,7 +127,6 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external;
 
@@ -140,7 +139,6 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external;
 

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -101,8 +101,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 epoch,
         uint256 tokens,
         address allocationID,
-        bytes32 metadata,
-        address assetHolder
+        bytes32 metadata
     );
 
     /**
@@ -156,9 +155,15 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
     );
 
     /**
-     * @dev Emitted when `caller` set `slasher` address as `enabled` to slash stakes.
+     * @dev Emitted when `caller` set `slasher` address as `allowed` to slash stakes.
      */
-    event SlasherUpdate(address indexed caller, address indexed slasher, bool enabled);
+    event SlasherUpdate(address indexed caller, address indexed slasher, bool allowed);
+
+    /**
+     * @dev Emitted when `caller` set `assetHolder` address as `allowed` to send funds
+     * to staking contract.
+     */
+    event AssetHolderUpdate(address indexed caller, address indexed assetHolder, bool allowed);
 
     /**
      * @dev Emitted when `indexer` set `operator` access.
@@ -361,8 +366,20 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _allowed True if slasher is allowed
      */
     function setSlasher(address _slasher, bool _allowed) external override onlyGovernor {
+        require(_slasher != address(0), "!slasher");
         slashers[_slasher] = _allowed;
         emit SlasherUpdate(msg.sender, _slasher, _allowed);
+    }
+
+    /**
+     * @dev Set an address as allowed asset holder.
+     * @param _assetHolder Address of allowed source for state channel funds
+     * @param _allowed True if asset holder is allowed
+     */
+    function setAssetHolder(address _assetHolder, bool _allowed) external override onlyGovernor {
+        require(_assetHolder != address(0), "!assetHolder");
+        assetHolders[_assetHolder] = _allowed;
+        emit AssetHolderUpdate(msg.sender, _assetHolder, _allowed);
     }
 
     /**
@@ -683,24 +700,15 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
      * @param _tokens Amount of tokens to allocate
      * @param _allocationID The allocation identifier
-     * @param _assetHolder Authorized sender address of collected funds
      * @param _metadata IPFS hash for additional information about the allocation
      */
     function allocate(
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external override notPaused {
-        _allocate(
-            msg.sender,
-            _subgraphDeploymentID,
-            _tokens,
-            _allocationID,
-            _assetHolder,
-            _metadata
-        );
+        _allocate(msg.sender, _subgraphDeploymentID, _tokens, _allocationID, _metadata);
     }
 
     /**
@@ -709,7 +717,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
      * @param _tokens Amount of tokens to allocate
      * @param _allocationID The allocation identifier
-     * @param _assetHolder Authorized sender address of collected funds
      * @param _metadata IPFS hash for additional information about the allocation
      */
     function allocateFrom(
@@ -717,10 +724,9 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external override notPaused {
-        _allocate(_indexer, _subgraphDeploymentID, _tokens, _allocationID, _assetHolder, _metadata);
+        _allocate(_indexer, _subgraphDeploymentID, _tokens, _allocationID, _metadata);
     }
 
     /**
@@ -744,7 +750,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
      * @param _tokens Amount of tokens to allocate
      * @param _allocationID The allocation identifier
-     * @param _assetHolder Authorized sender address of collected funds
      * @param _metadata IPFS hash for additional information about the allocation
      */
     function closeAndAllocate(
@@ -754,11 +759,10 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) external override notPaused {
         _closeAllocation(_closingAllocationID, _poi);
-        _allocate(_indexer, _subgraphDeploymentID, _tokens, _allocationID, _assetHolder, _metadata);
+        _allocate(_indexer, _subgraphDeploymentID, _tokens, _allocationID, _metadata);
     }
 
     /**
@@ -770,13 +774,8 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         // Allocation identifier validation
         require(_allocationID != address(0), "Invalid allocation");
 
-        // NOTE: commented out for easier test of state-channel integrations
-        // NOTE: this validation might be removed in the future if no harm to the
-        // NOTE: economic incentive structure is done by an external caller use
-        // NOTE: of this function
-        // The contract caller must be an asset holder registered during allocate()
-        // Allocation memory alloc = allocations[_allocationID];
-        // require(alloc.assetHolder == msg.sender, "caller is not authorized");
+        // The contract caller must be an authorized asset holder
+        require(assetHolders[msg.sender] == true, "!assetHolder");
 
         // Transfer tokens to collect from the authorized sender
         require(
@@ -822,7 +821,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         alloc.closedAtEpoch = 0;
         alloc.collectedFees = 0;
         alloc.effectiveAllocation = 0;
-        alloc.assetHolder = address(0); // This avoid collect() to be called
 
         // -- Effects --
 
@@ -886,7 +884,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
      * @param _tokens Amount of tokens to allocate
      * @param _allocationID The allocationID will work to identify collected funds related to this allocation
-     * @param _assetHolder Authorized sender address of collected funds
      * @param _metadata Metadata related to the allocation
      */
     function _allocate(
@@ -894,7 +891,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        address _assetHolder,
         bytes32 _metadata
     ) internal {
         require(_onlyAuth(_indexer), "!auth");
@@ -927,7 +923,6 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
             0, // closedAtEpoch
             0, // Initialize collected fees
             0, // Initialize effective allocation
-            _assetHolder, // Source address for allocation collected funds
             _updateRewards(_subgraphDeploymentID) // Initialize accumulated rewards per stake allocated
         );
         allocations[_allocationID] = alloc;
@@ -947,8 +942,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
             alloc.createdAtEpoch,
             alloc.tokens,
             _allocationID,
-            _metadata,
-            _assetHolder
+            _metadata
         );
     }
 

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -67,4 +67,9 @@ contract StakingV1Storage is Managed {
 
     // Operator auth : indexer => operator
     mapping(address => mapping(address => bool)) public operatorAuth;
+
+    // -- Asset Holders --
+
+    // Allowed AssetHolders: assetHolder => is allowed
+    mapping(address => bool) public assetHolders;
 }

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -20,13 +20,11 @@ import {
 const { keccak256 } = utils
 
 describe('DisputeManager:POI', async () => {
-  let me: Account
   let other: Account
   let governor: Account
   let arbitrator: Account
   let indexer: Account
   let fisherman: Account
-  let indexer2: Account
   let assetHolder: Account
 
   let fixture: NetworkFixture
@@ -67,27 +65,12 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(indexerWallet.signer).stake(indexerTokens)
       await staking
         .connect(indexerWallet.signer)
-        .allocate(
-          subgraphDeploymentID,
-          indexerAllocatedTokens,
-          indexerAllocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID, indexerAllocatedTokens, indexerAllocationID, metadata)
     }
   }
 
   before(async function () {
-    ;[
-      me,
-      other,
-      governor,
-      arbitrator,
-      indexer,
-      fisherman,
-      indexer2,
-      assetHolder,
-    ] = await getAccounts()
+    ;[other, governor, arbitrator, indexer, fisherman, assetHolder] = await getAccounts()
 
     fixture = new NetworkFixture()
     ;({ disputeManager, epochManager, grt, staking } = await fixture.load(
@@ -99,6 +82,9 @@ describe('DisputeManager:POI', async () => {
     // Give some funds to the fisherman
     await grt.connect(governor.signer).mint(fisherman.address, fishermanTokens)
     await grt.connect(fisherman.signer).approve(disputeManager.address, fishermanTokens)
+
+    // Allow the asset holder
+    await staking.connect(governor.signer).setAssetHolder(assetHolder.address, true)
   })
 
   beforeEach(async function () {
@@ -141,13 +127,7 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
-        .allocate(
-          subgraphDeploymentID,
-          indexerAllocatedTokens,
-          allocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID, indexerAllocatedTokens, allocationID, metadata)
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
       await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -133,7 +133,6 @@ describe('DisputeManager:Query', async () => {
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
           indexerAllocationID,
-          assetHolder.address,
           metadata,
         )
     }
@@ -161,6 +160,9 @@ describe('DisputeManager:Query', async () => {
     // Give some funds to the fisherman
     await grt.connect(governor.signer).mint(fisherman.address, fishermanTokens)
     await grt.connect(fisherman.signer).approve(disputeManager.address, fishermanTokens)
+
+    // Allow the asset holder
+    await staking.connect(governor.signer).setAssetHolder(assetHolder.address, true)
 
     // Create an attestation
     const attestation = await buildAttestation(receipt, indexer1ChannelKey.privKey)
@@ -217,7 +219,6 @@ describe('DisputeManager:Query', async () => {
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
           indexer1ChannelKey.address,
-          assetHolder.address,
           metadata,
         )
       const receipt1 = await tx1.wait()

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -35,7 +35,6 @@ describe('Rewards', () => {
   let curator2: Account
   let indexer1: Account
   let indexer2: Account
-  let assetHolder: Account
   let oracle: Account
 
   let fixture: NetworkFixture
@@ -127,16 +126,7 @@ describe('Rewards', () => {
   }
 
   before(async function () {
-    ;[
-      delegator,
-      governor,
-      curator1,
-      curator2,
-      indexer1,
-      indexer2,
-      assetHolder,
-      oracle,
-    ] = await getAccounts()
+    ;[delegator, governor, curator1, curator2, indexer1, indexer2, oracle] = await getAccounts()
 
     fixture = new NetworkFixture()
     ;({ grt, curation, epochManager, staking, rewardsManager } = await fixture.load(
@@ -375,13 +365,7 @@ describe('Rewards', () => {
       await staking.connect(indexer1.signer).stake(tokensToAllocate)
       await staking
         .connect(indexer1.signer)
-        .allocate(
-          subgraphDeploymentID1,
-          tokensToAllocate,
-          allocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
 
       // Jump
       await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -412,13 +396,7 @@ describe('Rewards', () => {
       await staking.connect(indexer1.signer).stake(tokensToAllocate)
       await staking
         .connect(indexer1.signer)
-        .allocate(
-          subgraphDeploymentID1,
-          tokensToAllocate,
-          allocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
 
       // Jump
       await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -455,13 +433,7 @@ describe('Rewards', () => {
       await staking.connect(indexer1.signer).stake(tokensToAllocate)
       await staking
         .connect(indexer1.signer)
-        .allocate(
-          subgraphDeploymentID1,
-          tokensToAllocate,
-          allocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
 
       // Jump
       await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -519,13 +491,7 @@ describe('Rewards', () => {
       await staking.connect(indexer1.signer).stake(tokensToAllocate)
       await staking
         .connect(indexer1.signer)
-        .allocate(
-          subgraphDeploymentID1,
-          tokensToAllocate,
-          allocationID,
-          assetHolder.address,
-          metadata,
-        )
+        .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
     }
 
     it('should distribute rewards on closed allocation', async function () {

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -181,6 +181,9 @@ describe('Staking::Delegation', () => {
       await grt.connect(governor.signer).mint(wallet.address, toGRT('1000000'))
       await grt.connect(wallet.signer).approve(staking.address, toGRT('1000000'))
     }
+
+    // Allow the asset holder
+    await staking.connect(governor.signer).setAssetHolder(assetHolder.address, true)
   })
 
   beforeEach(async function () {
@@ -428,7 +431,7 @@ describe('Staking::Delegation', () => {
     const setupAllocation = async (tokens: BigNumber) => {
       return staking
         .connect(indexer.signer)
-        .allocate(subgraphDeploymentID, tokens, allocationID, assetHolder.address, metadata)
+        .allocate(subgraphDeploymentID, tokens, allocationID, metadata)
     }
 
     beforeEach(async function () {

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -34,7 +34,6 @@ describe('Staking:Stakes', () => {
   let indexer: Account
   let slasher: Account
   let fisherman: Account
-  let assetHolder: Account
 
   let fixture: NetworkFixture
 
@@ -53,7 +52,7 @@ describe('Staking:Stakes', () => {
   const allocate = function (tokens: BigNumber) {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, allocationID, assetHolder.address, metadata)
+      .allocate(subgraphDeploymentID, tokens, allocationID, metadata)
   }
 
   // Stake and verify state change
@@ -76,7 +75,7 @@ describe('Staking:Stakes', () => {
   }
 
   before(async function () {
-    ;[me, governor, indexer, slasher, fisherman, assetHolder] = await getAccounts()
+    ;[me, governor, indexer, slasher, fisherman] = await getAccounts()
 
     fixture = new NetworkFixture()
     ;({ grt, staking } = await fixture.load(governor.signer, slasher.signer))


### PR DESCRIPTION
In a previous state channel implementation the AssetHolder was a multisig created for the purpose of funding each channel, as the multisig address was determined by the indexer-gateway relationship it needed to be passed in the allocate call and we needed to keep track of it in each allocation.

In the newer implementation the AssetHolder will be shared (using ledger channels) across multiple channels, collateral is sent to the AssetHolder to keep an open tab to play multiple games, when a game finishes the adjudicator contract will end up unlocking funds from the AssetHolder and transferring it to the Staking contract according to the game played. The game played will carry the information about the destination address for collected funds, this is our allocationID.

### Implements

- Remove assetHolder parameter from all allocate() calls
- Remove assetHolder state variable from Allocation
- Add a governance function to set a new AssetHolder address as allowed
- Verify in collect() function that the caller is any of the allowed AssetHolders

@davekaj please, watch out for event changes: `SlasherUpdate` `AssetHolderUpdate`
@Jannis this changes the signature of `allocate()` and `allocateFrom()` - also as long as we don't use ledger channels we need to allow the address of the gateway

**Related to: [H01]**