### PR TITLE
[N13] staking: unreachable condition in tokensWithdrawable function

### DIFF
--- a/contracts/staking/libs/Stakes.sol
+++ b/contracts/staking/libs/Stakes.sol
@@ -176,12 +176,6 @@ library Stakes {
         if (stake.tokensLockedUntil == 0 || block.number < stake.tokensLockedUntil) {
             return 0;
         }
-        // Cannot withdraw more than currently staked
-        // This condition can happen if while tokens are locked for withdrawal a slash condition happens
-        // In that case the total staked tokens could be below the amount to be withdrawn
-        if (stake.tokensLocked > stake.tokensStaked) {
-            return stake.tokensStaked;
-        }
         return stake.tokensLocked;
     }
 }


### PR DESCRIPTION
The tokensWithdrawable function of the Stakes library checks whether the tokens staked are less than the tokens locked, but this condition will never be true even after a slash condition happens, as the slash function of the Staking contract will unlock the slashed amount of tokens for later releasing them.

**Related to: [N13]**