### PR TITLE
[L13] rewards: _pow function can revert in extreme conditions

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -5,6 +5,7 @@ contracts/discovery/erc1056
 contracts/token/IGraphToken.sol
 contracts/upgrades/GraphProxy.sol
 contracts/rewards/RewardsManager.sol
+contracts/tests/RewardsManagerMock.sol
 contracts/tests/ens
 contracts/curation/IGraphCurationToken.sol
 contracts/staking/libs/LibFixedMath.sol

--- a/contracts/tests/RewardsManagerMock.sol
+++ b/contracts/tests/RewardsManagerMock.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
+
+// Mock contract used for testing rewards
+contract RewardsManagerMock {
+    /**
+     * @dev Raises x to the power of n with scaling factor of base.
+     * Based on: https://github.com/makerdao/dss/blob/master/src/pot.sol#L81
+     * @param x Base of the exponentation
+     * @param n Exponent
+     * @param base Scaling factor
+     * @return z Exponential of n with base x
+     */
+    function pow(
+        uint256 x,
+        uint256 n,
+        uint256 base
+    ) public pure returns (uint256 z) {
+        assembly {
+            switch x
+                case 0 {
+                    switch n
+                        case 0 {
+                            z := base
+                        }
+                        default {
+                            z := 0
+                        }
+                }
+                default {
+                    switch mod(n, 2)
+                        case 0 {
+                            z := base
+                        }
+                        default {
+                            z := x
+                        }
+                    let half := div(base, 2) // for rounding.
+                    for {
+                        n := div(n, 2)
+                    } n {
+                        n := div(n, 2)
+                    } {
+                        let xx := mul(x, x)
+                        if iszero(eq(div(xx, x), x)) {
+                            revert(0, 0)
+                        }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) {
+                            revert(0, 0)
+                        }
+                        x := div(xxRound, base)
+                        if mod(n, 2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) {
+                                revert(0, 0)
+                            }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) {
+                                revert(0, 0)
+                            }
+                            z := div(zxRound, base)
+                        }
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
Ensure the `pow()` function have a separate test that runs under reasonable but quite high boundaries to ensure there is room to accomodate unreasonable high issuance rate and time periods parameters.

**Related to: [L13]**