### PR TITLE
[H04] upgrades: updating the proxy admin address was not emitting an event

### DIFF
--- a/contracts/upgrades/GraphProxy.sol
+++ b/contracts/upgrades/GraphProxy.sol
@@ -23,7 +23,7 @@ contract GraphProxy is GraphProxyStorage {
         );
 
         _setAdmin(msg.sender);
-        upgradeTo(_impl);
+        _setPendingImplementation(_impl);
     }
 
     /**

--- a/contracts/upgrades/GraphProxyStorage.sol
+++ b/contracts/upgrades/GraphProxyStorage.sol
@@ -46,6 +46,11 @@ contract GraphProxyStorage {
     event ImplementationUpdated(address oldImplementation, address newImplementation);
 
     /**
+     * @dev Emitted when the admin account has changed.
+     */
+    event AdminUpdated(address oldAdmin, address newAdmin);
+
+    /**
      * @dev Modifier to check whether the `msg.sender` is the admin.
      */
     modifier onlyAdmin() {
@@ -72,6 +77,8 @@ contract GraphProxyStorage {
         assembly {
             sstore(slot, _newAdmin)
         }
+
+        emit AdminUpdated(_admin(), _newAdmin);
     }
 
     /**


### PR DESCRIPTION
### Implements

Add `AdminUpdated(address oldAdmin, address newAdmin)` event whenever `_setAdmin()` is called

**Fixes: [H04]** 