### PR TITLE
[H05] upgrades: sensitive functions inherited in implementations

### DIFF
--- a/contracts/upgrades/GraphUpgradeable.sol
+++ b/contracts/upgrades/GraphUpgradeable.sol
@@ -1,14 +1,20 @@
 pragma solidity ^0.6.12;
 
 import "./IGraphProxy.sol";
-import "./GraphProxyStorage.sol";
 
 /**
  * @title Graph Upgradeable
  * @dev This contract is intended to be inherited from upgradeable contracts.
- * This contract should NOT define storage as it is managed by GraphProxyStorage.
  */
-contract GraphUpgradeable is GraphProxyStorage {
+contract GraphUpgradeable {
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32
+        internal constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
     /**
      * @dev Check if the caller is the proxy admin.
      */
@@ -23,6 +29,17 @@ contract GraphUpgradeable is GraphProxyStorage {
     modifier onlyImpl {
         require(msg.sender == _implementation(), "Caller must be the implementation");
         _;
+    }
+
+    /**
+     * @dev Returns the current implementation.
+     * @return impl Address of the current implementation
+     */
+    function _implementation() internal view returns (address impl) {
+        bytes32 slot = IMPLEMENTATION_SLOT;
+        assembly {
+            impl := sload(slot)
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation

GraphUpgradeable is meant to be inherited from contracts that will be implementations of the upgradeable pattern. As GraphUpgradeable was in turn inheriting GraphProxyStorage it was exposing some functions meant only to be used by the GraphProxy.

### Implements

Remove the GraphProxyStorage link to GraphUpgradeable and only expose the read-only required function to query the implementation address.

**Fixes: [H05]**