### PR TITLE
[L08] upgrades: externally owned accounts can be set as implementation contracts

### DIFF
--- a/contracts/upgrades/GraphProxy.sol
+++ b/contracts/upgrades/GraphProxy.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.6.12;
 
+import "@openzeppelin/contracts/utils/Address.sol";
+
 import "./GraphProxyStorage.sol";
 
 /**
@@ -69,6 +71,7 @@ contract GraphProxy is GraphProxyStorage {
      */
     function acceptUpgrade() external {
         address _pendingImplementation = _pendingimplementation();
+        require(Address.isContract(_pendingImplementation), "Implementation must be a contract");
         require(
             _pendingImplementation != address(0) && msg.sender == _pendingImplementation,
             "Caller must be the pending implementation"


### PR DESCRIPTION
Checking whether the address passed to the `acceptUpgrade` function is a contract or not using the `Address.isContract` function of the OpenZeppelin contracts.

**Fixes: [L08]**