### PR TITLE
discovery: make the service registry to be used from operators

### DIFF
--- a/contracts/discovery/IServiceRegistry.sol
+++ b/contracts/discovery/IServiceRegistry.sol
@@ -8,7 +8,15 @@ interface IServiceRegistry {
 
     function register(string calldata _url, string calldata _geohash) external;
 
+    function registerFor(
+        address _indexer,
+        string calldata _url,
+        string calldata _geohash
+    ) external;
+
     function unregister() external;
+
+    function unregisterFor(address _indexer) external;
 
     function isRegistered(address _indexer) external view returns (bool);
 }

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -90,6 +90,8 @@ interface IStaking {
 
     function setOperator(address _operator, bool _allowed) external;
 
+    function isOperator(address _operator, address _indexer) external view returns (bool);
+
     // -- Staking --
 
     function stake(uint256 _tokens) external;

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -182,7 +182,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @dev Check if the caller is authorized (indexer or operator)
      */
     function _onlyAuth(address _indexer) internal view returns (bool) {
-        return msg.sender == _indexer || operatorAuth[_indexer][msg.sender] == true;
+        return msg.sender == _indexer || isOperator(msg.sender, _indexer) == true;
     }
 
     /**
@@ -522,6 +522,15 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         require(_operator != msg.sender, "operator != sender");
         operatorAuth[msg.sender][_operator] = _allowed;
         emit SetOperator(msg.sender, _operator, _allowed);
+    }
+
+    /**
+     * @dev Return true if operator is allowed for indexer.
+     * @param _operator Address of the operator
+     * @param _indexer Address of the indexer
+     */
+    function isOperator(address _operator, address _indexer) public override view returns (bool) {
+        return operatorAuth[_indexer][_operator];
     }
 
     /**

--- a/graph.config.yml
+++ b/graph.config.yml
@@ -25,6 +25,9 @@ contracts:
       - fn: "setContractProxy"
         id: "0x45fc200c7e4544e457d3c5709bfe0d520442c30bbcbdaede89e8d4a4bbc19247" # keccak256('GraphToken')
         contractAddress: "${{GraphToken.address}}"
+  ServiceRegistry:
+    init:
+      controller: "${{Controller.address}}"
   EpochManager:
     init:
       controller: "${{Controller.address}}"

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -188,8 +188,13 @@ export async function deployEthereumDIDRegistry(deployer: Signer): Promise<Ether
   >
 }
 
-export async function deployServiceRegistry(deployer: Signer): Promise<ServiceRegistry> {
-  return (deployContract('ServiceRegistry', deployer) as unknown) as Promise<ServiceRegistry>
+export async function deployServiceRegistry(
+  deployer: Signer,
+  controller: string,
+): Promise<ServiceRegistry> {
+  return (deployContract('ServiceRegistry', deployer, controller) as unknown) as Promise<
+    ServiceRegistry
+  >
 }
 
 export async function deployStaking(deployer: Signer, controller: string): Promise<Staking> {

--- a/test/lib/fixtures.ts
+++ b/test/lib/fixtures.ts
@@ -33,7 +33,7 @@ export class NetworkFixture {
       arbitratorAddress,
     )
     const rewardsManager = await deployment.deployRewardsManager(deployer, controller.address)
-    const serviceRegistry = await deployment.deployServiceRegistry(deployer)
+    const serviceRegistry = await deployment.deployServiceRegistry(deployer, controller.address)
 
     // Setup controller
     await controller.setContractProxy(utils.id('EpochManager'), epochManager.address)

--- a/test/serviceRegisty.test.ts
+++ b/test/serviceRegisty.test.ts
@@ -1,16 +1,20 @@
 import { expect } from 'chai'
 
 import { ServiceRegistry } from '../build/typechain/contracts/ServiceRegistry'
+import { Staking } from '../build/typechain/contracts/Staking'
 
-import * as deployment from './lib/deployment'
 import { getAccounts, Account } from './lib/testHelpers'
+import { NetworkFixture } from './lib/fixtures'
 
 describe('ServiceRegistry', () => {
-  let me: Account
+  let governor: Account
   let indexer: Account
+  let operator: Account
+
+  let fixture: NetworkFixture
 
   let serviceRegistry: ServiceRegistry
-  const geohash = '69y7hdrhm6mp'
+  let staking: Staking
 
   const shouldRegister = async (url: string, geohash: string) => {
     // Register the indexer service
@@ -26,23 +30,31 @@ describe('ServiceRegistry', () => {
   }
 
   before(async function () {
-    ;[me, indexer] = await getAccounts()
+    ;[governor, indexer, operator] = await getAccounts()
+
+    fixture = new NetworkFixture()
+    ;({ serviceRegistry, staking } = await fixture.load(governor.signer, governor.signer))
   })
 
   beforeEach(async function () {
-    const controller = await deployment.deployController(me.signer)
-    serviceRegistry = await deployment.deployServiceRegistry(me.signer)
+    await fixture.setUp()
+  })
+
+  afterEach(async function () {
+    await fixture.tearDown()
   })
 
   describe('register', function () {
+    const url = 'https://192.168.2.1/'
+    const geo = '69y7hdrhm6mp'
+
     it('should allow registering', async function () {
-      const url = 'https://192.168.2.1/'
-      await shouldRegister(url, geohash)
+      await shouldRegister(url, geo)
     })
 
     it('should allow registering with a very long string', async function () {
       const url = 'https://' + 'a'.repeat(125) + '.com'
-      await shouldRegister(url, geohash)
+      await shouldRegister(url, geo)
     })
 
     it('should allow updating a registration', async function () {
@@ -56,14 +68,35 @@ describe('ServiceRegistry', () => {
       const tx = serviceRegistry.connect(indexer.signer).register('', '')
       await expect(tx).revertedWith('Service must specify a URL')
     })
+
+    describe('operator', function () {
+      it('reject register from unauthorized operator', async function () {
+        const tx = serviceRegistry
+          .connect(operator.signer)
+          .registerFor(indexer.address, 'http://thegraph.com', '')
+        await expect(tx).revertedWith('!auth')
+      })
+
+      it('should register from operator', async function () {
+        // Auth and register
+        await staking.connect(indexer.signer).setOperator(operator.address, true)
+        await serviceRegistry.connect(operator.signer).registerFor(indexer.address, url, geo)
+
+        // Updated state
+        const indexerService = await serviceRegistry.services(indexer.address)
+        expect(indexerService.url).eq(url)
+        expect(indexerService.geohash).eq(geo)
+      })
+    })
   })
 
   describe('unregister', function () {
-    it('should unregister existing registration', async function () {
-      const url = 'https://thegraph.com'
+    const url = 'https://192.168.2.1/'
+    const geo = '69y7hdrhm6mp'
 
+    it('should unregister existing registration', async function () {
       // Register the indexer service
-      await serviceRegistry.connect(indexer.signer).register(url, geohash)
+      await serviceRegistry.connect(indexer.signer).register(url, geo)
 
       // Unregister the indexer service
       const tx = serviceRegistry.connect(indexer.signer).unregister()
@@ -73,6 +106,31 @@ describe('ServiceRegistry', () => {
     it('reject unregister non-existing registration', async function () {
       const tx = serviceRegistry.connect(indexer.signer).unregister()
       await expect(tx).revertedWith('Service already unregistered')
+    })
+
+    describe('operator', function () {
+      it('reject unregister from unauthorized operator', async function () {
+        // Register the indexer service
+        await serviceRegistry.connect(indexer.signer).register(url, geo)
+
+        // Unregister
+        const tx = serviceRegistry.connect(operator.signer).unregisterFor(indexer.address)
+        await expect(tx).revertedWith('!auth')
+      })
+
+      it('should unregister from operator', async function () {
+        // Register the indexer service
+        await serviceRegistry.connect(indexer.signer).register(url, geo)
+
+        // Auth and unregister
+        await staking.connect(indexer.signer).setOperator(operator.address, true)
+        await serviceRegistry.connect(operator.signer).unregisterFor(indexer.address)
+
+        // Updated state
+        const indexerService = await serviceRegistry.services(indexer.address)
+        expect(indexerService.url).eq('')
+        expect(indexerService.geohash).eq('')
+      })
     })
   })
 })


### PR DESCRIPTION
### Motivation
The indexer-agent can perform some actions on behalf of the indexer by using operator keys. The issue is that one of those action is registering the URL for the service endpoint in the ServiceRegistry and this contracts does not support checking operator keys as it is pretty simple and does not have awareness of other contracts.

### Implements
- Makes the ServiceRegistry aware of the Controller.
- Introduces registerFor() and unregisterFor() that can be called by both
operators and indexers to set the registration. It accepts the indexer
address as first parameter.
- Query the auth operators from the Staking contract.
- Update the deploy config file to pass the Controller address to the
ServiceRegistry.

@davekaj @Jannis 