### PR TITLE
staking: claim can be called by public

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -912,10 +912,8 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         Allocation storage alloc = allocations[_allocationID];
         AllocationState allocState = _getAllocationState(_allocationID);
 
-        // Validate ownership
-        require(_onlyAuthOrDelegator(alloc.indexer), "!auth-or-del");
-
-        // TODO: restake when delegator called should not be allowed?
+        // Only the indexer or operator can decide if to restake
+        bool restake = _onlyAuth(alloc.indexer) ? _restake : false;
 
         // Funds can only be claimed after a period of time passed since allocation was closed
         require(allocState == AllocationState.Finalized, "!finalized");
@@ -949,7 +947,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         // When there are tokens to claim from the rebate pool, transfer or restake
         if (tokensToClaim > 0) {
             // Assign claimed tokens
-            if (_restake) {
+            if (restake) {
                 // Restake to place fees into the indexer stake
                 _stake(alloc.indexer, tokensToClaim);
             } else {


### PR DESCRIPTION
### Motivation

The claim function is called to get the rebate rewards for a particular finalized allocation. This function will always send funds to the indexer that created the allocation. Currently it can be called by the indexer, operator or delegators from the indexer pool. There is no negative consequence for this function to be called by external actors as funds will always be transferred to the indexer. By removing this validation anyone could call the function when the indexer is not incentivized or willing to do so.

### Implements

- Allow anyone to call the claim() function.
- Restake can only be decided by the indexer or delegator.
