### PR TITLE
cli: gas price and limit overrides

### DIFF
--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'ethers'
 import { extendEnvironment, task, usePlugin } from '@nomiclabs/buidler/config'
 
 import { getAddressBook } from './cli/address-book'
-import { cliOpts } from './cli/constants'
+import { cliOpts } from './cli/defaults'
 import { loadContracts, loadEnv } from './cli/env'
 import { getContractAt } from './cli/network'
 import { migrate } from './cli/commands/migrate'

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -12,7 +12,7 @@ import { transferTeamTokensCommand } from './commands/transferTeamTokens'
 import { simulationCommand } from './commands/simulations'
 import { airdropCommand } from './commands/airdrop'
 
-import { cliOpts } from './constants'
+import { cliOpts } from './defaults'
 
 dotenv.config()
 

--- a/cli/commands/airdrop.ts
+++ b/cli/commands/airdrop.ts
@@ -213,12 +213,10 @@ export const airdrop = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
         totalAmount,
       )} tokens (${totalAmount} wei)`,
     )
-    await sendTransaction(
-      cli.wallet,
-      graphToken,
-      'approve',
-      ...[disperseContract.address, totalAmount],
-    )
+    await sendTransaction(cli.wallet, graphToken, 'approve', [
+      disperseContract.address,
+      totalAmount,
+    ])
   }
 
   // Distribute
@@ -245,12 +243,11 @@ export const airdrop = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
         )
       }
       try {
-        const receipt = await sendTransaction(
-          nonceManager,
-          disperseContract,
-          'disperseToken',
-          ...[graphToken.address, addressList, amountList],
-        )
+        const receipt = await sendTransaction(nonceManager, disperseContract, 'disperseToken', [
+          graphToken.address,
+          addressList,
+          amountList,
+        ])
         saveResumeList(cliArgs.resumefile, receipt.transactionHash, batch)
       } catch (err) {
         logger.error(`Failed to send #${batchNum}`, err)

--- a/cli/commands/contracts/any.ts
+++ b/cli/commands/contracts/any.ts
@@ -21,7 +21,7 @@ export const any = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> 
     logger.success(`${func} = ${value}`)
   } else if (cliArgs.type == 'set') {
     logger.log(`Setting ${func}...`)
-    await sendTransaction(cli.wallet, attachedContract, func, ...params)
+    await sendTransaction(cli.wallet, attachedContract, func, params)
   }
 }
 

--- a/cli/commands/contracts/curation.ts
+++ b/cli/commands/contracts/curation.ts
@@ -15,9 +15,9 @@ export const mint = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const graphToken = cli.contracts.GraphToken
 
   logger.log('First calling approve() to ensure curation contract can call transferFrom()...')
-  await sendTransaction(cli.wallet, graphToken, 'approve', ...[curation.address, amount])
+  await sendTransaction(cli.wallet, graphToken, 'approve', [curation.address, amount])
   logger.log(`Signaling on ${subgraphID} with ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, curation, 'mint', ...[subgraphID, amount])
+  await sendTransaction(cli.wallet, curation, 'mint', [subgraphID, amount])
 }
 export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const subgraphID = cliArgs.subgraphID
@@ -25,7 +25,7 @@ export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const curation = cli.contracts.Curation
 
   logger.log(`Burning signal on ${subgraphID} with ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, curation, 'burn', ...[subgraphID, amount])
+  await sendTransaction(cli.wallet, curation, 'burn', [subgraphID, amount])
 }
 
 export const curationCommand = {

--- a/cli/commands/contracts/ens.ts
+++ b/cli/commands/contracts/ens.ts
@@ -15,7 +15,7 @@ export const registerTestName = async (cli: CLIEnvironment, cliArgs: CLIArgs): P
   const label = utils.keccak256(utils.toUtf8Bytes(normalizedName))
   logger.log(`Namehash for ${labelNameFull}: ${labelHashFull}`)
   logger.log(`Registering ${name} with ${cli.walletAddress} on the test registrar`)
-  await sendTransaction(cli.wallet, testRegistrar, 'register', ...[label, cli.walletAddress])
+  await sendTransaction(cli.wallet, testRegistrar, 'register', [label, cli.walletAddress])
 }
 export const checkOwner = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const name = cliArgs.name

--- a/cli/commands/contracts/ethereumDIDRegistry.ts
+++ b/cli/commands/contracts/ethereumDIDRegistry.ts
@@ -44,12 +44,12 @@ export const setAttribute = async (cli: CLIEnvironment, cliArgs: CLIArgs) => {
   const metaHashBytes = await handleAccountMetadata(ipfsEndpoint, metadataPath)
 
   logger.log(`Setting attribute on ethereum DID registry ...`)
-  await sendTransaction(
-    cli.wallet,
-    ethereumDIDRegistry,
-    'setAttribute',
-    ...[cli.walletAddress, name, metaHashBytes, 0],
-  )
+  await sendTransaction(cli.wallet, ethereumDIDRegistry, 'setAttribute', [
+    cli.walletAddress,
+    name,
+    metaHashBytes,
+    0,
+  ])
 }
 
 export const ethereumDIDRegistryCommand = {

--- a/cli/commands/contracts/gns.ts
+++ b/cli/commands/contracts/gns.ts
@@ -18,12 +18,7 @@ export const setDefaultName = async (cli: CLIEnvironment, cliArgs: CLIArgs): Pro
   const gns = cli.contracts.GNS
 
   logger.log(`Setting default name as ${name} for ${graphAccount}...`)
-  await sendTransaction(
-    cli.wallet,
-    gns,
-    'setDefaultName',
-    ...[graphAccount, nameSystem, node, name],
-  )
+  await sendTransaction(cli.wallet, gns, 'setDefaultName', [graphAccount, nameSystem, node, name])
 }
 
 export const publishNewSubgraph = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -39,12 +34,12 @@ export const publishNewSubgraph = async (cli: CLIEnvironment, cliArgs: CLIArgs):
   const gns = cli.contracts.GNS
 
   logger.log(`Publishing new subgraph for ${graphAccount}`)
-  await sendTransaction(
-    cli.wallet,
-    gns,
-    'publishNewSubgraph',
-    ...[graphAccount, subgraphDeploymentIDBytes, versionHashBytes, subgraphHashBytes],
-  )
+  await sendTransaction(cli.wallet, gns, 'publishNewSubgraph', [
+    graphAccount,
+    subgraphDeploymentIDBytes,
+    versionHashBytes,
+    subgraphHashBytes,
+  ])
 }
 
 export const publishNewVersion = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -59,12 +54,12 @@ export const publishNewVersion = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   const gns = cli.contracts.GNS
 
   logger.log(`Publishing new subgraph version for ${graphAccount}`)
-  await sendTransaction(
-    cli.wallet,
-    gns,
-    'publishNewVersion',
-    ...[graphAccount, subgraphNumber, subgraphDeploymentIDBytes, versionHashBytes],
-  )
+  await sendTransaction(cli.wallet, gns, 'publishNewVersion', [
+    graphAccount,
+    subgraphNumber,
+    subgraphDeploymentIDBytes,
+    versionHashBytes,
+  ])
 }
 
 export const deprecate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -72,7 +67,7 @@ export const deprecate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<
   const subgraphNumber = cliArgs.subgraphNumber
   const gns = cli.contracts.GNS
   logger.log(`Deprecating subgraph ${graphAccount}-${subgraphNumber}...`)
-  await sendTransaction(cli.wallet, gns, 'deprecate', ...[graphAccount, subgraphNumber])
+  await sendTransaction(cli.wallet, gns, 'deprecate', [graphAccount, subgraphNumber])
 }
 
 export const updateSubgraphMetadata = async (
@@ -87,12 +82,11 @@ export const updateSubgraphMetadata = async (
   const gns = cli.contracts.GNS
 
   logger.log(`Updating subgraph metadata for ${graphAccount}-${subgraphNumber}...`)
-  await sendTransaction(
-    cli.wallet,
-    gns,
-    'updateSubgraphMetadata',
-    ...[graphAccount, subgraphNumber, subgraphHashBytes],
-  )
+  await sendTransaction(cli.wallet, gns, 'updateSubgraphMetadata', [
+    graphAccount,
+    subgraphNumber,
+    subgraphHashBytes,
+  ])
 }
 
 export const mintNSignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -102,7 +96,7 @@ export const mintNSignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promis
   const gns = cli.contracts.GNS
 
   logger.log(`Minting nSignal for ${graphAccount}-${subgraphNumber}...`)
-  await sendTransaction(cli.wallet, gns, 'mintNSignal', ...[graphAccount, subgraphNumber, tokens])
+  await sendTransaction(cli.wallet, gns, 'mintNSignal', [graphAccount, subgraphNumber, tokens])
 }
 
 export const burnNSignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -112,7 +106,7 @@ export const burnNSignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promis
   const gns = cli.contracts.GNS
 
   logger.log(`Burning nSignal from ${graphAccount}-${subgraphNumber}...`)
-  await sendTransaction(cli.wallet, gns, 'burnNSignal', ...[graphAccount, subgraphNumber, nSignal])
+  await sendTransaction(cli.wallet, gns, 'burnNSignal', [graphAccount, subgraphNumber, nSignal])
 }
 
 export const withdrawGRT = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -121,7 +115,7 @@ export const withdrawGRT = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promis
   const gns = cli.contracts.GNS
 
   logger.log(`Withdrawing locked GRT from subgraph ${graphAccount}-${subgraphNumber}...`)
-  await sendTransaction(cli.wallet, gns, 'withdrawGRT', ...[graphAccount, subgraphNumber])
+  await sendTransaction(cli.wallet, gns, 'withdrawGRT', [graphAccount, subgraphNumber])
 }
 
 export const gnsCommand = {

--- a/cli/commands/contracts/graphToken.ts
+++ b/cli/commands/contracts/graphToken.ts
@@ -13,7 +13,7 @@ export const mint = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const graphToken = cli.contracts.GraphToken
 
   logger.log(`Minting ${cliArgs.amount} tokens for user ${account}...`)
-  await sendTransaction(cli.wallet, graphToken, 'mint', ...[account, amount])
+  await sendTransaction(cli.wallet, graphToken, 'mint', [account, amount])
 }
 
 export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -21,7 +21,7 @@ export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const graphToken = cli.contracts.GraphToken
 
   logger.log(`Burning ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, graphToken, 'burn', ...[amount])
+  await sendTransaction(cli.wallet, graphToken, 'burn', [amount])
 }
 
 export const transfer = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -30,7 +30,7 @@ export const transfer = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const graphToken = cli.contracts.GraphToken
 
   logger.log(`Transferring ${cliArgs.amount} tokens to user ${account}...`)
-  await sendTransaction(cli.wallet, graphToken, 'transfer', ...[account, amount])
+  await sendTransaction(cli.wallet, graphToken, 'transfer', [account, amount])
 }
 
 export const approve = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -39,7 +39,7 @@ export const approve = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   const graphToken = cli.contracts.GraphToken
 
   logger.log(`Approving ${cliArgs.amount} tokens for user ${account} to spend...`)
-  await sendTransaction(cli.wallet, graphToken, 'approve', ...[account, amount])
+  await sendTransaction(cli.wallet, graphToken, 'approve', [account, amount])
 }
 
 export const allowance = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {

--- a/cli/commands/contracts/gsr-gdai.ts
+++ b/cli/commands/contracts/gsr-gdai.ts
@@ -12,7 +12,7 @@ export const setGSR = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<voi
   const gdai = cli.contracts.GDAI
 
   logger.log(`Setting GSR to ${account}...`)
-  await sendTransaction(cli.wallet, gdai, 'setGSR', ...[account])
+  await sendTransaction(cli.wallet, gdai, 'setGSR', [account])
 }
 
 export const setRate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -20,7 +20,7 @@ export const setRate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   const gsr = cli.contracts.GSRManager
 
   logger.log(`Setting rate to ${amount}...`)
-  await sendTransaction(cli.wallet, gsr, 'setRate', ...[amount])
+  await sendTransaction(cli.wallet, gsr, 'setRate', [amount])
 }
 
 export const join = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -29,7 +29,7 @@ export const join = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
 
   logger.log(`Reminder - you must call approve on the GSR before`)
   logger.log(`Joining GSR with ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, gsr, 'join', ...[amount])
+  await sendTransaction(cli.wallet, gsr, 'join', [amount])
 }
 
 export const mint = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -38,7 +38,7 @@ export const mint = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const gdai = cli.contracts.GDAI
 
   logger.log(`Minting ${cliArgs.amount} GDAI for user ${account}...`)
-  await sendTransaction(cli.wallet, gdai, 'mint', ...[account, amount])
+  await sendTransaction(cli.wallet, gdai, 'mint', [account, amount])
 }
 
 export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -46,7 +46,7 @@ export const burn = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void>
   const gdai = cli.contracts.GDAI
 
   logger.log(`Burning ${cliArgs.amount} GDAI...`)
-  await sendTransaction(cli.wallet, gdai, 'burn', ...[amount])
+  await sendTransaction(cli.wallet, gdai, 'burn', [amount])
 }
 
 export const transfer = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -55,7 +55,7 @@ export const transfer = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const gdai = cli.contracts.GDAI
 
   logger.log(`Transferring ${cliArgs.amount} tokens to user ${account}...`)
-  await sendTransaction(cli.wallet, gdai, 'transfer', ...[account, amount])
+  await sendTransaction(cli.wallet, gdai, 'transfer', [account, amount])
 }
 
 export const approve = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -64,7 +64,7 @@ export const approve = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   const gdai = cli.contracts.GDAI
 
   logger.log(`Approving ${cliArgs.amount} GDAI for user ${account} to spend...`)
-  await sendTransaction(cli.wallet, gdai, 'approve', ...[account, amount])
+  await sendTransaction(cli.wallet, gdai, 'approve', [account, amount])
 }
 
 export const gdaiCommand = {

--- a/cli/commands/contracts/serviceRegistry.ts
+++ b/cli/commands/contracts/serviceRegistry.ts
@@ -11,7 +11,7 @@ export const register = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const serviceRegistry = cli.contracts.ServiceRegistry
 
   logger.log(`Registering indexer ${cli.walletAddress} with url ${url} and geoHash ${geoHash}`)
-  await sendTransaction(cli.wallet, serviceRegistry, 'register', ...[url, geoHash])
+  await sendTransaction(cli.wallet, serviceRegistry, 'register', [url, geoHash])
 }
 export const unregister = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const serviceRegistry = cli.contracts.ServiceRegistry

--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -12,7 +12,7 @@ export const stake = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void
   const staking = cli.contracts.Staking
 
   logger.log(`Staking ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, staking, 'stake', ...[amount])
+  await sendTransaction(cli.wallet, staking, 'stake', [amount])
 }
 
 export const unstake = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -20,7 +20,7 @@ export const unstake = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   const staking = cli.contracts.Staking
 
   logger.log(`Unstaking ${cliArgs.amount} tokens...`)
-  await sendTransaction(cli.wallet, staking, 'unstake', ...[amount])
+  await sendTransaction(cli.wallet, staking, 'unstake', [amount])
 }
 
 export const withdraw = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -38,12 +38,12 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const staking = cli.contracts.Staking
 
   logger.log(`Allocating ${cliArgs.amount} tokens on ${subgraphDeploymentID}...`)
-  await sendTransaction(
-    cli.wallet,
-    staking,
-    'allocate',
-    ...[subgraphDeploymentID, amount, allocationID, metadata],
-  )
+  await sendTransaction(cli.wallet, staking, 'allocate', [
+    subgraphDeploymentID,
+    amount,
+    allocationID,
+    metadata,
+  ])
 }
 
 export const closeAllocation = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -51,7 +51,7 @@ export const closeAllocation = async (cli: CLIEnvironment, cliArgs: CLIArgs): Pr
   const staking = cli.contracts.Staking
 
   logger.log(`Closing allocation with allocationID ${allocationID}...`)
-  await sendTransaction(cli.wallet, staking, 'close', ...[allocationID])
+  await sendTransaction(cli.wallet, staking, 'close', [allocationID])
 }
 
 export const collect = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -68,7 +68,7 @@ export const claim = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void
   const staking = cli.contracts.Staking
 
   logger.log(`Claiming on ${channelID} with restake = ${restake}...`)
-  await sendTransaction(cli.wallet, staking, 'claim', ...[channelID, restake])
+  await sendTransaction(cli.wallet, staking, 'claim', [channelID, restake])
 }
 
 export const delegate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -77,7 +77,7 @@ export const delegate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const staking = cli.contracts.Staking
 
   logger.log(`Delegating ${cliArgs.amount} tokens to indexer ${indexer}...`)
-  await sendTransaction(cli.wallet, staking, 'delegate', ...[indexer, amount])
+  await sendTransaction(cli.wallet, staking, 'delegate', [indexer, amount])
 }
 
 export const undelegate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -86,7 +86,7 @@ export const undelegate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise
   const staking = cli.contracts.Staking
 
   logger.log(`Undelegating ${cliArgs.amount} tokens from indexer ${indexer}...`)
-  await sendTransaction(cli.wallet, staking, 'undelegate', ...[indexer, amount])
+  await sendTransaction(cli.wallet, staking, 'undelegate', [indexer, amount])
 }
 
 export const withdrawDelegated = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -99,7 +99,7 @@ export const withdrawDelegated = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   } else {
     logger.log(`Withdrawing from ${indexer} without restaking`)
   }
-  await sendTransaction(cli.wallet, staking, 'withdrawDelegated', ...[indexer, newIndexer])
+  await sendTransaction(cli.wallet, staking, 'withdrawDelegated', [indexer, newIndexer])
 }
 
 export const setDelegationParameters = async (
@@ -116,19 +116,18 @@ export const setDelegationParameters = async (
       queryFeeCut       = ${queryFeeCut}
       cooldownBlocks    = ${cooldownBlocks}
   `)
-  await sendTransaction(
-    cli.wallet,
-    staking,
-    'setDelegationParameters',
-    ...[indexingRewardCut, queryFeeCut, cooldownBlocks],
-  )
+  await sendTransaction(cli.wallet, staking, 'setDelegationParameters', [
+    indexingRewardCut,
+    queryFeeCut,
+    cooldownBlocks,
+  ])
 }
 export const setOperator = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const operator = cliArgs.operator
   const allowed = cliArgs.allowed
   const staking = cli.contracts.Staking
   logger.log(`Setting operator ${operator} to ${allowed} for account ${cli.walletAddress}`)
-  await sendTransaction(cli.wallet, staking, 'setOperator', ...[operator, allowed])
+  await sendTransaction(cli.wallet, staking, 'setOperator', [operator, allowed])
 }
 
 export const stakingCommand = {

--- a/cli/commands/migrate.ts
+++ b/cli/commands/migrate.ts
@@ -3,7 +3,7 @@ import { constants, utils } from 'ethers'
 import yargs, { Argv } from 'yargs'
 
 import { loadCallParams, readConfig, getContractConfig } from '../config'
-import { cliOpts } from '../constants'
+import { cliOpts } from '../defaults'
 import {
   isContractDeployed,
   deployContractAndSave,
@@ -100,7 +100,7 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
           cli.wallet,
           entry.contract,
           call.fn,
-          ...loadCallParams(call.params, cli.addressBook),
+          loadCallParams(call.params, cli.addressBook),
         )
       }
       logger.log('')

--- a/cli/commands/protocol/set.ts
+++ b/cli/commands/protocol/set.ts
@@ -83,7 +83,7 @@ export const setProtocolParam = async (cli: CLIEnvironment, cliArgs: CLIArgs): P
 
   // Send tx
   const contract = getContractAt(fn.contract, addressEntry.address).connect(cli.wallet)
-  await sendTransaction(cli.wallet, contract, fn.name, ...params)
+  await sendTransaction(cli.wallet, contract, fn.name, params)
 }
 
 export const setCommand = {

--- a/cli/commands/proxy/admin.ts
+++ b/cli/commands/proxy/admin.ts
@@ -44,7 +44,7 @@ export const setProxyAdmin = async (cli: CLIEnvironment, cliArgs: CLIArgs): Prom
 
   // Update admin
   const contract = getContractAt('GraphProxy', addressEntry.address).connect(cli.wallet)
-  await sendTransaction(cli.wallet, contract, 'setAdmin', ...[adminAddress])
+  await sendTransaction(cli.wallet, contract, 'setAdmin', [adminAddress])
   consola.success('Done')
 }
 

--- a/cli/commands/proxy/upgrade.ts
+++ b/cli/commands/proxy/upgrade.ts
@@ -59,12 +59,12 @@ export const upgradeProxy = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promi
   // Upgrade to new implementation
   const pendingImplementation = (await proxy.functions['pendingImplementation']())[0]
   if (pendingImplementation != implAddress) {
-    await sendTransaction(cli.wallet, proxy, 'upgradeTo', ...[implAddress])
+    await sendTransaction(cli.wallet, proxy, 'upgradeTo', [implAddress])
   }
 
   // Accept upgrade from the implementation
   const contractArgs = initArgs ? initArgs.split(',') : []
-  await sendTransaction(cli.wallet, contract, 'acceptProxy', ...[proxy.address, ...contractArgs])
+  await sendTransaction(cli.wallet, contract, 'acceptProxy', [proxy.address, ...contractArgs])
 
   // TODO
   // -- update entry

--- a/cli/commands/simulations/curatorSimulation.ts
+++ b/cli/commands/simulations/curatorSimulation.ts
@@ -38,12 +38,12 @@ const createSubgraphs = async (
     logger.log(`  Version Hash: ${versionHashBytes}`)
     logger.log(`  Subgraph Hash: ${subgraphHashBytes}`)
 
-    await sendTransaction(
-      cli.wallet,
-      gns,
-      'publishNewSubgraph',
-      ...[graphAccount, subgraphDeploymentIDBytes, versionHashBytes, subgraphHashBytes],
-    )
+    await sendTransaction(cli.wallet, gns, 'publishNewSubgraph', [
+      graphAccount,
+      subgraphDeploymentIDBytes,
+      versionHashBytes,
+      subgraphHashBytes,
+    ])
   }
 }
 
@@ -62,12 +62,11 @@ const curateOnSubgraphs = async (
 
     logger.log(`Minting nSignal for ${graphAccount}-${firstSubgraphNumber}...`)
     // TODO - this fails on gas estimate, might need to hardcode it in, but this happens for other funcs too
-    await sendTransaction(
-      cli.wallet,
-      gns,
-      'mintNSignal',
-      ...[graphAccount, firstSubgraphNumber, tokens],
-    )
+    await sendTransaction(cli.wallet, gns, 'mintNSignal', [
+      graphAccount,
+      firstSubgraphNumber,
+      tokens,
+    ])
     firstSubgraphNumber++
   }
 }
@@ -79,7 +78,7 @@ const createAndSignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const graphToken = cli.contracts.GraphToken
 
   logger.log(`Approving MAX tokens for user GNS to spend on behalf of ${cli.walletAddress}...`)
-  await sendTransaction(cli.wallet, graphToken, 'approve', ...[gnsAddr, maxUint])
+  await sendTransaction(cli.wallet, graphToken, 'approve', [gnsAddr, maxUint])
 
   const txData = parseCreateSubgraphsCSV(__dirname + cliArgs.path)
   logger.log(`Running createAndSignal for ${txData.length} subgraphs`)
@@ -103,7 +102,7 @@ const unsignal = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> =>
     const account = txData[i].account
     const subgraphNumber = txData[i].subgraphNumber
     logger.log(`Burning ${formatGRT(burnAmount)} nSignal for ${account}-${subgraphNumber}...`)
-    await sendTransaction(cli.wallet, gns, 'burnNSignal', ...[account, subgraphNumber, burnAmount])
+    await sendTransaction(cli.wallet, gns, 'burnNSignal', [account, subgraphNumber, burnAmount])
   }
 }
 export const curatorSimulationCommand = {

--- a/cli/commands/transferTeamTokens.ts
+++ b/cli/commands/transferTeamTokens.ts
@@ -24,7 +24,7 @@ export const transferTeamTokens = async (cli: CLIEnvironment, cliArgs: CLIArgs):
       if (balance.gt(BALANCE_THRESHOLD)) {
         logger.log(`${member.address} over balance`)
       } else {
-        await sendTransaction(cli.wallet, graphToken, 'transfer', ...[member.address, amount])
+        await sendTransaction(cli.wallet, graphToken, 'transfer', [member.address, amount])
       }
     })
   }

--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -1,11 +1,16 @@
 import { Options } from 'yargs'
+import { utils, Overrides } from 'ethers'
 
-export const defaults = {
+export const local = {
   mnemonic: 'myth like bonus scare over problem client lizard pioneer submit female collect',
   providerUrl: 'http://localhost:8545',
   addressBookPath: './addresses.json',
   graphConfigPath: './graph.config.yml',
   accountNumber: '0',
+}
+export const defaultOverrides: Overrides = {
+  // gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  // gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {
@@ -14,35 +19,35 @@ export const cliOpts = {
     description: 'The path to your address book file',
     type: 'string',
     group: 'Config',
-    default: defaults.addressBookPath,
+    default: local.addressBookPath,
   },
   graphConfig: {
     alias: 'graph-config',
     description: 'The path to the config file',
     type: 'string',
     group: 'Config',
-    default: defaults.graphConfigPath,
+    default: local.graphConfigPath,
   },
   providerUrl: {
     alias: 'provider-url',
     description: 'The URL of an Ethereum provider',
     type: 'string',
     group: 'Ethereum',
-    default: defaults.providerUrl,
+    default: local.providerUrl,
   },
   mnemonic: {
     alias: 'mnemonic',
     description: 'The mnemonic for an account which will pay for gas',
     type: 'string',
     group: 'Ethereum',
-    default: defaults.mnemonic,
+    default: local.mnemonic,
   },
   accountNumber: {
     alias: 'account-number',
     description: 'The account number of the mnemonic',
     type: 'string',
     group: 'Ethereum',
-    default: defaults.accountNumber,
+    default: local.accountNumber,
   },
   force: {
     alias: 'force',

--- a/cli/env.ts
+++ b/cli/env.ts
@@ -3,6 +3,7 @@ import { utils, BigNumber, Contract, Wallet } from 'ethers'
 import { Argv } from 'yargs'
 
 import { getAddressBook, AddressBook } from './address-book'
+import { defaultOverrides } from './defaults'
 import { getContractAt } from './network'
 import { getProvider } from './utils'
 
@@ -42,6 +43,14 @@ export const loadContracts = (
   return contracts
 }
 
+export const displayGasOverrides = () => {
+  const r = { gasPrice: 'auto', gasLimit: 'auto', ...defaultOverrides }
+  if (r['gasPrice']) {
+    r['gasPrice'] = r['gasPrice'].toString()
+  }
+  return r
+}
+
 export const loadEnv = async (argv: CLIArgs, wallet?: Wallet): Promise<CLIEnvironment> => {
   if (!wallet) {
     wallet = Wallet.fromMnemonic(argv.mnemonic, `m/44'/60'/0'/0/${argv.accountNumber}`).connect(
@@ -60,6 +69,7 @@ export const loadEnv = async (argv: CLIArgs, wallet?: Wallet): Promise<CLIEnviro
   logger.log(
     `Connected Wallet: address=${walletAddress} nonce=${nonce} balance=${formatEther(balance)}\n`,
   )
+  logger.log('Gas settings:', displayGasOverrides(), '\n')
 
   return {
     balance,

--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import * as dotenv from 'dotenv'
 import consola from 'consola'
 
-import { utils, providers, Wallet, Overrides } from 'ethers'
+import { utils, providers, Wallet } from 'ethers'
 import ipfsHttpClient from 'ipfs-http-client'
 
 import * as bs58 from 'bs58'
@@ -15,14 +15,8 @@ import {
 } from './metadata'
 
 dotenv.config()
-const logger = consola.create({})
 
-export const defaultOverrides = (): Overrides => {
-  return {
-    gasPrice: utils.parseUnits('25', 'gwei'),
-    gasLimit: 2000000,
-  }
-}
+const logger = consola.create({})
 
 export class IPFS {
   static createIpfsClient(node: string): typeof ipfsHttpClient {


### PR DESCRIPTION
### Motivation

Provide a way for the CLI to configure the gas price and gas limit.

### Implements

- Removes the resend of transaction within `network.sendTransaction` when **UNPREDICTABLE_GAS_LIMIT** as this might be a warning that the transaction will fail and it will make the call spend unnecessary gas.
- Adds a parameter to `network.sendTransaction` to pass gas overrides, it is up to the caller to decide if wants to override.
- Change ...params in `network.sendTransaction` to a list to accommodate the overrides object at the end.
- `network.sendTransaction` now uses a global gas override if set in `cli/defaults.ts`. If the object is empty, it will use automatic detection.
- Renames cli/constants.ts to cli/defaults.ts and add an object with for the default gas overrides.
