### PR TITLE
gns: fix issue with initializing a name pool when version signal received is too small

### DIFF
--- a/contracts/discovery/GNSStorage.sol
+++ b/contracts/discovery/GNSStorage.sol
@@ -16,10 +16,6 @@ contract GNSV1Storage is Managed {
     // Bonding curve formula
     address public bondingCurve;
 
-    // Minimum amount of vSignal that must be staked to start the curve
-    // Set to 10**18, as vSignal has 18 decimals
-    uint256 public minimumVSignalStake;
-
     // graphAccountID => subgraphNumber => subgraphDeploymentID
     // subgraphNumber = A number associated to a graph accounts deployed subgraph. This
     //                  is used to point to a subgraphID (graphAccountID + subgraphNumber)

--- a/contracts/discovery/IGNS.sol
+++ b/contracts/discovery/IGNS.sol
@@ -17,8 +17,6 @@ interface IGNS {
 
     function approveAll() external;
 
-    function setMinimumVsignal(uint256 _minimumVSignalStake) external;
-
     function setOwnerFeePercentage(uint32 _ownerFeePercentage) external;
 
     // -- Publishing --


### PR DESCRIPTION
Add a test that make the GNS fail under a combination of factors.

The condition that make the GNS revert when minting signal is:

- 1) Publish NamedSubgraph-0 that targets SubgraphDeploymentID0
- 2) Mint some amount of signal to NamedSubgraph-0
- 3) Publish NamedSubgraph-1 that targets SubgraphDeploymentID0
- 4) Mint a small mount of signal to NamedSubgraph-1

The GNS receives less VSignal than the minimum expected as the SubgraphDeploymentID0 is far ahead in the bonding curve.

@davekaj I reproduced with a test the issue you saw during the week in testnet and left a failing test to fix.

I think that having two bonding curves make things complex because we have:
1) named subgraph bonding curve A connected to subgraph bonding curve 0
2) named subgraph bonding curve B connected to subgraph bonding curve 0

So we can't initialize the named bonding curve as we are doing now, as you can't never rely that vSignal to be a particular value, it is not decided by the user. 
