### PR TITLE
[L15] staking,curation: remove and fix return value in functions

### DIFF
--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -507,11 +507,10 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration {
      * @dev Triggers an update of rewards due to a change in signal.
      * @param _subgraphDeploymentID Subgrapy deployment updated
      */
-    function _updateRewards(bytes32 _subgraphDeploymentID) internal returns (uint256) {
+    function _updateRewards(bytes32 _subgraphDeploymentID) internal {
         IRewardsManager rewardsManager = rewardsManager();
         if (address(rewardsManager) != address(0)) {
-            return rewardsManager.onSubgraphSignalUpdate(_subgraphDeploymentID);
+            rewardsManager.onSubgraphSignalUpdate(_subgraphDeploymentID);
         }
-        return 0;
     }
 }

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -111,11 +111,11 @@ interface IStaking {
 
     // -- Delegation --
 
-    function delegate(address _indexer, uint256 _tokens) external;
+    function delegate(address _indexer, uint256 _tokens) external returns (uint256);
 
-    function undelegate(address _indexer, uint256 _shares) external;
+    function undelegate(address _indexer, uint256 _shares) external returns (uint256);
 
-    function withdrawDelegated(address _indexer, address _newIndexer) external;
+    function withdrawDelegated(address _indexer, address _newIndexer) external returns (uint256);
 
     // -- Channel management and allocations --
 


### PR DESCRIPTION
### Motivation

There were some places in the code base where functions are unnecessarily returning values, even though those values are not being assigned nor being read.

### Implements

Removes unused return values in:
- `_updateRewards()`
- `_distributeRewards()`

Adds return values to `delegate()` and `undelegate()` for easier contract composition.

**Fix: [L15]**
