### PR TITLE
staking: emit delegation parameters updated event on first stake

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -982,6 +982,8 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
             pool.indexingRewardCut = MAX_PPM;
             pool.queryFeeCut = MAX_PPM;
             pool.updatedAtBlock = block.number;
+
+            emit DelegationParametersUpdated(_indexer, pool.indexingRewardCut, pool.queryFeeCut, 0);
         }
 
         emit StakeDeposited(_indexer, _tokens);

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -324,7 +324,10 @@ describe('Staking::Delegation', () => {
         expect(beforeParams.updatedAtBlock).eq(0)
 
         // Indexer stake tokens
-        await staking.connect(indexer.signer).stake(toGRT('200'))
+        const tx = staking.connect(indexer.signer).stake(toGRT('200'))
+        await expect(tx)
+          .emit(staking, 'DelegationParametersUpdated')
+          .withArgs(indexer.address, MAX_PPM, MAX_PPM, 0)
 
         // State updated
         const afterParams = await staking.delegationPools(indexer.address)


### PR DESCRIPTION
### Motivation

The first time an indexer stakes tokens into the protocol the delegation parameters for their pool is initialized to use 100% both indexer rewards cut and query fee cut. However, and event was not emitted like we do when setting the parameters explicitly and it was hard for the Network Subgraph to read the initial values.

### Implements

- Emit `DelegationParametersUpdated` when staking for the first time.