### PR TITLE
staking: add a function to close multiple allocations

### DIFF
--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -30,6 +30,16 @@ interface IStaking {
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
     }
 
+    /**
+     * @dev Represents a request to close an allocation with a specific proof of indexing.
+     * This is passed when calling closeAllocationMany to define the closing parameters for
+     * each allocation.
+     */
+    struct CloseAllocationRequest {
+        address allocationID;
+        bytes32 poi;
+    }
+
     // -- Delegation Data --
 
     /**
@@ -137,6 +147,8 @@ interface IStaking {
     ) external;
 
     function closeAllocation(address _allocationID, bytes32 _poi) external;
+
+    function closeAllocationMany(CloseAllocationRequest[] calldata _requests) external;
 
     function closeAndAllocate(
         address _oldAllocationID,

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -856,6 +856,23 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
     }
 
     /**
+     * @dev Close multiple allocations and free the staked tokens.
+     * To be eligible for rewards a proof of indexing must be presented.
+     * Presenting a bad proof is subject to slashable condition.
+     * To opt out for rewards set _poi to 0x0
+     * @param _requests An array of CloseAllocationRequest
+     */
+    function closeAllocationMany(CloseAllocationRequest[] calldata _requests)
+        external
+        override
+        notPaused
+    {
+        for (uint256 i = 0; i < _requests.length; i++) {
+            _closeAllocation(_requests[i].allocationID, _requests[i].poi);
+        }
+    }
+
+    /**
      * @dev Close and allocate. This will perform a close and then create a new Allocation
      * atomically on the same transaction.
      * @param _closingAllocationID The identifier of the allocation to be closed

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -518,6 +518,32 @@ describe('Staking:Allocation', () => {
       await staking.connect(indexer.signer).setOperator(me.address, true)
       await staking.connect(me.signer).closeAllocation(allocationID, poi)
     })
+
+    it('should close many allocations in batch', async function () {
+      // Setup a second allocation
+      await staking.connect(indexer.signer).stake(tokensToAllocate)
+      const allocationID2 = deriveChannelKey().address
+      await staking
+        .connect(indexer.signer)
+        .allocate(subgraphDeploymentID, tokensToAllocate, allocationID2, metadata)
+
+      // Move at least one epoch to be able to close
+      await advanceToNextEpoch(epochManager)
+      await advanceToNextEpoch(epochManager)
+
+      // Close multiple allocations in one tx
+      const requests = [
+        {
+          allocationID: allocationID,
+          poi: poi,
+        },
+        {
+          allocationID: allocationID2,
+          poi: poi,
+        },
+      ]
+      await staking.connect(indexer.signer).closeAllocationMany(requests)
+    })
   })
 
   describe('closeAndAllocate', function () {


### PR DESCRIPTION
### Motivation

Indexers from time to time close allocations by calling the `closeAllocation()` function. This means that if a particular indexer opened _many_ allocations that need to close in a short span of time, it requires sending multiple transactions and wait them to be mined sequentially. An improvement to that is having a function that can process multiple allocations in a single transaction to speedup the process.

### Implements

- Add a `closeAllocationMany()` that can receive an array of allocationIDs and POIs and close multiple allocations.

**NOTES:** 
- If any of the allocationIDs reverts the whole transaction is reverted.
- Be aware of the block gas limit, there is a reasonable limit on the number of allocations that can be processed in a single transaction.

@Jannis 