### PR TITLE
staking: add a function to claim multiple allocations

### DIFF
--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -152,6 +152,8 @@ interface IStaking {
 
     function claim(address _allocationID, bool _restake) external;
 
+    function claimMany(address[] calldata _allocationID, bool _restake) external;
+
     // -- Getters and calculations --
 
     function hasStake(address _indexer) external view returns (bool);

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -719,6 +719,22 @@ describe('Staking:Allocation', () => {
         expect(afterIndexerStake.tokensStaked).not.eq(beforeIndexerStake.tokensStaked)
       })
 
+      it('should claim many rebates with restake', async function () {
+        // Advance blocks to get the allocation in epoch where it can be claimed
+        await advanceToNextEpoch(epochManager)
+
+        // Before state
+        const beforeIndexerStake = await staking.getIndexerStakedTokens(indexer.address)
+
+        // Claim with restake
+        expect(await staking.getAllocationState(allocationID)).eq(AllocationState.Finalized)
+        await staking.connect(indexer.signer).claimMany([allocationID], true)
+
+        // Verify that the claimed tokens are restaked
+        const afterIndexerStake = await staking.getIndexerStakedTokens(indexer.address)
+        expect(afterIndexerStake).eq(beforeIndexerStake.add(tokensToCollect))
+      })
+
       it('reject claim if already claimed', async function () {
         // Advance blocks to get the allocation finalized
         await advanceToNextEpoch(epochManager)


### PR DESCRIPTION
Indexers from time to time claim allocations by calling the claim() function. This means that if a particular indexer opened many allocations that needs to claim in a short span of time, it requires sending multiple transactions and wait them to be mined sequentially. An improvement to that is having a function that can process multiple claims in a single transaction to speedup the process.

NOTES:

- If any of the allocationIDs reverts the whole transaction is reverted.
- Be aware of the block gas limit, there is a reasonable limit on the number of allocations that can be processed in a single transaction.