### PR TITLE
staking: gas optimization

### DIFF
--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -160,17 +160,16 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration {
 
     /**
      * @dev Assign Graph Tokens collected as curation fees to the curation pool reserve.
+     * This function can only be called by the Staking contract and will do the bookeeping of
+     * transferred tokens into this contract.
      * @param _subgraphDeploymentID SubgraphDeployment where funds should be allocated as reserves
      * @param _tokens Amount of Graph Tokens to add to reserves
      */
-    function collect(bytes32 _subgraphDeploymentID, uint256 _tokens) external override onlyStaking {
-        // Transfer tokens collected from the staking contract to this contract
-        require(
-            graphToken().transferFrom(address(staking()), address(this), _tokens),
-            "Cannot transfer tokens to collect"
-        );
+    function collect(bytes32 _subgraphDeploymentID, uint256 _tokens) external override {
+        // Only Staking contract is authorized as caller
+        require(msg.sender == address(staking()), "Caller must be the staking contract");
 
-        // Collect tokens and assign them to the reserves
+        // Must be curated to accept tokens
         require(
             isCurated(_subgraphDeploymentID),
             "Subgraph deployment must be curated to collect fees"

--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -163,7 +163,7 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
     /**
      * @dev Approve curation contract to pull funds.
      */
-    function approveAll() external override onlyGovernor {
+    function approveAll() external override {
         graphToken().approve(address(curation()), MAX_UINT256);
     }
 

--- a/contracts/governance/Managed.sol
+++ b/contracts/governance/Managed.sol
@@ -57,16 +57,6 @@ contract Managed {
         _;
     }
 
-    modifier onlyStaking() {
-        require(msg.sender == address(staking()), "Caller must be the staking contract");
-        _;
-    }
-
-    modifier onlyCuration() {
-        require(msg.sender == address(curation()), "Caller must be the curation contract");
-        _;
-    }
-
     /**
      * @dev Initialize the controller
      */

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -346,13 +346,17 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
 
     /**
      * @dev Pull rewards from the contract for a particular allocation.
-     * This function will mint the necessary tokens to reward based on the inflation calculation
+     * This function can only be called by the Staking contract.
+     * This function will mint the necessary tokens to reward based on the inflation calculation.
      * @param _allocationID Allocation
      * @return Assigned rewards amount
      */
-    function takeRewards(address _allocationID) external override onlyStaking returns (uint256) {
-        IGraphToken graphToken = graphToken();
+    function takeRewards(address _allocationID) external override returns (uint256) {
+        // Only Staking contract is authorized as caller
         IStaking staking = staking();
+        require(msg.sender == address(staking), "Caller must be the staking contract");
+
+        IGraphToken graphToken = graphToken();
         IStaking.Allocation memory alloc = staking.getAllocation(_allocationID);
 
         uint256 accRewardsPerAllocatedToken = onSubgraphAllocationUpdate(

--- a/scripts/build
+++ b/scripts/build
@@ -3,9 +3,9 @@
 set -eo pipefail
 
 # Allow these interfaces to be used from 0.6.x and 0.7.x contracts
-sed -i 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/math/SafeMath.sol
-sed -i 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol
-sed -i 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/cryptography/ECDSA.sol
+sed -i='' 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/math/SafeMath.sol
+sed -i='' 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol
+sed -i='' 's/pragma solidity ^0.7.0/pragma solidity >=0.6.0 <0.8.0/g' node_modules/@openzeppelin/contracts/cryptography/ECDSA.sol
 
 # Compile AttestationApp along with the rest of the contracts
 cp node_modules/@graphprotocol/statechannels/contracts/Attestation*.sol contracts/statechannels

--- a/scripts/test
+++ b/scripts/test
@@ -37,7 +37,7 @@ fi
 
 mkdir -p reports
 
-npm run compile
+npm run build
 
 if [ "$RUN_EVM" = true ]; then
   # Run using the standalone evm instance

--- a/test/curation/curation.test.ts
+++ b/test/curation/curation.test.ts
@@ -171,6 +171,7 @@ describe('Curation', () => {
     const beforeTotalBalance = await grt.balanceOf(curation.address)
 
     // Source of tokens must be the staking for this to work
+    await grt.connect(stakingMock.signer).transfer(curation.address, tokensToCollect)
     const tx = curation.connect(stakingMock.signer).collect(subgraphDeploymentID, tokensToCollect)
     await expect(tx).emit(curation, 'Collected').withArgs(subgraphDeploymentID, tokensToCollect)
 

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -657,7 +657,6 @@ describe('Staking:Allocation', () => {
       // After state
       const afterBalance = await grt.balanceOf(indexer.address)
       const afterStake = await staking.stakes(indexer.address)
-      const afterAlloc = await staking.allocations(allocationID)
       const afterRebatePool = await staking.rebates(beforeAlloc.closedAtEpoch)
 
       // Funds distributed to indexer
@@ -672,12 +671,6 @@ describe('Staking:Allocation', () => {
       } else {
         expect(afterStake.tokensStaked).eq(beforeStake.tokensStaked)
       }
-      // Allocation updated (purged)
-      expect(afterAlloc.tokens).eq(toGRT('0'))
-      expect(afterAlloc.createdAtEpoch).eq(toGRT('0'))
-      expect(afterAlloc.closedAtEpoch).eq(toGRT('0'))
-      expect(afterAlloc.collectedFees).eq(toGRT('0'))
-      expect(afterAlloc.effectiveAllocation).eq(toGRT('0'))
       // Rebate updated
       expect(afterRebatePool.unclaimedAllocationsCount).eq(
         beforeRebatePool.unclaimedAllocationsCount - 1,


### PR DESCRIPTION
**Staking.Collect():**
- Merge _collect() and collect() to avoid multiple STATICCALL/SLOAD graphToken()
- Pass graphToken in burnTokens function to avoid multiple STATICCALL/SLOAD
- Change Curation.collect() to work as a "transferAndCall" instead of pulling tokens
- Remove unused onlyCuration() modifier from Managed
- Remove onlyStaking() modifier and use within the respective function to avoid reading staking() multiple times

Reduce the gas cost of calling Staking.collect() about 20%

**Staking._getAllocationState():**
- Use storage instead of memory to avoid SLOAD all the attributes that could not be used. This is a very frequently used function.

**Staking.Claim():**
- Remove setting Allocation struct variables to zero as as the struct is not completely cleaned the refund is not happening. By removing the SSTORE we avoid spending about 20000 gas.

**RewardsManager.takeRewards():**
- Avoid reading STATICCALL/SLOAD staking() multiple times in takeRewards()
