### PR TITLE
[M12] misc: add input validation

### DIFF
--- a/contracts/curation/Curation.sol
+++ b/contracts/curation/Curation.sol
@@ -75,6 +75,8 @@ contract Curation is CurationV1Storage, GraphUpgradeable, ICuration {
         uint256 _minimumCurationDeposit
     ) external onlyImpl {
         Managed._initialize(_controller);
+
+        require(_bondingCurve != address(0), "Bonding curve must be set");
         bondingCurve = _bondingCurve;
 
         // Settings

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -215,6 +215,7 @@ contract DisputeManager is Managed, IDisputeManager {
      * @param _arbitrator The address of the arbitration contract or party
      */
     function _setArbitrator(address _arbitrator) private {
+        require(_arbitrator != address(0), "Arbitrator must be set");
         arbitrator = _arbitrator;
         emit ParameterUpdated("arbitrator");
     }
@@ -234,6 +235,7 @@ contract DisputeManager is Managed, IDisputeManager {
      * @param _minimumDeposit The minimum deposit in Graph Tokens
      */
     function _setMinimumDeposit(uint256 _minimumDeposit) private {
+        require(_minimumDeposit > 0, "Minimum deposit must be set");
         minimumDeposit = _minimumDeposit;
         emit ParameterUpdated("minimumDeposit");
     }

--- a/contracts/governance/Controller.sol
+++ b/contracts/governance/Controller.sol
@@ -57,8 +57,22 @@ contract Controller is Governed, Pausable, IController {
         override
         onlyGovernor
     {
+        require(_contractAddress != address(0), "Contract address must be set");
         registry[_id] = _contractAddress;
         emit SetContractProxy(_id, _contractAddress);
+    }
+
+    /**
+     * @notice Unregister a contract address
+     * @param _id Contract id (keccak256 hash of contract name)
+     */
+    function unsetContractProxy(bytes32 _id)
+        external
+        override
+        onlyGovernor
+    {
+        registry[_id] = address(0);
+        emit SetContractProxy(_id, address(0));
     }
 
     /**
@@ -75,6 +89,7 @@ contract Controller is Governed, Pausable, IController {
      * @param _controller Controller address
      */
     function updateController(bytes32 _id, address _controller) external override onlyGovernor {
+        require(_controller != address(0), "Controller must be set");
         return IManaged(registry[_id]).setController(_controller);
     }
 
@@ -101,6 +116,7 @@ contract Controller is Governed, Pausable, IController {
      * @param _newPauseGuardian The address of the new Pause Guardian
      */
     function setPauseGuardian(address _newPauseGuardian) external override onlyGovernor {
+        require(_newPauseGuardian != address(0), "PauseGuardian must be set");
         _setPauseGuardian(_newPauseGuardian);
     }
 

--- a/contracts/governance/Governed.sol
+++ b/contracts/governance/Governed.sol
@@ -38,6 +38,8 @@ contract Governed {
      * @param _newGovernor Address of new `governor`
      */
     function transferOwnership(address _newGovernor) external onlyGovernor {
+        require(_newGovernor != address(0), "Governor must be set");
+
         address oldPendingGovernor = pendingGovernor;
         pendingGovernor = _newGovernor;
 

--- a/contracts/governance/IController.sol
+++ b/contracts/governance/IController.sol
@@ -9,6 +9,8 @@ interface IController {
 
     function setContractProxy(bytes32 _id, address _contractAddress) external;
 
+    function unsetContractProxy(bytes32 _id) external;
+
     function updateController(bytes32 _id, address _controller) external;
 
     function getContractProxy(bytes32 _id) external view returns (address);

--- a/contracts/governance/Managed.sol
+++ b/contracts/governance/Managed.sol
@@ -71,7 +71,7 @@ contract Managed {
      * @dev Initialize the controller
      */
     function _initialize(address _controller) internal {
-        controller = IController(_controller);
+        _setController(_controller);
     }
 
     /**
@@ -79,6 +79,15 @@ contract Managed {
      * @param _controller Controller contract address
      */
     function setController(address _controller) external onlyController {
+        _setController(_controller);
+    }
+
+    /**
+     * @dev Set controller.
+     * @param _controller Controller contract address
+     */
+    function _setController(address _controller) internal {
+        require(_controller != address(0), "Controller must be set");
         controller = IController(_controller);
         emit SetController(_controller);
     }

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -243,6 +243,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _minimumIndexerStake Minimum indexer stake
      */
     function _setMinimumIndexerStake(uint256 _minimumIndexerStake) private {
+        require(_minimumIndexerStake > 0, "!minimumIndexerStake");
         minimumIndexerStake = _minimumIndexerStake;
         emit ParameterUpdated("minimumIndexerStake");
     }
@@ -260,6 +261,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _thawingPeriod Period in blocks to wait for token withdrawals after unstaking
      */
     function _setThawingPeriod(uint32 _thawingPeriod) private {
+        require(_thawingPeriod > 0, "!thawingPeriod");
         thawingPeriod = _thawingPeriod;
         emit ParameterUpdated("thawingPeriod");
     }
@@ -315,6 +317,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _channelDisputeEpochs Period in epochs
      */
     function _setChannelDisputeEpochs(uint32 _channelDisputeEpochs) private {
+        require(_channelDisputeEpochs > 0, "!channelDisputeEpochs");
         channelDisputeEpochs = _channelDisputeEpochs;
         emit ParameterUpdated("channelDisputeEpochs");
     }
@@ -458,6 +461,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
      * @param _delegationUnbondingPeriod Period in epochs to wait for token withdrawals after undelegating
      */
     function _setDelegationUnbondingPeriod(uint32 _delegationUnbondingPeriod) private {
+        require(_delegationUnbondingPeriod > 0, "!delegationUnbondingPeriod");
         delegationUnbondingPeriod = _delegationUnbondingPeriod;
         emit ParameterUpdated("delegationUnbondingPeriod");
     }

--- a/test/disputes/configuration.test.ts
+++ b/test/disputes/configuration.test.ts
@@ -1,3 +1,4 @@
+import { constants } from 'ethers'
 import { expect } from 'chai'
 
 import { DisputeManager } from '../../build/typechain/contracts/DisputeManager'
@@ -5,6 +6,8 @@ import { DisputeManager } from '../../build/typechain/contracts/DisputeManager'
 import { defaults } from '../lib/deployment'
 import { NetworkFixture } from '../lib/fixtures'
 import { getAccounts, toBN, Account } from '../lib/testHelpers'
+
+const { AddressZero } = constants
 
 const MAX_PPM = 1000000
 
@@ -47,6 +50,11 @@ describe('DisputeManager:Config', () => {
       it('reject set `arbitrator` if not allowed', async function () {
         const tx = disputeManager.connect(me.signer).setArbitrator(arbitrator.address)
         await expect(tx).revertedWith('Caller must be Controller governor')
+      })
+
+      it('reject set `arbitrator` to address zero', async function () {
+        const tx = disputeManager.connect(governor.signer).setArbitrator(AddressZero)
+        await expect(tx).revertedWith('Arbitrator must be set')
       })
     })
 

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -8,6 +8,7 @@ import { Staking } from '../../build/typechain/contracts/Staking'
 
 import { NetworkFixture } from '../lib/fixtures'
 import {
+  advanceBlock,
   advanceToNextEpoch,
   deriveChannelKey,
   getAccounts,
@@ -120,8 +121,8 @@ describe('DisputeManager:POI', async () => {
       await grt.connect(governor.signer).mint(assetHolder.address, indexerCollectedTokens)
       await grt.connect(assetHolder.signer).approve(staking.address, indexerCollectedTokens)
 
-      // Set the thawing period to zero to make the test easier
-      await staking.connect(governor.signer).setThawingPeriod(toBN('0'))
+      // Set the thawing period to one to make the test easier
+      await staking.connect(governor.signer).setThawingPeriod(toBN('1'))
 
       // Indexer stake funds, allocate, close, unstake and withdraw the stake fully
       await staking.connect(indexer.signer).stake(indexerTokens)
@@ -134,7 +135,8 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
       await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
       await staking.connect(indexer.signer).unstake(indexerTokens)
-      await staking.connect(indexer.signer).withdraw() // no thawing period so we are good
+      await advanceBlock() // pass thawing period
+      await staking.connect(indexer.signer).withdraw()
 
       // Create dispute
       const tx = disputeManager

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -9,6 +9,7 @@ import { Staking } from '../../build/typechain/contracts/Staking'
 
 import { NetworkFixture } from '../lib/fixtures'
 import {
+  advanceBlock,
   advanceToNextEpoch,
   deriveChannelKey,
   getAccounts,
@@ -218,7 +219,7 @@ describe('DisputeManager:Query', async () => {
       await grt.connect(assetHolder.signer).approve(staking.address, indexerCollectedTokens)
 
       // Set the thawing period to zero to make the test easier
-      await staking.connect(governor.signer).setThawingPeriod(toBN('0'))
+      await staking.connect(governor.signer).setThawingPeriod(toBN('1'))
 
       // Indexer stake funds, allocate, close allocation, unstake and withdraw the stake fully
       await staking.connect(indexer.signer).stake(indexerTokens)
@@ -236,7 +237,8 @@ describe('DisputeManager:Query', async () => {
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
       await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
       await staking.connect(indexer.signer).unstake(indexerTokens)
-      await staking.connect(indexer.signer).withdraw() // no thawing period so we are good
+      await advanceBlock() // pass thawing period
+      await staking.connect(indexer.signer).withdraw()
 
       // Create dispute
       const tx = disputeManager

--- a/test/governance/controller.test.ts
+++ b/test/governance/controller.test.ts
@@ -1,11 +1,13 @@
 import { expect } from 'chai'
-import { utils } from 'ethers'
+import { constants, utils } from 'ethers'
 
 import { Controller } from '../../build/typechain/contracts/Controller'
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
 
 import { getAccounts, Account } from '../lib/testHelpers'
 import { NetworkFixture } from '../lib/fixtures'
+
+const { AddressZero } = constants
 
 describe('Managed', () => {
   let me: Account
@@ -34,37 +36,103 @@ describe('Managed', () => {
   afterEach(async function () {
     await fixture.tearDown()
   })
-  it('should set contract proxy and test get contract proxy', async function () {
-    // Set right in the constructor
-    expect(await epochManager.controller()).eq(controller.address)
 
-    // Test the controller
-    const id = utils.id('EpochManager')
-    const tx = controller.connect(governor.signer).setContractProxy(id, newMockEpochManager.address)
-    await expect(tx).emit(controller, 'SetContractProxy').withArgs(id, newMockEpochManager.address)
-    expect(await controller.getContractProxy(id)).eq(newMockEpochManager.address)
+  describe('setContractProxy()', function () {
+    it('should set contract proxy and test get contract proxy', async function () {
+      // Set right in the constructor
+      expect(await epochManager.controller()).eq(controller.address)
+
+      // Test the controller
+      const id = utils.id('EpochManager')
+      const tx = controller
+        .connect(governor.signer)
+        .setContractProxy(id, newMockEpochManager.address)
+      await expect(tx)
+        .emit(controller, 'SetContractProxy')
+        .withArgs(id, newMockEpochManager.address)
+      expect(await controller.getContractProxy(id)).eq(newMockEpochManager.address)
+    })
+
+    it('reject set contract proxy to address zero', async function () {
+      const id = utils.id('EpochManager')
+      const tx = controller.connect(governor.signer).setContractProxy(id, AddressZero)
+      await expect(tx).revertedWith('Contract address must be set')
+    })
+
+    it('reject set contract proxy if not governor', async function () {
+      const id = utils.id('EpochManager')
+      const tx = controller.connect(me.signer).setContractProxy(id, newMockEpochManager.address)
+      await expect(tx).revertedWith('Only Governor can call')
+    })
   })
-  it('should fail to set contract proxy if not governor', async function () {
-    // Test the controller
-    const id = utils.id('EpochManager')
-    const tx = controller.connect(me.signer).setContractProxy(id, newMockEpochManager.address)
-    await expect(tx).revertedWith('Only Governor can call')
+
+  describe('unsetContractProxy()', function () {
+    it('should unset contract proxy', async function () {
+      // Set contract
+      const id = utils.id('EpochManager')
+      await controller.connect(governor.signer).setContractProxy(id, newMockEpochManager.address)
+      expect(await controller.getContractProxy(id)).eq(newMockEpochManager.address)
+
+      // Unset contract
+      const tx = controller.connect(governor.signer).unsetContractProxy(id)
+      await expect(tx).emit(controller, 'SetContractProxy').withArgs(id, AddressZero)
+      expect(await controller.getContractProxy(id)).eq(AddressZero)
+    })
+
+    it('reject to call if not authorized caller', async function () {
+      // Unset contract
+      const id = utils.id('EpochManager')
+      const tx = controller.connect(me.signer).unsetContractProxy(id)
+      await expect(tx).revertedWith('Only Governor can call')
+    })
   })
-  it('should update controller on a manager', async function () {
-    const tx = controller
-      .connect(governor.signer)
-      .updateController(utils.id('EpochManager'), mockController.address)
-    await expect(tx).emit(epochManager, 'SetController').withArgs(mockController.address)
-    expect(await epochManager.controller()).eq(mockController.address)
+
+  describe('updateController()', function () {
+    it('should update controller on a manager', async function () {
+      const tx = controller
+        .connect(governor.signer)
+        .updateController(utils.id('EpochManager'), mockController.address)
+      await expect(tx).emit(epochManager, 'SetController').withArgs(mockController.address)
+      expect(await epochManager.controller()).eq(mockController.address)
+    })
+
+    it('should fail updating controller when not called by governor', async function () {
+      const tx = controller
+        .connect(me.signer)
+        .updateController(utils.id('EpochManager'), mockController.address)
+      await expect(tx).revertedWith('Only Governor can call')
+    })
+
+    it('reject update controller to address zero', async function () {
+      const tx = controller
+        .connect(governor.signer)
+        .updateController(utils.id('EpochManager'), AddressZero)
+      await expect(tx).revertedWith('Controller must be set')
+    })
   })
-  it('should fail updating controller when not called by governor', async function () {
-    const tx = controller
-      .connect(me.signer)
-      .updateController(utils.id('EpochManager'), mockController.address)
-    await expect(tx).revertedWith('Only Governor can call')
+
+  describe('setController()', function () {
+    it('should fail setting controller when not called from Controller', async function () {
+      const tx = epochManager.connect(me.signer).setController(mockController.address)
+      await expect(tx).revertedWith('Caller must be Controller')
+    })
   })
-  it('should fail setting controller when not called from Controller', async function () {
-    const tx = epochManager.connect(me.signer).setController(mockController.address)
-    await expect(tx).revertedWith('Caller must be Controller')
+
+  describe('setPauseGuardian()', function () {
+    it('should set the pause guardian', async function () {
+      const tx = controller.connect(governor.signer).setPauseGuardian(me.address)
+      await expect(tx).emit(controller, 'NewPauseGuardian').withArgs(AddressZero, me.address)
+      expect(await controller.pauseGuardian()).eq(me.address)
+    })
+
+    it('reject to call if not authorized caller', async function () {
+      const tx = controller.connect(me.signer).setPauseGuardian(me.address)
+      await expect(tx).revertedWith('Only Governor can call')
+    })
+
+    it('reject set pause guardian to address zero', async function () {
+      const tx = controller.connect(governor.signer).setPauseGuardian(AddressZero)
+      await expect(tx).revertedWith('PauseGuardian must be set')
+    })
   })
 })

--- a/test/staking/configuration.test.ts
+++ b/test/staking/configuration.test.ts
@@ -54,6 +54,11 @@ describe('Staking:Config', () => {
       const tx = staking.connect(me.signer).setMinimumIndexerStake(newValue)
       await expect(tx).revertedWith('Caller must be Controller governor')
     })
+
+    it('reject set `minimumIndexerStake` to zero', async function () {
+      const tx = staking.connect(governor.signer).setMinimumIndexerStake(0)
+      await expect(tx).revertedWith('!minimumIndexerStake')
+    })
   })
 
   describe('setSlasher', function () {
@@ -101,7 +106,7 @@ describe('Staking:Config', () => {
       await expect(tx).revertedWith('Caller must be Controller governor')
     })
 
-    it('reject set `assetHolder` for zero', async function () {
+    it('reject set `assetHolder` to address zero', async function () {
       const tx = staking.connect(governor.signer).setAssetHolder(AddressZero, true)
       await expect(tx).revertedWith('!assetHolder')
     })
@@ -118,6 +123,11 @@ describe('Staking:Config', () => {
       const newValue = toBN('5')
       const tx = staking.connect(other.signer).setChannelDisputeEpochs(newValue)
       await expect(tx).revertedWith('Caller must be Controller governor')
+    })
+
+    it('reject set `channelDisputeEpochs` to zero', async function () {
+      const tx = staking.connect(governor.signer).setChannelDisputeEpochs(0)
+      await expect(tx).revertedWith('!channelDisputeEpochs')
     })
   })
 
@@ -185,6 +195,11 @@ describe('Staking:Config', () => {
       const newValue = toBN('5')
       const tx = staking.connect(other.signer).setThawingPeriod(newValue)
       await expect(tx).revertedWith('Caller must be Controller governor')
+    })
+
+    it('reject set `thawingPeriod` to zero', async function () {
+      const tx = staking.connect(governor.signer).setThawingPeriod(0)
+      await expect(tx).revertedWith('!thawingPeriod')
     })
   })
 


### PR DESCRIPTION
### Motivation

Throughout the code base, there are multiple situations where the input function’s value is not checked before being used.

### Implements

Add validation for the cases where it is obvious that sending an empty value constitutes an error when crafting the transaction.

#### Functions with added input validation:
```
- Controller.updateController()
- Controller.setContractProxy()
- Controller.setPauseGuardian()

- Managed.setController()

- Governed.transferOwnership()

- DisputeManager.setArbitrator()

- Staking.setMinimumIndexerStake()
- Staking.setThawingPeriod()
- Staking.setChannelDisputeEpochs()
- Staking.setDelegationUnbondingPeriod()
```

#### Functions that are allowed to set zero values to disable the feature:
```
- Staking.setCurationPercentage()
- Staking.setProtocolPercentage()
- Staking.setDelegationRatio()
- Staking.setDelegationParametersCooldown()
```