### PR TITLE
[L01] staking: when allocating require indexer a proof of owning the AllocationID

### DIFF
--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -137,7 +137,8 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        bytes32 _metadata
+        bytes32 _metadata,
+        bytes calldata _proof
     ) external;
 
     function allocateFrom(
@@ -145,7 +146,8 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        bytes32 _metadata
+        bytes32 _metadata,
+        bytes calldata _proof
     ) external;
 
     function closeAllocation(address _allocationID, bytes32 _poi) external;
@@ -159,7 +161,8 @@ interface IStaking {
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,
         address _allocationID,
-        bytes32 _metadata
+        bytes32 _metadata,
+        bytes calldata _proof
     ) external;
 
     function collect(uint256 _tokens, address _allocationID) external;

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -52,20 +52,27 @@ describe('DisputeManager:POI', async () => {
     await staking.connect(governor.signer).setSlasher(disputeManager.address, true)
 
     // Stake & allocate
-    const indexerList = [{ wallet: indexer, allocationID: indexerChannelKey.address }]
+    const indexerList = [
+      { account: indexer, allocationID: indexerChannelKey.address, channelKey: indexerChannelKey },
+    ]
     for (const activeIndexer of indexerList) {
-      const indexerWallet = activeIndexer.wallet
-      const indexerAllocationID = activeIndexer.allocationID
+      const { channelKey, allocationID, account: indexerAccount } = activeIndexer
 
       // Give some funds to the indexer
-      await grt.connect(governor.signer).mint(indexerWallet.address, indexerTokens)
-      await grt.connect(indexerWallet.signer).approve(staking.address, indexerTokens)
+      await grt.connect(governor.signer).mint(indexerAccount.address, indexerTokens)
+      await grt.connect(indexerAccount.signer).approve(staking.address, indexerTokens)
 
       // Indexer stake funds
-      await staking.connect(indexerWallet.signer).stake(indexerTokens)
+      await staking.connect(indexerAccount.signer).stake(indexerTokens)
       await staking
-        .connect(indexerWallet.signer)
-        .allocate(subgraphDeploymentID, indexerAllocatedTokens, indexerAllocationID, metadata)
+        .connect(indexerAccount.signer)
+        .allocate(
+          subgraphDeploymentID,
+          indexerAllocatedTokens,
+          allocationID,
+          metadata,
+          await channelKey.generateProof(indexerAccount.address),
+        )
     }
   }
 
@@ -127,7 +134,13 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
-        .allocate(subgraphDeploymentID, indexerAllocatedTokens, allocationID, metadata)
+        .allocate(
+          subgraphDeploymentID,
+          indexerAllocatedTokens,
+          allocationID,
+          metadata,
+          await indexerChannelKey.generateProof(indexer.address),
+        )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
       await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -120,26 +120,34 @@ describe('DisputeManager:Query', async () => {
 
     // Stake
     const indexerList = [
-      { wallet: indexer, allocationID: indexer1ChannelKey.address },
-      { wallet: indexer2, allocationID: indexer2ChannelKey.address },
+      {
+        account: indexer,
+        allocationID: indexer1ChannelKey.address,
+        channelKey: indexer1ChannelKey,
+      },
+      {
+        account: indexer2,
+        allocationID: indexer2ChannelKey.address,
+        channelKey: indexer2ChannelKey,
+      },
     ]
     for (const activeIndexer of indexerList) {
-      const indexerWallet = activeIndexer.wallet
-      const indexerAllocationID = activeIndexer.allocationID
+      const { channelKey, allocationID, account: indexerAccount } = activeIndexer
 
       // Give some funds to the indexer
-      await grt.connect(governor.signer).mint(indexerWallet.address, indexerTokens)
-      await grt.connect(indexerWallet.signer).approve(staking.address, indexerTokens)
+      await grt.connect(governor.signer).mint(indexerAccount.address, indexerTokens)
+      await grt.connect(indexerAccount.signer).approve(staking.address, indexerTokens)
 
       // Indexer stake funds
-      await staking.connect(indexerWallet.signer).stake(indexerTokens)
+      await staking.connect(indexerAccount.signer).stake(indexerTokens)
       await staking
-        .connect(indexerWallet.signer)
+        .connect(indexerAccount.signer)
         .allocate(
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
-          indexerAllocationID,
+          allocationID,
           metadata,
+          await channelKey.generateProof(indexerAccount.address),
         )
     }
   }
@@ -229,6 +237,7 @@ describe('DisputeManager:Query', async () => {
           indexerAllocatedTokens,
           indexer1ChannelKey.address,
           metadata,
+          await indexer1ChannelKey.generateProof(indexer.address),
         )
       const receipt1 = await tx1.wait()
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -95,9 +95,24 @@ interface ChannelKey {
   privKey: string
   pubKey: string
   address: string
+  wallet: Signer
+  generateProof: (address) => Promise<string>
 }
 
 export const deriveChannelKey = (): ChannelKey => {
   const w = Wallet.createRandom()
-  return { privKey: w.privateKey, pubKey: w.publicKey, address: utils.computeAddress(w.publicKey) }
+  return {
+    privKey: w.privateKey,
+    pubKey: w.publicKey,
+    address: w.address,
+    wallet: w,
+    generateProof: (indexerAddress: string): Promise<string> => {
+      const messageHash = utils.solidityKeccak256(
+        ['address', 'address'],
+        [indexerAddress, w.address],
+      )
+      const messageHashBytes = utils.arrayify(messageHash)
+      return w.signMessage(messageHashBytes)
+    },
+  }
 }

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -14,6 +14,7 @@ import { Staking } from '../../build/typechain/contracts/Staking'
 
 import {
   advanceBlocks,
+  deriveChannelKey,
   getAccounts,
   randomHexBytes,
   latestBlock,
@@ -48,9 +49,13 @@ describe('Rewards', () => {
   let rewardsManager: RewardsManager
   let rewardsManagerMock: RewardsManagerMock
 
+  // Derive some channel keys for each indexer used to sign attestations
+  const channelKey = deriveChannelKey()
+
   const subgraphDeploymentID1 = randomHexBytes()
   const subgraphDeploymentID2 = randomHexBytes()
-  const allocationID = '0x6367E9dD7641e0fF221740b57B8C730031d72530'
+
+  const allocationID = channelKey.address
   const metadata = HashZero
 
   const ISSUANCE_RATE_PERIODS = 4 // blocks required to issue 5% rewards
@@ -386,7 +391,13 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
+          .allocate(
+            subgraphDeploymentID1,
+            tokensToAllocate,
+            allocationID,
+            metadata,
+            await channelKey.generateProof(indexer1.address),
+          )
 
         // Jump
         await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -417,7 +428,13 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
+          .allocate(
+            subgraphDeploymentID1,
+            tokensToAllocate,
+            allocationID,
+            metadata,
+            await channelKey.generateProof(indexer1.address),
+          )
 
         // Jump
         await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -454,7 +471,13 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
+          .allocate(
+            subgraphDeploymentID1,
+            tokensToAllocate,
+            allocationID,
+            metadata,
+            await channelKey.generateProof(indexer1.address),
+          )
 
         // Jump
         await advanceBlocks(ISSUANCE_RATE_PERIODS)
@@ -493,7 +516,13 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
+          .allocate(
+            subgraphDeploymentID1,
+            tokensToAllocate,
+            allocationID,
+            metadata,
+            await channelKey.generateProof(indexer1.address),
+          )
       }
 
       async function setupIndexerAllocationWithDelegation(
@@ -529,7 +558,13 @@ describe('Rewards', () => {
         // Allocate
         await staking
           .connect(indexer1.signer)
-          .allocate(subgraphDeploymentID1, tokensToAllocate, allocationID, metadata)
+          .allocate(
+            subgraphDeploymentID1,
+            tokensToAllocate,
+            allocationID,
+            metadata,
+            await channelKey.generateProof(indexer1.address),
+          )
       }
 
       it('should distribute rewards on closed allocation', async function () {

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -506,7 +506,13 @@ describe('Staking::Delegation', () => {
     const setupAllocation = async (tokens: BigNumber) => {
       return staking
         .connect(indexer.signer)
-        .allocate(subgraphDeploymentID, tokens, allocationID, metadata)
+        .allocate(
+          subgraphDeploymentID,
+          tokens,
+          allocationID,
+          metadata,
+          await channelKey.generateProof(indexer.address),
+        )
     }
 
     beforeEach(async function () {

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -49,10 +49,16 @@ describe('Staking:Stakes', () => {
   const metadata = randomHexBytes(32)
 
   // Allocate with test values
-  const allocate = function (tokens: BigNumber) {
+  const allocate = async (tokens: BigNumber) => {
     return staking
       .connect(indexer.signer)
-      .allocate(subgraphDeploymentID, tokens, allocationID, metadata)
+      .allocate(
+        subgraphDeploymentID,
+        tokens,
+        allocationID,
+        metadata,
+        await channelKey.generateProof(indexer.address),
+      )
   }
 
   // Stake and verify state change


### PR DESCRIPTION
### Motivation

The allocate function of the Staking contract makes use of the internal _allocate function to create a new allocation, which will be saved in the allocations mapping under the allocationID key.

The allocationID is an address generated by the indexer from a key pair and published when calling allocate(). The issue is that this value must be unique and allocate() enforces its uniqueness. This can be used by malicious indexers to front-run others allocation creations, setting themselves as an indexer for that particular allocationID.

### Implements

To avoid this situation and indexer needs to present a proof with the form of a message hash signed by the private key that correspond to the AllocationID address.

```
messageHash = keccak256(indexerAddress,allocationID)
ethSignedMessage = eth_signed_message(messageHash)
proof = privKey.sign(ethSignedMessage)
```

**BREAKING CHANGE**

- Adds a `bytes calldata _proof` parameter to `allocate()` and `allocateFrom()`

@Jannis 

**Fix: [L01]**