### PR TITLE
[L11] misc: fix lack of indexed parameters in some events

### DIFF
--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -32,7 +32,7 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * @dev Emitted when graph account sets their default name
      */
     event SetDefaultName(
-        address graphAccount,
+        address indexed graphAccount,
         uint256 nameSystem, // only ENS for now
         bytes32 nameIdentifier,
         string name
@@ -42,8 +42,8 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * @dev Emitted when graph account sets a subgraphs metadata on IPFS
      */
     event SubgraphMetadataUpdated(
-        address graphAccount,
-        uint256 subgraphNumber,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
         bytes32 subgraphMetadata
     );
 
@@ -53,25 +53,25 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * The event also emits a `metadataHash` with subgraph details and version details.
      */
     event SubgraphPublished(
-        address graphAccount,
-        uint256 subgraphNumber,
-        bytes32 subgraphDeploymentID,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        bytes32 indexed subgraphDeploymentID,
         bytes32 versionMetadata
     );
 
     /**
      * @dev Emitted when a graph account deprecated one of their subgraphs
      */
-    event SubgraphDeprecated(address graphAccount, uint256 subgraphNumber);
+    event SubgraphDeprecated(address indexed graphAccount, uint256 indexed subgraphNumber);
 
     /**
      * @dev Emitted when a graphAccount creates an nSignal bonding curve that
      * points to a subgraph deployment
      */
     event NameSignalEnabled(
-        address graphAccount,
-        uint256 subgraphNumber,
-        bytes32 subgraphDeploymentID,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        bytes32 indexed subgraphDeploymentID,
         uint32 reserveRatio
     );
 
@@ -79,9 +79,9 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * @dev Emitted when a name curator deposits their vSignal into an nSignal curve to mint nSignal
      */
     event NSignalMinted(
-        address graphAccount,
-        uint256 subgraphNumber,
-        address nameCurator,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        address indexed nameCurator,
         uint256 nSignalCreated,
         uint256 vSignalCreated,
         uint256 tokensDeposited
@@ -92,9 +92,9 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * the vSignal, and receives GRT
      */
     event NSignalBurned(
-        address graphAccount,
-        uint256 subgraphNumber,
-        address nameCurator,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        address indexed nameCurator,
         uint256 nSignalBurnt,
         uint256 vSignalBurnt,
         uint256 tokensReceived
@@ -106,25 +106,29 @@ contract GNS is GNSV1Storage, GraphUpgradeable, IGNS {
      * new vSignal curve, creating new nSignal
      */
     event NameSignalUpgrade(
-        address graphAccount,
-        uint256 subgraphNumber,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
         uint256 newVSignalCreated,
         uint256 tokensSignalled,
-        bytes32 subgraphDeploymentID
+        bytes32 indexed subgraphDeploymentID
     );
 
     /**
      * @dev Emitted when an nSignal curve has been permanently disabled
      */
-    event NameSignalDisabled(address graphAccount, uint256 subgraphNumber, uint256 withdrawableGRT);
+    event NameSignalDisabled(
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        uint256 withdrawableGRT
+    );
 
     /**
      * @dev Emitted when a nameCurator withdraws their GRT from a deprecated name signal pool
      */
     event GRTWithdrawn(
-        address graphAccount,
-        uint256 subgraphNumber,
-        address nameCurator,
+        address indexed graphAccount,
+        uint256 indexed subgraphNumber,
+        address indexed nameCurator,
         uint256 nSignalBurnt,
         uint256 withdrawnGRT
     );

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -155,7 +155,7 @@ contract DisputeManager is Managed, IDisputeManager {
      * This event will be emitted after each DisputeCreated event is emitted
      * for each of the individual disputes.
      */
-    event DisputeLinked(bytes32 disputeID1, bytes32 disputeID2);
+    event DisputeLinked(bytes32 indexed disputeID1, bytes32 indexed disputeID2);
 
     /**
      * @dev Check if the caller is the arbitrator.

--- a/contracts/governance/Controller.sol
+++ b/contracts/governance/Controller.sol
@@ -16,7 +16,7 @@ contract Controller is Governed, Pausable, IController {
     // Track contract ids to contract proxy address
     mapping(bytes32 => address) private registry;
 
-    event SetContractProxy(bytes32 id, address contractAddress);
+    event SetContractProxy(bytes32 indexed id, address contractAddress);
 
     /** 
      * @dev Contract constructor.

--- a/contracts/governance/Pausable.sol
+++ b/contracts/governance/Pausable.sol
@@ -18,7 +18,7 @@ contract Pausable {
 
     event PartialPauseChanged(bool isPaused);
     event PauseChanged(bool isPaused);
-    event NewPauseGuardian(address oldPauseGuardian, address pauseGuardian);
+    event NewPauseGuardian(address indexed oldPauseGuardian, address indexed pauseGuardian);
 
     /**
      * @notice Change the partial paused state of the contract

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -36,7 +36,7 @@ contract RewardsManager is RewardsManagerV1Storage, GraphUpgradeable, IRewardsMa
     /**
      * @dev Emitted when a subgraph is denied for claiming rewards.
      */
-    event RewardsDenylistUpdated(bytes32 subgraphDeploymentID, uint256 sinceBlock);
+    event RewardsDenylistUpdated(bytes32 indexed subgraphDeploymentID, uint256 sinceBlock);
 
     // -- Modifiers --
 

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -102,7 +102,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 indexed subgraphDeploymentID,
         uint256 epoch,
         uint256 tokens,
-        address allocationID,
+        address indexed allocationID,
         bytes32 metadata
     );
 
@@ -116,7 +116,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 indexed subgraphDeploymentID,
         uint256 epoch,
         uint256 tokens,
-        address allocationID,
+        address indexed allocationID,
         address from,
         uint256 curationFees,
         uint256 rebateFees
@@ -133,7 +133,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         bytes32 indexed subgraphDeploymentID,
         uint256 epoch,
         uint256 tokens,
-        address allocationID,
+        address indexed allocationID,
         uint256 effectiveAllocation,
         address sender,
         bytes32 poi
@@ -148,7 +148,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
     event RebateClaimed(
         address indexed indexer,
         bytes32 indexed subgraphDeploymentID,
-        address allocationID,
+        address indexed allocationID,
         uint256 epoch,
         uint256 forEpoch,
         uint256 tokens,
@@ -170,7 +170,7 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
     /**
      * @dev Emitted when `indexer` set `operator` access.
      */
-    event SetOperator(address indexed indexer, address operator, bool allowed);
+    event SetOperator(address indexed indexer, address indexed operator, bool allowed);
 
     /**
      * @dev Check if the caller is the slasher.

--- a/contracts/upgrades/GraphProxyStorage.sol
+++ b/contracts/upgrades/GraphProxyStorage.sol
@@ -37,20 +37,23 @@ contract GraphProxyStorage {
      * @dev Emitted when pendingImplementation is changed.
      */
     event PendingImplementationUpdated(
-        address oldPendingImplementation,
-        address newPendingImplementation
+        address indexed oldPendingImplementation,
+        address indexed newPendingImplementation
     );
 
     /**
      * @dev Emitted when pendingImplementation is accepted,
      * which means contract implementation is updated.
      */
-    event ImplementationUpdated(address oldImplementation, address newImplementation);
+    event ImplementationUpdated(
+        address indexed oldImplementation,
+        address indexed newImplementation
+    );
 
     /**
      * @dev Emitted when the admin account has changed.
      */
-    event AdminUpdated(address oldAdmin, address newAdmin);
+    event AdminUpdated(address indexed oldAdmin, address indexed newAdmin);
 
     /**
      * @dev Modifier to check whether the `msg.sender` is the admin.


### PR DESCRIPTION
### Motivation

Throughout the code base, there are events defined without any indexed parameters.

### Implements

Add indexing event parameters when appropriate to avoid hindering the task of off-chain services searching and filtering for specific events.