### PR TITLE
[N04] misc: declare structs within interface to be consistent

### DIFF
--- a/contracts/rewards/IRewardsManager.sol
+++ b/contracts/rewards/IRewardsManager.sol
@@ -3,6 +3,16 @@
 pragma solidity ^0.7.3;
 
 interface IRewardsManager {
+    /**
+     * @dev Stores accumulated rewards and snapshots related to a particular SubgraphDeployment.
+     */
+    struct Subgraph {
+        uint256 accRewardsForSubgraph;
+        uint256 accRewardsForSubgraphSnapshot;
+        uint256 accRewardsPerSignalSnapshot;
+        uint256 accRewardsPerAllocatedToken;
+    }
+
     // -- Params --
 
     function setIssuanceRate(uint256 _issuanceRate) external;

--- a/contracts/rewards/RewardsManagerStorage.sol
+++ b/contracts/rewards/RewardsManagerStorage.sol
@@ -2,17 +2,11 @@
 
 pragma solidity ^0.7.3;
 
+import "./IRewardsManager.sol";
 import "../governance/Managed.sol";
 
 contract RewardsManagerV1Storage is Managed {
     // -- State --
-
-    struct Subgraph {
-        uint256 accRewardsForSubgraph;
-        uint256 accRewardsForSubgraphSnapshot;
-        uint256 accRewardsPerSignalSnapshot;
-        uint256 accRewardsPerAllocatedToken;
-    }
 
     uint256 public issuanceRate;
     uint256 public accRewardsPerSignal;
@@ -22,7 +16,7 @@ contract RewardsManagerV1Storage is Managed {
     address public subgraphAvailabilityOracle;
 
     // Subgraph related rewards: subgraph deployment ID => subgraph rewards
-    mapping(bytes32 => Subgraph) public subgraphs;
+    mapping(bytes32 => IRewardsManager.Subgraph) public subgraphs;
 
     // Subgraph denylist : subgraph deployment ID => block when added or zero (if not denied)
     mapping(bytes32 => uint256) public denylist;


### PR DESCRIPTION
Move struct definition in RewardsManager to the interface to be consistent with the rest of contracts.