### PR TITLE
disputes: parse signature in (r,s,v) order from the DisputeManager

### DIFF
--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -39,11 +39,11 @@ contract DisputeManager is Managed, IDisputeManager {
     uint256 private constant ATTESTATION_SIZE_BYTES = 161;
     uint256 private constant RECEIPT_SIZE_BYTES = 96;
 
-    uint256 private constant SIG_V_LENGTH = 1;
     uint256 private constant SIG_R_LENGTH = 32;
-    uint256 private constant SIG_V_OFFSET = RECEIPT_SIZE_BYTES;
-    uint256 private constant SIG_R_OFFSET = RECEIPT_SIZE_BYTES + SIG_V_LENGTH;
-    uint256 private constant SIG_S_OFFSET = RECEIPT_SIZE_BYTES + SIG_V_LENGTH + SIG_R_LENGTH;
+    uint256 private constant SIG_S_LENGTH = 32;
+    uint256 private constant SIG_R_OFFSET = RECEIPT_SIZE_BYTES;
+    uint256 private constant SIG_S_OFFSET = RECEIPT_SIZE_BYTES + SIG_R_LENGTH;
+    uint256 private constant SIG_V_OFFSET = RECEIPT_SIZE_BYTES + SIG_R_LENGTH + SIG_S_LENGTH;
 
     uint256 private constant UINT8_BYTE_LENGTH = 1;
     uint256 private constant BYTES32_BYTE_LENGTH = 32;
@@ -771,11 +771,11 @@ contract DisputeManager is Managed, IDisputeManager {
 
         // Decode signature
         // Signature is expected to be in the order defined in the Attestation struct
-        uint8 v = _toUint8(_data, SIG_V_OFFSET);
         bytes32 r = _toBytes32(_data, SIG_R_OFFSET);
         bytes32 s = _toBytes32(_data, SIG_S_OFFSET);
+        uint8 v = _toUint8(_data, SIG_V_OFFSET);
 
-        return Attestation(requestCID, responseCID, subgraphDeploymentID, v, r, s);
+        return Attestation(requestCID, responseCID, subgraphDeploymentID, r, s, v);
     }
 
     /**

--- a/contracts/disputes/IDisputeManager.sol
+++ b/contracts/disputes/IDisputeManager.sol
@@ -28,9 +28,9 @@ interface IDisputeManager {
         bytes32 requestCID;
         bytes32 responseCID;
         bytes32 subgraphDeploymentID;
-        uint8 v;
         bytes32 r;
         bytes32 s;
+        uint8 v;
     }
 
     // -- Configuration --

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
-const { defaultAbiCoder: abi, arrayify, concat, hexlify, solidityKeccak256 } = utils
+const { defaultAbiCoder: abi, arrayify, concat, hexlify, solidityKeccak256, joinSignature } = utils
 
 const MAX_PPM = 1000000
 const NON_EXISTING_DISPUTE_ID = randomHexBytes()
@@ -58,11 +58,7 @@ function encodeAttestation(attestation: Attestation): string {
       [attestation.requestCID, attestation.responseCID, attestation.subgraphDeploymentID],
     ),
   )
-  const sig = concat([
-    arrayify(hexlify(attestation.v)),
-    arrayify(attestation.r),
-    arrayify(attestation.s),
-  ])
+  const sig = joinSignature(attestation)
   return hexlify(concat([data, sig]))
 }
 


### PR DESCRIPTION
### Motivation

The DisputeManager was expecting the Attestation signature ordered like (v,r,s) as it was defined original in the spec and because that is the default ordering of ecrecover() opcode parameters `ecrecover(hash, v, r, s)`. However it is normally packed as (r,s,v) as one can see in libraries like Ethers and the order in which ECDSA.recover() use to parse the input signature.

### Implements

- Parse the Attestation by considering the signature is ordered as (r,s,v) like the return of `ethers.joinSignature()`
- Use `joinSignature()` in tests to match how clients build the signature.

```
export function joinSignature(signature: SignatureLike): string {
    signature = splitSignature(signature);

    return hexlify(concat([
         signature.r,
         signature.s,
         (signature.recoveryParam ? "0x1c": "0x1b")
    ]));
```

@Jannis @That3Percent 