### PR TITLE
disputes: make the dispute manager upgradeable

### DIFF
--- a/contracts/disputes/DisputeManagerStorage.sol
+++ b/contracts/disputes/DisputeManagerStorage.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.7.3;
+
+import "../governance/Managed.sol";
+
+import "./IDisputeManager.sol";
+
+contract DisputeManagerV1Storage is Managed {
+    // -- State --
+
+    bytes32 internal DOMAIN_SEPARATOR;
+
+    // The arbitrator is solely in control of arbitrating disputes
+    address public arbitrator;
+
+    // Minimum deposit required to create a Dispute
+    uint256 public minimumDeposit;
+
+    // Percentage of indexer slashed funds to assign as a reward to fisherman in successful dispute
+    // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
+    uint32 public fishermanRewardPercentage;
+
+    // Percentage of indexer stake to slash on disputes
+    // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
+    uint32 public slashingPercentage;
+
+    // Disputes created : disputeID => Dispute
+    // disputeID - check creation functions to see how disputeID is built
+    mapping(bytes32 => IDisputeManager.Dispute) public disputes;
+}

--- a/contracts/upgrades/GraphProxyAdmin.sol
+++ b/contracts/upgrades/GraphProxyAdmin.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+
 pragma solidity ^0.7.3;
 
 import "../governance/Governed.sol";

--- a/graph.config.yml
+++ b/graph.config.yml
@@ -49,6 +49,7 @@ contracts:
       curationTaxPercentage: 50000 # 5% (parts per million)
       minimumCurationDeposit: "1000000000000000000" # 1 GRT
   DisputeManager:
+    proxy: true
     init:
       controller: "${{Controller.address}}"
       arbitrator: *arbitrator

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -138,16 +138,21 @@ export async function deployDisputeManager(
   deployer: Signer,
   controller: string,
   arbitrator: string,
+  proxyAdmin: GraphProxyAdmin,
 ): Promise<DisputeManager> {
   // Deploy
-  return deployContract(
+  return network.deployContractWithProxy(
+    proxyAdmin,
     'DisputeManager',
+    [
+      controller,
+      arbitrator,
+      defaults.dispute.minimumDeposit.toString(),
+      defaults.dispute.fishermanRewardPercentage.toString(),
+      defaults.dispute.slashingPercentage.toString(),
+    ],
     deployer,
-    controller,
-    arbitrator,
-    defaults.dispute.minimumDeposit.toString(),
-    defaults.dispute.fishermanRewardPercentage.toString(),
-    defaults.dispute.slashingPercentage.toString(),
+    false,
   ) as Promise<DisputeManager>
 }
 

--- a/test/lib/fixtures.ts
+++ b/test/lib/fixtures.ts
@@ -35,6 +35,7 @@ export class NetworkFixture {
       deployer,
       controller.address,
       arbitratorAddress,
+      proxyAdmin,
     )
     const rewardsManager = await deployment.deployRewardsManager(
       deployer,


### PR DESCRIPTION
### Motivation

This was the only non-upgradeable contract we had as this one does not have dependencies from other contracts that query the state of this contract and in case we needed it was easier to swap. However, maintaining the address and doing an upgrade can be helpful to avoid making older attestations invalid as those are signed with a particular **verifying contract address** based on EIP-712.