### PR TITLE
style: use type decoration instead of casting

### DIFF
--- a/contracts/statechannels/GRTAssetHolder.sol
+++ b/contracts/statechannels/GRTAssetHolder.sol
@@ -15,10 +15,10 @@ contract GRTAssetHolder is ERC20AssetHolder {
     constructor(
         address _AdjudicatorAddress,
         address _TokenAddress,
-        address _ControllerAddress
+        IController _Controller
     ) public ERC20AssetHolder(_AdjudicatorAddress, _TokenAddress) {
         AdjudicatorAddress = _AdjudicatorAddress;
-        Controller = IController(_ControllerAddress);
+        Controller = _Controller;
     }
 
     function staking() public view returns (IStaking) {


### PR DESCRIPTION
A minor thing the auditors flagged. 