### PR TITLE
staking: set unused Allocation parameters to zero after it is claimed

### DIFF
--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -9,8 +9,8 @@ export const local = {
   accountNumber: '0',
 }
 export const defaultOverrides: Overrides = {
-  gasPrice: utils.parseUnits('25', 'gwei'), // auto
-  gasLimit: 2000000, // auto
+  // gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  // gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1216,8 +1216,15 @@ contract Staking is StakingV1Storage, GraphUpgradeable, IStaking {
         uint256 delegationRewards = _collectDelegationQueryRewards(alloc.indexer, tokensToClaim);
         tokensToClaim = tokensToClaim.sub(delegationRewards);
 
-        // Update the allocate state
+        // Purge allocation data except for:
+        // - indexer: used in disputes and to avoid reusing an allocationID
+        // - subgraphDeploymentID: used in disputes
         allocations[_allocationID].tokens = 0; // This avoid collect(), close() and claim() to be called
+        allocations[_allocationID].createdAtEpoch = 0;
+        allocations[_allocationID].closedAtEpoch = 0;
+        allocations[_allocationID].collectedFees = 0;
+        allocations[_allocationID].effectiveAllocation = 0;
+        allocations[_allocationID].accRewardsPerAllocatedToken = 0;
 
         // -- Interactions --
 

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -701,6 +701,7 @@ describe('Staking:Allocation', () => {
       // After state
       const afterBalance = await grt.balanceOf(indexer.address)
       const afterStake = await staking.stakes(indexer.address)
+      const afterAlloc = await staking.allocations(allocationID)
       const afterRebatePool = await staking.rebates(beforeAlloc.closedAtEpoch)
 
       // Funds distributed to indexer
@@ -715,6 +716,13 @@ describe('Staking:Allocation', () => {
       } else {
         expect(afterStake.tokensStaked).eq(beforeStake.tokensStaked)
       }
+      // Allocation updated (purged)
+      expect(afterAlloc.tokens).eq(toGRT('0'))
+      expect(afterAlloc.createdAtEpoch).eq(toGRT('0'))
+      expect(afterAlloc.closedAtEpoch).eq(toGRT('0'))
+      expect(afterAlloc.collectedFees).eq(toGRT('0'))
+      expect(afterAlloc.effectiveAllocation).eq(toGRT('0'))
+      expect(afterAlloc.accRewardsPerAllocatedToken).eq(toGRT('0'))
       // Rebate updated
       expect(afterRebatePool.unclaimedAllocationsCount).eq(
         beforeRebatePool.unclaimedAllocationsCount - 1,


### PR DESCRIPTION
### Summary
Based on the latest deployed testnet and the data from Tenderly gas profiler, the claim() was refunding more gas when it was setting the struct attributes to zero. This is different from the information that ganache returned that lead to the changes.

### Partially reverts
- https://github.com/graphprotocol/contracts/pull/401/files

Closes: https://github.com/graphprotocol/contracts/issues/422


@davekaj this is a candidate for upgrade in testnet