### PR TITLE
misc: reserve storage in the inherited Managed contract for potential upgrades

### DIFF
--- a/contracts/governance/Managed.sol
+++ b/contracts/governance/Managed.sol
@@ -19,6 +19,8 @@ import "../token/IGraphToken.sol";
 contract Managed {
     // Controller that contract is registered with
     IController public controller;
+    mapping(bytes32 => address) public addressCache;
+    uint256[10] private __gap;
 
     event ParameterUpdated(string param);
     event SetController(address controller);


### PR DESCRIPTION
### Motivation

The Managed class is inherited by most of the contracts and is defining the first slot of the storage layout. Reserve space in case we need to use storage for changing the implementation. 