### PR TITLE
cli: Add empty team addresses module (otherwise cli is broken)

### DIFF
--- a/cli/teamAddresses.ts
+++ b/cli/teamAddresses.ts
@@ -1,0 +1,1 @@
+export const teamAddresses = []


### PR DESCRIPTION
This makes the CLI build again so it can actually be used. 😉 