### PR TITLE
Set indexer rewards destination using rewards pool

### DIFF
--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -9,8 +9,8 @@ export const local = {
   accountNumber: '0',
 }
 export const defaultOverrides: Overrides = {
-  gasPrice: utils.parseUnits('25', 'gwei'), // auto
-  gasLimit: 2000000, // auto
+  // gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  // gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -18,6 +18,14 @@ interface IStaking {
     enum AllocationState { Null, Active, Closed, Finalized, Claimed }
 
     /**
+     * @dev Possible states of Rewards Destination
+     * States:
+     * - Stake = Rewards are sent to the indexer stake, subject to thawing period
+     * - RewardsPool = Rewards are sent to a rewards pool
+     */
+    enum RewardsDestination { Stake, RewardsPool }
+
+    /**
      * @dev Allocate GRT tokens for the purpose of serving queries of a subgraph deployment
      * An allocation is created in the allocate() function and consumed in claim()
      */
@@ -123,7 +131,9 @@ interface IStaking {
 
     function withdraw() external;
 
-    function setRewardsDestination(address _destination) external;
+    function setRewardsDestination(RewardsDestination _destination) external;
+
+    function withdrawRewards(address _beneficiary) external;
 
     // -- Delegation --
 

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -123,6 +123,8 @@ interface IStaking {
 
     function withdraw() external;
 
+    function setRewardsDestination(address _destination) external;
+
     // -- Delegation --
 
     function delegate(address _indexer, uint256 _tokens) external returns (uint256);

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -744,6 +744,8 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         require(tokens > 0, "!rewards-tokens");
         require(_beneficiary != address(0), "!rewards-beneficiary");
 
+        rewardsPool[msg.sender] = 0;
+
         require(graphToken().transfer(_beneficiary, tokens), "!transfer");
 
         emit RewardsWithdrawn(msg.sender, _beneficiary, tokens);

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1603,14 +1603,15 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
             _stake(_beneficiary, _amount);
         } else {
             // Transfer funds to the beneficiary's designated rewards destination if set
-            address destination = rewardsDestination[_beneficiary];
-            require(
-                _graphToken.transfer(
-                    destination == address(0) ? _beneficiary : destination,
-                    _amount
-                ),
-                "!transfer"
-            );
+            rewardsPool[_beneficiary] = rewardsPool[_beneficiary].add(_amount);
+            // address destination = rewardsDestination[_beneficiary];
+            // require(
+            //     _graphToken.transfer(
+            //         destination == address(0) ? _beneficiary : destination,
+            //         _amount
+            //     ),
+            //     "!transfer"
+            // );
         }
     }
 

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -51,6 +51,11 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     event StakeWithdrawn(address indexed indexer, uint256 tokens);
 
     /**
+     * @dev Emitted when `owner` withdrew `tokens` from the rewards pool to `beneficiary` address.
+     */
+    event RewardsWithdrawn(address indexed owner, address indexed beneficiary, uint256 tokens);
+
+    /**
      * @dev Emitted when `indexer` was slashed for a total of `tokens` amount.
      * Tracks `reward` amount of tokens given to `beneficiary`.
      */
@@ -735,11 +740,13 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      * @param _beneficiary Address to send rewards
      */
     function withdrawRewards(address _beneficiary) external override {
-        require(rewardsPool[msg.sender] > 0, "!rewards-tokens");
+        uint256 tokens = rewardsPool[msg.sender];
+        require(tokens > 0, "!rewards-tokens");
+        require(_beneficiary != address(0), "!rewards-beneficiary");
 
-        require(graphToken().transfer(_beneficiary, rewardsPool[msg.sender]), "!transfer");
+        require(graphToken().transfer(_beneficiary, tokens), "!transfer");
 
-        // TODO: emit event
+        emit RewardsWithdrawn(msg.sender, _beneficiary, tokens);
     }
 
     /**

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -82,3 +82,7 @@ contract StakingV1Storage is Managed {
     // Allowed AssetHolders: assetHolder => is allowed
     mapping(address => bool) public assetHolders;
 }
+
+contract StakingV2Storage is StakingV1Storage {
+    mapping(address => address) public rewardsDestination;
+}

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -84,6 +84,8 @@ contract StakingV1Storage is Managed {
 }
 
 contract StakingV2Storage is StakingV1Storage {
-    mapping(address => address) public rewardsDestination;
+    // Destination of accrued rewards : beneficiary => rewards destination
+    mapping(address => IStaking.RewardsDestination) public rewardsDestination;
+    // Pool that holds rewards : beneficiary => accumulated rewards
     mapping(address => uint256) public rewardsPool;
 }

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -85,4 +85,5 @@ contract StakingV1Storage is Managed {
 
 contract StakingV2Storage is StakingV1Storage {
     mapping(address => address) public rewardsDestination;
+    mapping(address => uint256) public rewardsPool;
 }

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -25,6 +25,11 @@ import {
   advanceToNextEpoch,
 } from '../lib/testHelpers'
 
+enum RewardsDestination {
+  Stake,
+  RewardsPool,
+}
+
 const MAX_PPM = 1000000
 
 const { HashZero, WeiPerEther } = constants
@@ -615,8 +620,8 @@ describe('Rewards', () => {
         expect(toRound(afterTokenSupply)).eq(toRound(expectedTokenSupply))
       })
 
-      it.only('should distribute rewards on closed allocation and send to destination', async function () {
-        await staking.connect(indexer1.signer).setRewardsDestination(indexer1.address)
+      it('should distribute rewards on closed allocation and send to rewards pool', async function () {
+        await staking.connect(indexer1.signer).setRewardsDestination(RewardsDestination.RewardsPool)
 
         // Setup
         await setupIndexerAllocation()

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -615,7 +615,7 @@ describe('Rewards', () => {
         expect(toRound(afterTokenSupply)).eq(toRound(expectedTokenSupply))
       })
 
-      it('should distribute rewards on closed allocation and send to destination', async function () {
+      it.only('should distribute rewards on closed allocation and send to destination', async function () {
         await staking.connect(indexer1.signer).setRewardsDestination(indexer1.address)
 
         // Setup
@@ -655,12 +655,12 @@ describe('Rewards', () => {
         const expectedTokenSupply = beforeTokenSupply.add(expectedIndexingRewards)
         // Check stake should not have changed
         expect(toRound(afterIndexer1Stake)).eq(toRound(expectedIndexerStake))
-        // Check indexing rewards are received by the rewards destination
-        expect(toRound(afterIndexer1Balance)).eq(
-          toRound(beforeIndexer1Balance.add(expectedIndexingRewards)),
+        // Check indexer balance remains the same
+        expect(afterIndexer1Balance).eq(beforeIndexer1Balance)
+        // Check indexing rewards are kept in the staking contract
+        expect(toRound(afterStakingBalance)).eq(
+          toRound(beforeStakingBalance.add(expectedIndexingRewards)),
         )
-        // Check indexing rewards are sent from the staking contract
-        expect(afterStakingBalance).eq(beforeStakingBalance)
         // Check that tokens have been minted
         expect(toRound(afterTokenSupply)).eq(toRound(expectedTokenSupply))
       })

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -137,6 +137,28 @@ describe('Staking:Allocation', () => {
     })
   })
 
+  describe('rewardsDestination', function () {
+    it('should set rewards destination', async function () {
+      // Before state
+      const beforeDestination = await staking.rewardsDestination(indexer.address)
+
+      // Set
+      const tx = staking.connect(indexer.signer).setRewardsDestination(me.address)
+      await expect(tx).emit(staking, 'SetRewardsDestination').withArgs(indexer.address, me.address)
+
+      // After state
+      const afterDestination = await staking.rewardsDestination(indexer.address)
+
+      // State updated
+      expect(beforeDestination).eq(AddressZero)
+      expect(afterDestination).eq(me.address)
+
+      // Must be able to set back to zero
+      await staking.rewardsDestination(AddressZero)
+      expect(await staking.rewardsDestination(indexer.address)).eq(AddressZero)
+    })
+  })
+
   /**
    * Allocate
    */


### PR DESCRIPTION
Related to https://github.com/graphprotocol/contracts/pull/450

- Indexer can set a rewards destination (Stake or RewardsPool) for indexing rewards after closing an allocation and for rebate claims
- A function called withdrawRewards() is available to claim accrued tokens from both indexing rewards and query fees.

The main differences is that it accrues any rewards on the stake or rebate pool depending on how rewards destination is set.

This version is about 4% more gas efficient on every close allocation call and is slightly more efficient when calling claim() without restake as it behaves the same way as close allocation. The reason for that is that transferring a token means doing two SSTORE, one to change the balance of the sender and another one for the receiver, additionally a CALL/SLOAD to get the graph token address. Instead it just use one SLOAD and one SSTORE to update the rewards pool.

Discussed in: https://forum.thegraph.com/t/rewards-destination-for-indexers-indexing-rewards/1279/64