### PR TITLE
Withdraw helper contract to support collecting funds from channels

### DIFF
--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -9,8 +9,8 @@ export const local = {
   accountNumber: '0',
 }
 export const defaultOverrides: Overrides = {
-//  gasPrice: utils.parseUnits('25', 'gwei'), // auto
-//  gasLimit: 2000000, // auto
+  //  gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  //  gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {

--- a/contracts/statechannels/GRTWithdrawHelper.sol
+++ b/contracts/statechannels/GRTWithdrawHelper.sol
@@ -30,7 +30,7 @@ contract GRTWithdrawHelper is WithdrawHelper {
 
     // -- State --
 
-    address public tokenAddress;
+    address public immutable tokenAddress;
 
     /**
      * @notice Contract constructor.
@@ -64,7 +64,7 @@ contract GRTWithdrawHelper is WithdrawHelper {
 
         // Approve the staking contract to pull the transfer amount
         (bool success1, ) =
-            _wd.assetId.call(
+            tokenAddress.call(
                 abi.encodeWithSelector(APPROVE_SELECTOR, collectData.staking, _actualAmount)
             );
 

--- a/contracts/statechannels/GRTWithdrawHelper.sol
+++ b/contracts/statechannels/GRTWithdrawHelper.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.7.3;
+pragma experimental ABIEncoderV2;
+
+import "../staking/IStaking.sol";
+import "../token/IGraphToken.sol";
+
+import "./WithdrawHelper.sol";
+
+/**
+ * @title WithdrawHelper contract for GRT tokens
+ * @notice This contract encodes the logic that connects the withdrawal of funds from a channel
+ * back to the protocol for a particular allocation.
+ */
+contract GRTWithdrawHelper is WithdrawHelper {
+    struct CollectData {
+        address staking;
+        address allocationID;
+    }
+
+    // -- State --
+
+    address public tokenAddress;
+
+    /**
+     * @notice Contract constructor.
+     * @param _tokenAddress Token address to use for transfers
+     */
+    constructor(address _tokenAddress) {
+        tokenAddress = _tokenAddress;
+    }
+
+    /**
+     * @notice Returns the ABI encoded representation of a CollectData struct.
+     * @param _collectData CollectData struct with information about how to collect funds
+     */
+    function getCallData(CollectData calldata _collectData) public pure returns (bytes memory) {
+        return abi.encode(_collectData);
+    }
+
+    /**
+     * @notice Execute hook used by a channel to send funds to the protocol.
+     * @param _wd WithdrawData struct for the withdrawal commitment
+     * @param _actualAmount Amount to transfer to the Staking contract
+     */
+    function execute(WithdrawData calldata _wd, uint256 _actualAmount) external override {
+        require(_wd.assetId == tokenAddress, "GRTWithdrawHelper: !token");
+
+        // Decode and validate collect data
+        CollectData memory collectData = abi.decode(_wd.callData, (CollectData));
+        require(collectData.staking != address(0), "GRTWithdrawHelper: !staking");
+        require(collectData.allocationID != address(0), "GRTWithdrawHelper: !allocationID");
+
+        // Approve the staking contract to pull the transfer amount
+        require(
+            IGraphToken(_wd.assetId).approve(collectData.staking, _actualAmount),
+            "GRTWithdrawHelper: !approve"
+        );
+
+        // Call the staking contract to collect funds from this contract
+        IStaking(collectData.staking).collect(_actualAmount, collectData.allocationID);
+    }
+}

--- a/contracts/statechannels/ICMCWithdraw.sol
+++ b/contracts/statechannels/ICMCWithdraw.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.7.3;
+pragma experimental ABIEncoderV2;
+
+struct WithdrawData {
+    address channelAddress;
+    address assetId;
+    address payable recipient;
+    uint256 amount;
+    uint256 nonce;
+    address callTo;
+    bytes callData;
+}
+
+interface ICMCWithdraw {
+    function getWithdrawalTransactionRecord(WithdrawData calldata wd) external view returns (bool);
+
+    function withdraw(
+        WithdrawData calldata wd,
+        bytes calldata aliceSignature,
+        bytes calldata bobSignature
+    ) external;
+}

--- a/contracts/statechannels/WithdrawHelper.sol
+++ b/contracts/statechannels/WithdrawHelper.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.7.3;
+pragma experimental ABIEncoderV2;
+
+import "./ICMCWithdraw.sol";
+
+interface WithdrawHelper {
+    function execute(WithdrawData calldata wd, uint256 actualAmount) external;
+}

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat'
 import { providers, utils, BigNumber, Signer, Wallet } from 'ethers'
-import { formatUnits } from 'ethers/lib/utils'
+import { formatUnits, getAddress } from 'ethers/lib/utils'
 
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
 
@@ -17,6 +17,7 @@ export const logStake = (stakes: any): void => {
     console.log(k, ':', parseEther(v as string))
   })
 }
+export const randomAddress = (): string => getAddress(randomHexBytes(20))
 
 // Network
 

--- a/test/payments/withdrawHelper.test.ts
+++ b/test/payments/withdrawHelper.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { constants } from 'ethers'
 
-import { GrtWithdrawHelper } from '../../build/typechain/contracts/GrtWithdrawHelper'
+import { GRTWithdrawHelper } from '../../build/typechain/contracts/GRTWithdrawHelper'
 import { GraphToken } from '../../build/typechain/contracts/GraphToken'
 import { Staking } from '../../build/typechain/contracts/Staking'
 
@@ -21,7 +21,7 @@ describe('WithdrawHelper', () => {
 
   let grt: GraphToken
   let staking: Staking
-  let withdrawHelper: GrtWithdrawHelper
+  let withdrawHelper: GRTWithdrawHelper
 
   function createWithdrawData(callData: string) {
     return {
@@ -44,7 +44,7 @@ describe('WithdrawHelper', () => {
       'GRTWithdrawHelper',
       governor.signer,
       grt.address,
-    )) as unknown) as GrtWithdrawHelper
+    )) as unknown) as GRTWithdrawHelper
 
     // Give some funds to the indexer and approve staking contract to use funds on indexer behalf
     const indexerTokens = toGRT('100000')

--- a/test/payments/withdrawHelper.test.ts
+++ b/test/payments/withdrawHelper.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai'
+import { constants } from 'ethers'
+
+import { GrtWithdrawHelper } from '../../build/typechain/contracts/GrtWithdrawHelper'
+import { GraphToken } from '../../build/typechain/contracts/GraphToken'
+import { Staking } from '../../build/typechain/contracts/Staking'
+
+import { NetworkFixture } from '../lib/fixtures'
+
+import * as deployment from '../lib/deployment'
+import { deriveChannelKey, getAccounts, randomHexBytes, toGRT, Account } from '../lib/testHelpers'
+
+const { AddressZero } = constants
+
+describe('WithdrawHelper', () => {
+  let cmc: Account
+  let governor: Account
+  let indexer: Account
+
+  let fixture: NetworkFixture
+
+  let grt: GraphToken
+  let staking: Staking
+  let withdrawHelper: GrtWithdrawHelper
+
+  function createWithdrawData(callData: string) {
+    return {
+      amount: 0,
+      assetId: grt.address,
+      callData,
+      callTo: withdrawHelper.address,
+      channelAddress: randomHexBytes(20),
+      nonce: 1,
+      recipient: withdrawHelper.address,
+    }
+  }
+
+  before(async function () {
+    ;[cmc, governor, indexer] = await getAccounts()
+
+    fixture = new NetworkFixture()
+    ;({ grt, staking } = await fixture.load(governor.signer))
+    withdrawHelper = ((await deployment.deployContract(
+      'GRTWithdrawHelper',
+      governor.signer,
+      grt.address,
+    )) as unknown) as GrtWithdrawHelper
+
+    // Give some funds to the indexer and approve staking contract to use funds on indexer behalf
+    const indexerTokens = toGRT('100000')
+    await grt.connect(governor.signer).mint(indexer.address, indexerTokens)
+    await grt.connect(indexer.signer).approve(staking.address, indexerTokens)
+
+    // Give some funds to the CMC multisig fake account
+    const cmcTokens = toGRT('5000')
+    await grt.connect(governor.signer).mint(cmc.address, cmcTokens)
+  })
+
+  beforeEach(async function () {
+    await fixture.setUp()
+  })
+
+  afterEach(async function () {
+    await fixture.tearDown()
+  })
+
+  describe('execute withdrawal', function () {
+    it('withdraw tokens from the CMC to staking contract through WithdrawHelper', async function () {
+      // Generate test data
+      const channelKey = deriveChannelKey()
+      const allocationID = channelKey.address
+      const subgraphDeploymentID = randomHexBytes(32)
+      const metadata = randomHexBytes(32)
+
+      // Allow WithdrawHelper to call the Staking contract
+      await staking.connect(governor.signer).setAssetHolder(withdrawHelper.address, true)
+
+      // Setup staking
+      const stakeTokens = toGRT('100000')
+      await staking.connect(indexer.signer).stake(stakeTokens)
+      await staking
+        .connect(indexer.signer)
+        .allocate(
+          subgraphDeploymentID,
+          stakeTokens,
+          allocationID,
+          metadata,
+          await channelKey.generateProof(indexer.address),
+        )
+
+      // Initiate a withdrawal
+      // For the purpose of the test we skip the CMC and call WithdrawHelper
+      // directly. Transfer tokens from the CMC -> WithdrawHelper being the recipient
+      const actualAmount = toGRT('2000') // <- withdraw amount
+      await grt.connect(cmc.signer).transfer(withdrawHelper.address, actualAmount)
+
+      // Simulate callTo from the CMC to the WithdrawHelper
+      const callData = await withdrawHelper.getCallData({
+        staking: staking.address,
+        allocationID,
+      })
+      const withdrawData = {
+        amount: 0,
+        assetId: grt.address,
+        callData,
+        callTo: withdrawHelper.address,
+        channelAddress: randomHexBytes(20),
+        nonce: 1,
+        recipient: withdrawHelper.address,
+      }
+      await withdrawHelper.execute(withdrawData, actualAmount)
+
+      // Allocation must have collected the withdrawn tokens
+      const allocation = await staking.allocations(allocationID)
+      expect(allocation.collectedFees).eq(actualAmount)
+    })
+
+    it('reject collect data with no staking address', async function () {
+      // Simulate callTo from the CMC to the WithdrawHelper
+      const callData = await withdrawHelper.getCallData({
+        staking: AddressZero,
+        allocationID: randomHexBytes(20),
+      })
+      const tx = withdrawHelper.execute(createWithdrawData(callData), toGRT('100'))
+      await expect(tx).revertedWith('GRTWithdrawHelper: !staking')
+    })
+
+    it('reject collect data with no allocation', async function () {
+      // Simulate callTo from the CMC to the WithdrawHelper
+      const callData = await withdrawHelper.getCallData({
+        staking: randomHexBytes(20),
+        allocationID: AddressZero,
+      })
+      const tx = withdrawHelper.execute(createWithdrawData(callData), toGRT('100'))
+      await expect(tx).revertedWith('GRTWithdrawHelper: !allocationID')
+    })
+  })
+})


### PR DESCRIPTION
### Summary

Introduces a contract called `GRTWithdrawHelper`. The main goal of this contract is to encode custom logic in the process of withdrawing funds from the Vector Channel Multisigs. The contract receives funds from a Channel Multisig, then it forwards them to the Staking contract related to an Allocation.

### Features
- The **GRTWithdrawHelper** is deployed with the token address that will be used for transfers, in our case it is the GRT token address. It can't be changed at later stage but this can easily be solved deploying a new contract if needed.
- The contract expects to have available tokens in balance when `execute(WithdrawData calldata wd, uint256 actualAmount)` is called by the Channel. For that to happen the Channel needs to transfer funds to the WithdrawHelper before execute is called. 
- On execute the WithdrawHelper will approve the funds to send to the Staking contract and then execute `collect()` passing the proper allocationID and amount. The Staking contract will then pull the tokens.
- If the call to `collect()` fails, the funds are returned to the channelAddress. This is important for Vector accounting of funds.

### Requirements
- Set the **GRTWithdrawHelper** contract as AssetHolder in the Staking contract. This way we allow accepting funds from this contract.
- The cooperative withdrawal commitments must have the following data (indicated with arrows):
```
struct WithdrawData {
    address channelAddress;
    address assetId;  // -> GRT token address
    address payable recipient; // -> GRTWithdrawHelper contract address
    uint256 amount;
    uint256 nonce;
    address callTo; // -> GRTWithdrawHelper contract address
    bytes callData; // -> CollectData struct defined below
}
```
```
struct CollectData {
    address staking;  // -> Staking contract address
    address allocationID; // -> AllocationID to send collected funds
}
```
The parties must agree and sign the WithdrawalCommitment with that information to achieve proper execution of the withdrawals.

### Exceptions
The following conditions will result in reverts of the execution:

- **assetId** in **WithdrawData** not matching the token address configured in the _GRTWithdrawHelper_.
- _GRTWithdrawHelper_ not having enough balance to transfer the Staking contract as stated in **actualAmount**.
- Setting an invalid **staking** contract address.

Note: To avoid unexpected conditions in the Vector offchain logic, it is encouraged that the parties verify the WithdrawData does not revert by doing a call/estimateGas.

### Handled Exceptions
These reverts are handled and will make the contract to return the funds to the channel address.

- Doing a withdrawal on a non-existing allocationID as defined in **CollectData** when calling `collect()`.

### Known Behaviour
- This contract does not know if a WithdrawalCommitment is right or wrong. It just accepts a transfer and WithdrawData that defines a destination. 
- A properly formatted WithdrawData can be crafted to send outside funds to the Staking contract. In that case, the person will get those funds distributed with Curators + Delegators + taxed a protocol percentage. There is no rational economic incentive to do so.
