### PR TITLE
Dave/update deploy scripts

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -559,6 +559,22 @@
       "creationCodeHash": "0x9c31294194a6e9768a6da9af195b293dbc589e98ef88ebfd81156487e61d87f3",
       "runtimeCodeHash": "0xb0e364454528b8dcf5876bdb1ac15e6efb46d97d10583b4746bcf54cee3783a0",
       "txHash": "0x5f58737c9a39e766142148cae55d49abf9bcd04427e9f450183e841f74136ac4"
+    },
+    "GraphGovernance": {
+      "address": "0x47241861A3918eaa9097c0345bb5A91660D7AEE1",
+      "initArgs": [
+        "0x1679a1d1caf1252ba43fb8fc17ebf914a0c725ae"
+      ],
+      "creationCodeHash": "0xa02709eb59b9cca8bee1271845b42db037dc1d042dad93410ba532d378a7c79f",
+      "runtimeCodeHash": "0xdb307489fd9a4a438b5b48909e12020b209280ad777561c0a7451655db097e75",
+      "txHash": "0x5101e33eb13504780b225a2557a7062bef93cada0838937e02e879fb3d5c2c01",
+      "proxy": true,
+      "implementation": {
+        "address": "0xa96F8468362e6A109ABFaAF6BBfDa303347B450e",
+        "creationCodeHash": "0x5bd7ee7fbf6eb49914ffc91c747d18c0909ca18c495a8b163499ebfdd82b29d2",
+        "runtimeCodeHash": "0xd77099bdfc3f66aec158303be46e92f8e434271d6b0c7643753cd8ac96b460b9",
+        "txHash": "0xb12705249777b5d955dd25ea7aebf46c5d1e3062b10bc9a0a5755b40f55e11e9"
+      }
     }
   }
 }

--- a/cli/commands/deploy.ts
+++ b/cli/commands/deploy.ts
@@ -1,7 +1,13 @@
 import consola from 'consola'
 import yargs, { Argv } from 'yargs'
 
-import { deployContract } from '../network'
+import {
+  getContractAt,
+  deployContract,
+  deployContractWithProxy,
+  deployContractAndSave,
+  deployContractWithProxyAndSave,
+} from '../network'
 import { loadEnv, CLIArgs, CLIEnvironment } from '../env'
 
 const logger = consola.create({})
@@ -9,12 +15,51 @@ const logger = consola.create({})
 export const deploy = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
   const contractName = cliArgs.contract
   const initArgs = cliArgs.init
+  const deployType = cliArgs.type
+  const buildAcceptProxyTx = cliArgs.buildTx
 
-  logger.log(`Deploying contract ${contractName}...`)
+  // Get the GraphProxyAdmin to own the GraphProxy for this contract
+  const proxyAdminEntry = cli.addressBook.getEntry('GraphProxyAdmin')
+  if (!proxyAdminEntry) {
+    throw new Error('GraphProxyAdmin not detected in the config, must be deployed first!')
+  }
+  const proxyAdmin = getContractAt('GraphProxyAdmin', proxyAdminEntry.address)
 
   // Deploy contract
   const contractArgs = initArgs ? initArgs.split(',') : []
-  await deployContract(contractName, contractArgs, cli.wallet)
+  switch (deployType) {
+    case 'deploy':
+      logger.log(`Deploying contract ${contractName}...`)
+      await deployContract(contractName, contractArgs, cli.wallet)
+      break
+    case 'deploy-save':
+      logger.log(`Deploying contract ${contractName} and saving to address book...`)
+      await deployContractAndSave(contractName, contractArgs, cli.wallet, cli.addressBook)
+      break
+    case 'deploy-proxy':
+      logger.log(`Deploying contract ${contractName} with proxy ...`)
+      await deployContractWithProxy(
+        proxyAdmin,
+        contractName,
+        contractArgs,
+        cli.wallet,
+        true,
+        buildAcceptProxyTx,
+      )
+      break
+    case 'deploy-proxy-save':
+      logger.log(`Deploying contract ${contractName} with proxy and saving to address book...`)
+      await deployContractWithProxyAndSave(
+        contractName,
+        contractArgs,
+        cli.wallet,
+        cli.addressBook,
+        buildAcceptProxyTx,
+      )
+      break
+    default:
+      logger.error('Please provide the correct option for deploy type')
+  }
 }
 
 export const deployCommand = {
@@ -34,6 +79,17 @@ export const deployCommand = {
         type: 'string',
         requiresArg: true,
         demandOption: true,
+      })
+      .option('t', {
+        alias: 'type',
+        description: 'Choose deploy, deploy-save, deploy-proxy, deploy-proxy-save',
+        type: 'string',
+        requiresArg: true,
+        demandOption: true,
+      })
+      .option('b', {
+        alias: 'build-tx',
+        description: 'Build the acceptProxy tx and print it. Then use tx data with a multisig',
       })
   },
   handler: async (argv: CLIArgs): Promise<void> => {

--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -9,8 +9,8 @@ export const local = {
   accountNumber: '0',
 }
 export const defaultOverrides: Overrides = {
-  gasPrice: utils.parseUnits('25', 'gwei'), // auto
-  gasLimit: 2000000, // auto
+  // gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  // gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {

--- a/contracts/governance/GraphGovernance.sol
+++ b/contracts/governance/GraphGovernance.sol
@@ -14,14 +14,12 @@ contract GraphGovernance is GraphGovernanceV1Storage, GraphUpgradeable, IGraphGo
     // -- Events --
 
     event ProposalCreated(
-        address submitter,
         bytes32 proposalId,
         bytes32 votes,
         bytes32 metadata,
         ProposalResolution resolution
     );
     event ProposalUpdated(
-        address submitter,
         bytes32 proposalId,
         bytes32 votes,
         bytes32 metadata,
@@ -65,7 +63,7 @@ contract GraphGovernance is GraphGovernanceV1Storage, GraphUpgradeable, IGraphGo
         require(!isProposalCreated(_proposalId), "proposed");
 
         proposals[_proposalId] = Proposal({ votes: _votes, metadata: _metadata, resolution: _resolution });
-        emit ProposalCreated(msg.sender, _proposalId, _votes, _metadata, _resolution);
+        emit ProposalCreated(_proposalId, _votes, _metadata, _resolution);
     }
 
     /**
@@ -87,6 +85,6 @@ contract GraphGovernance is GraphGovernanceV1Storage, GraphUpgradeable, IGraphGo
         require(isProposalCreated(_proposalId), "!proposed");
 
         proposals[_proposalId] = Proposal({ votes: _votes, metadata: _metadata, resolution: _resolution });
-        emit ProposalUpdated(msg.sender, _proposalId, _votes, _metadata, _resolution);
+        emit ProposalUpdated(_proposalId, _votes, _metadata, _resolution);
     }
 }

--- a/test/governance/gov.test.ts
+++ b/test/governance/gov.test.ts
@@ -41,7 +41,7 @@ describe('GraphGovernance', () => {
         .createProposal(proposalId, votes, metadata, ProposalResolution.Accepted)
       await expect(tx)
         .emit(gov, 'ProposalCreated')
-        .withArgs(governor.address, proposalId, votes, metadata, ProposalResolution.Accepted)
+        .withArgs(proposalId, votes, metadata, ProposalResolution.Accepted)
       expect(await gov.isProposalCreated(proposalId)).eq(true)
 
       const storedProposal = await gov.proposals(proposalId)
@@ -93,7 +93,7 @@ describe('GraphGovernance', () => {
           .updateProposal(proposalId, newvotes, metadata, newResolution)
         await expect(tx)
           .emit(gov, 'ProposalUpdated')
-          .withArgs(governor.address, proposalId, newvotes, metadata, newResolution)
+          .withArgs(proposalId, newvotes, metadata, newResolution)
 
         const storedProposal = await gov.proposals(proposalId)
         expect(storedProposal.metadata).eq(metadata)


### PR DESCRIPTION
- Allows all 4 types of deploying to be done from the CLI
- Adds option to build the TX rather than send the tx. This is so it can be used in gnosis multisig, when governor is a multisig
- also updates an event on Governance
- Some small cleaning up of the script