### PR TITLE
Withdraw indexing rewards to beneficiary address with thawing period

### DIFF
--- a/cli/defaults.ts
+++ b/cli/defaults.ts
@@ -9,8 +9,8 @@ export const local = {
   accountNumber: '0',
 }
 export const defaultOverrides: Overrides = {
-  gasPrice: utils.parseUnits('25', 'gwei'), // auto
-  gasLimit: 2000000, // auto
+  // gasPrice: utils.parseUnits('25', 'gwei'), // auto
+  // gasLimit: 2000000, // auto
 }
 
 export const cliOpts = {

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -3,70 +3,9 @@
 pragma solidity >=0.6.12 <0.8.0;
 pragma experimental ABIEncoderV2;
 
-interface IStaking {
-    // -- Allocation Data --
+import "./IStakingData.sol";
 
-    /**
-     * @dev Possible states an allocation can be
-     * States:
-     * - Null = indexer == address(0)
-     * - Active = not Null && tokens > 0
-     * - Closed = Active && closedAtEpoch != 0
-     * - Finalized = Closed && closedAtEpoch + channelDisputeEpochs > now()
-     * - Claimed = not Null && tokens == 0
-     */
-    enum AllocationState { Null, Active, Closed, Finalized, Claimed }
-
-    /**
-     * @dev Allocate GRT tokens for the purpose of serving queries of a subgraph deployment
-     * An allocation is created in the allocate() function and consumed in claim()
-     */
-    struct Allocation {
-        address indexer;
-        bytes32 subgraphDeploymentID;
-        uint256 tokens; // Tokens allocated to a SubgraphDeployment
-        uint256 createdAtEpoch; // Epoch when it was created
-        uint256 closedAtEpoch; // Epoch when it was closed
-        uint256 collectedFees; // Collected fees for the allocation
-        uint256 effectiveAllocation; // Effective allocation when closed
-        uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
-    }
-
-    /**
-     * @dev Represents a request to close an allocation with a specific proof of indexing.
-     * This is passed when calling closeAllocationMany to define the closing parameters for
-     * each allocation.
-     */
-    struct CloseAllocationRequest {
-        address allocationID;
-        bytes32 poi;
-        bool restake;
-    }
-
-    // -- Delegation Data --
-
-    /**
-     * @dev Delegation pool information. One per indexer.
-     */
-    struct DelegationPool {
-        uint32 cooldownBlocks; // Blocks to wait before updating parameters
-        uint32 indexingRewardCut; // in PPM
-        uint32 queryFeeCut; // in PPM
-        uint256 updatedAtBlock; // Block when the pool was last updated
-        uint256 tokens; // Total tokens as pool reserves
-        uint256 shares; // Total shares minted in the pool
-        mapping(address => Delegation) delegators; // Mapping of delegator => Delegation
-    }
-
-    /**
-     * @dev Individual delegation data of a delegator in a pool.
-     */
-    struct Delegation {
-        uint256 shares; // Shares owned by a delegator in the pool
-        uint256 tokensLocked; // Tokens locked for undelegation
-        uint256 tokensLockedUntil; // Block when locked tokens can be withdrawn
-    }
-
+interface IStaking is IStakingData {
     // -- Configuration --
 
     function setMinimumIndexerStake(uint256 _minimumIndexerStake) external;

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -40,6 +40,7 @@ interface IStaking {
     struct CloseAllocationRequest {
         address allocationID;
         bytes32 poi;
+        bool restake;
     }
 
     // -- Delegation Data --
@@ -123,6 +124,8 @@ interface IStaking {
 
     function withdraw() external;
 
+    function withdrawRewards(address _beneficiary) external;
+
     // -- Delegation --
 
     function delegate(address _indexer, uint256 _tokens) external returns (uint256);
@@ -150,13 +153,18 @@ interface IStaking {
         bytes calldata _proof
     ) external;
 
-    function closeAllocation(address _allocationID, bytes32 _poi) external;
+    function closeAllocation(
+        address _allocationID,
+        bytes32 _poi,
+        bool _restake
+    ) external;
 
     function closeAllocationMany(CloseAllocationRequest[] calldata _requests) external;
 
     function closeAndAllocate(
         address _oldAllocationID,
         bytes32 _poi,
+        bool _restake,
         address _indexer,
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,

--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.12 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+interface IStakingData {
+    // -- Allocation Data --
+
+    /**
+     * @dev Possible states an allocation can be
+     * States:
+     * - Null = indexer == address(0)
+     * - Active = not Null && tokens > 0
+     * - Closed = Active && closedAtEpoch != 0
+     * - Finalized = Closed && closedAtEpoch + channelDisputeEpochs > now()
+     * - Claimed = not Null && tokens == 0
+     */
+    enum AllocationState { Null, Active, Closed, Finalized, Claimed }
+
+    /**
+     * @dev Allocate GRT tokens for the purpose of serving queries of a subgraph deployment
+     * An allocation is created in the allocate() function and consumed in claim()
+     */
+    struct Allocation {
+        address indexer;
+        bytes32 subgraphDeploymentID;
+        uint256 tokens; // Tokens allocated to a SubgraphDeployment
+        uint256 createdAtEpoch; // Epoch when it was created
+        uint256 closedAtEpoch; // Epoch when it was closed
+        uint256 collectedFees; // Collected fees for the allocation
+        uint256 effectiveAllocation; // Effective allocation when closed
+        uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
+    }
+
+    /**
+     * @dev Represents a request to close an allocation with a specific proof of indexing.
+     * This is passed when calling closeAllocationMany to define the closing parameters for
+     * each allocation.
+     */
+    struct CloseAllocationRequest {
+        address allocationID;
+        bytes32 poi;
+        bool restake;
+    }
+
+    // -- Delegation Data --
+
+    /**
+     * @dev Delegation pool information. One per indexer.
+     */
+    struct DelegationPool {
+        uint32 cooldownBlocks; // Blocks to wait before updating parameters
+        uint32 indexingRewardCut; // in PPM
+        uint32 queryFeeCut; // in PPM
+        uint256 updatedAtBlock; // Block when the pool was last updated
+        uint256 tokens; // Total tokens as pool reserves
+        uint256 shares; // Total shares minted in the pool
+        mapping(address => Delegation) delegators; // Mapping of delegator => Delegation
+    }
+
+    /**
+     * @dev Individual delegation data of a delegator in a pool.
+     */
+    struct Delegation {
+        uint256 shares; // Shares owned by a delegator in the pool
+        uint256 tokensLocked; // Tokens locked for undelegation
+        uint256 tokensLockedUntil; // Block when locked tokens can be withdrawn
+    }
+}

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -3,9 +3,8 @@
 pragma solidity ^0.7.3;
 
 import "../governance/Managed.sol";
-import "../staking/IStaking.sol";
 
-import "./IStaking.sol";
+import "./IStakingData.sol";
 import "./libs/Rebates.sol";
 import "./libs/Stakes.sol";
 import "./libs/Rewards.sol";
@@ -41,7 +40,7 @@ contract StakingV1Storage is Managed {
     mapping(address => Stakes.Indexer) public stakes;
 
     // Allocations : allocationID => Allocation
-    mapping(address => IStaking.Allocation) public allocations;
+    mapping(address => IStakingData.Allocation) public allocations;
 
     // Subgraph Allocations: subgraphDeploymentID => tokens
     mapping(bytes32 => uint256) public subgraphAllocations;
@@ -72,7 +71,7 @@ contract StakingV1Storage is Managed {
     uint32 public delegationTaxPercentage;
 
     // Delegation pools : indexer => DelegationPool
-    mapping(address => IStaking.DelegationPool) public delegationPools;
+    mapping(address => IStakingData.DelegationPool) public delegationPools;
 
     // -- Operators --
 

--- a/contracts/staking/StakingStorage.sol
+++ b/contracts/staking/StakingStorage.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.7.3;
 
 import "../governance/Managed.sol";
 import "../staking/IStaking.sol";
+
 import "./IStaking.sol";
 import "./libs/Rebates.sol";
 import "./libs/Stakes.sol";
+import "./libs/Rewards.sol";
 
 contract StakingV1Storage is Managed {
     // -- Staking --
@@ -81,4 +83,9 @@ contract StakingV1Storage is Managed {
 
     // Allowed AssetHolders: assetHolder => is allowed
     mapping(address => bool) public assetHolders;
+}
+
+contract StakingV2Storage is StakingV1Storage {
+    // Pool that holds rewards : beneficiary => accumulated rewards
+    mapping(address => Rewards.Pool) public rewardsPools;
 }

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.3;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @title MathUtils Library
+ * @notice A collection of functions to perform math operations
+ */
+library MathUtils {
+    using SafeMath for uint256;
+
+    /**
+     * @dev Calculates the weighted average.
+     */
+    function weightedAverage(
+        uint256 valueA,
+        uint256 weightA,
+        uint256 valueB,
+        uint256 weightB
+    ) internal pure returns (uint256) {
+        return valueA.mul(weightA).add(valueB.mul(weightB)).div(weightA.add(weightB));
+    }
+
+    /**
+     * @dev Returns the minimum of two numbers.
+     */
+    function min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x <= y ? x : y;
+    }
+
+    /**
+     * @dev Returns the difference between two numbers or zero if negative.
+     */
+    function diff(uint256 x, uint256 y) internal pure returns (uint256) {
+        return (x > y) ? x.sub(y) : 0;
+    }
+}

--- a/contracts/staking/libs/Rewards.sol
+++ b/contracts/staking/libs/Rewards.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.3;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "./MathUtils.sol";
+
+library Rewards {
+    using SafeMath for uint256;
+
+    struct Pool {
+        uint256 tokensLocked;
+        uint256 tokensLockedUntil; // Block when locked tokens can be withdrawn
+    }
+
+    /**
+     * @dev Reset the rewards pool.
+     * @param _self Rewards pool
+     */
+    function reset(Rewards.Pool storage _self) internal {
+        _self.tokensLocked = 0;
+        _self.tokensLockedUntil = 0;
+    }
+
+    /**
+     * @dev Lock tokens until a thawing period pass.
+     * @param _self Rewards pool
+     * @param _tokens Amount of tokens to unstake
+     * @param _period Period in blocks that need to pass before withdrawal
+     */
+    function lockTokens(
+        Rewards.Pool storage _self,
+        uint256 _tokens,
+        uint256 _period
+    ) internal {
+        // Take into account period averaging for multiple deposits
+        uint256 lockingPeriod = _period;
+        if (_self.tokensLockedUntil > 0) {
+            lockingPeriod = MathUtils.weightedAverage(
+                MathUtils.diff(_self.tokensLockedUntil, block.number),
+                _self.tokensLocked,
+                _period,
+                _tokens
+            );
+        }
+
+        // Update balances
+        _self.tokensLocked = _self.tokensLocked.add(_tokens);
+        _self.tokensLockedUntil = block.number.add(lockingPeriod);
+    }
+}

--- a/contracts/staking/libs/Rewards.sol
+++ b/contracts/staking/libs/Rewards.sol
@@ -6,6 +6,10 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "./MathUtils.sol";
 
+/**
+ * @title Rewards Pool library
+ * @notice The rewards pool struct and a number of related operations
+ */
 library Rewards {
     using SafeMath for uint256;
 

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -146,7 +146,7 @@ describe('DisputeManager:POI', async () => {
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
       await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
-      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
+      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi, true)
       await staking.connect(indexer.signer).unstake(indexerTokens)
       await advanceBlock() // pass thawing period
       await staking.connect(indexer.signer).withdraw()

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -240,7 +240,7 @@ describe('DisputeManager:Query', async () => {
       const event1 = staking.interface.parseLog(receipt1.logs[0]).args
       await advanceToNextEpoch(epochManager) // wait the required one epoch to close allocation
       await staking.connect(assetHolder.signer).collect(indexerCollectedTokens, event1.allocationID)
-      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi)
+      await staking.connect(indexer.signer).closeAllocation(event1.allocationID, poi, true)
       await staking.connect(indexer.signer).unstake(indexerTokens)
       await advanceBlock() // pass thawing period
       await staking.connect(indexer.signer).withdraw()

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -4,7 +4,7 @@ import hre from 'hardhat'
 import { EpochManager } from '../../build/typechain/contracts/EpochManager'
 import { formatUnits } from 'ethers/lib/utils'
 
-const { hexlify, parseUnits, parseEther, randomBytes } = utils
+const { hexlify, parseUnits, parseEther, randomBytes, getAddress } = utils
 
 export const toBN = (value: string | number): BigNumber => BigNumber.from(value)
 export const toGRT = (value: string | number): BigNumber => {
@@ -12,11 +12,21 @@ export const toGRT = (value: string | number): BigNumber => {
 }
 export const formatGRT = (value: BigNumber): string => formatUnits(value, '18')
 export const randomHexBytes = (n = 32): string => hexlify(randomBytes(n))
+export const randomAddress = (): string => getAddress(randomHexBytes(20))
 export const logStake = (stakes: any): void => {
   Object.entries(stakes).map(([k, v]) => {
     console.log(k, ':', parseEther(v as string))
   })
 }
+
+// Math
+
+export const weightedAverage = (
+  valueA: BigNumber,
+  valueB: BigNumber,
+  periodA: BigNumber,
+  periodB: BigNumber,
+): BigNumber => periodA.mul(valueA).add(periodB.mul(valueB)).div(valueA.add(valueB))
 
 // Network
 

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -25,11 +25,6 @@ import {
   advanceToNextEpoch,
 } from '../lib/testHelpers'
 
-enum RewardsDestination {
-  Stake,
-  RewardsPool,
-}
-
 const MAX_PPM = 1000000
 
 const { HashZero, WeiPerEther } = constants

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -29,11 +29,6 @@ enum AllocationState {
   Claimed,
 }
 
-enum RewardsDestination {
-  Stake,
-  RewardsPool,
-}
-
 const calculateEffectiveAllocation = (
   tokens: BigNumber,
   numEpochs: BigNumber,

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -589,7 +589,7 @@ describe('Staking::Delegation', () => {
       await advanceToNextEpoch(epochManager)
 
       // Close allocation
-      await staking.connect(indexer.signer).closeAllocation(allocationID, poi)
+      await staking.connect(indexer.signer).closeAllocation(allocationID, poi, true)
 
       // Advance blocks to get the channel in epoch where it can be claimed
       await advanceToNextEpoch(epochManager)

--- a/test/staking/rewards.test.ts
+++ b/test/staking/rewards.test.ts
@@ -1,0 +1,195 @@
+import { expect } from 'chai'
+import { constants, BigNumber } from 'ethers'
+
+import { Curation } from '../../build/typechain/contracts/Curation'
+import { EpochManager } from '../../build/typechain/contracts/EpochManager'
+import { GraphToken } from '../../build/typechain/contracts/GraphToken'
+import { Staking } from '../../build/typechain/contracts/Staking'
+
+import { NetworkFixture } from '../lib/fixtures'
+import {
+  advanceBlocks,
+  advanceToNextEpoch,
+  deriveChannelKey,
+  getAccounts,
+  randomAddress,
+  randomHexBytes,
+  weightedAverage,
+  toGRT,
+  Account,
+  latestBlock,
+  toBN,
+} from '../lib/testHelpers'
+
+const { AddressZero, HashZero } = constants
+
+describe('Staking::Rewards', () => {
+  let governor: Account
+  let indexer: Account
+  let curator: Account
+
+  let fixture: NetworkFixture
+
+  let curation: Curation
+  let epochManager: EpochManager
+  let grt: GraphToken
+  let staking: Staking
+
+  // Test values
+  const indexerTokens = toGRT('100000')
+  const curatorTokens = toGRT('100000')
+
+  const allocateThenTimeAndClose = async (
+    tokens: BigNumber,
+    subgraphDeploymentID: string,
+    restake: boolean,
+  ) => {
+    const metadata = HashZero
+    const poi = randomHexBytes(32)
+    const channelKey = deriveChannelKey()
+    const allocationID = channelKey.address
+
+    await staking
+      .connect(indexer.signer)
+      .allocate(
+        subgraphDeploymentID,
+        tokens,
+        allocationID,
+        metadata,
+        await channelKey.generateProof(indexer.address),
+      )
+    await advanceToNextEpoch(epochManager)
+    await advanceToNextEpoch(epochManager)
+    await staking.connect(indexer.signer).closeAllocation(allocationID, poi, restake)
+  }
+
+  const shouldWithdrawRewards = async () => {
+    const beneficiary = randomAddress()
+
+    // Before state
+    const beforeRewardsPool = await staking.rewardsPools(indexer.address)
+    const beforeStakingBalance = await grt.balanceOf(staking.address)
+    const beforeBeneficiaryBalance = await grt.balanceOf(beneficiary)
+
+    // Withdraw rewards
+    const tokensToWithdraw = beforeRewardsPool.tokensLocked
+    const tx = staking.connect(indexer.signer).withdrawRewards(beneficiary)
+    await expect(tx)
+      .emit(staking, 'RewardsWithdrawn')
+      .withArgs(indexer.address, beneficiary, tokensToWithdraw)
+
+    // After state
+    const afterRewardsPool = await staking.rewardsPools(indexer.address)
+    const afterStakingBalance = await grt.balanceOf(staking.address)
+    const afterBeneficiaryBalance = await grt.balanceOf(beneficiary)
+
+    // Rewards pool updated
+    expect(afterRewardsPool.tokensLocked).eq(0)
+    expect(afterRewardsPool.tokensLockedUntil).eq(0)
+
+    // Balances updated
+    expect(afterStakingBalance).eq(beforeStakingBalance.sub(tokensToWithdraw))
+    expect(afterBeneficiaryBalance).eq(beforeBeneficiaryBalance.add(tokensToWithdraw))
+  }
+
+  before(async function () {
+    ;[governor, indexer, curator] = await getAccounts()
+
+    fixture = new NetworkFixture()
+    ;({ grt, staking, epochManager, curation } = await fixture.load(governor.signer))
+
+    // Give some funds to the indexer and approve staking contract to use funds on their behalf
+    await grt.connect(governor.signer).mint(indexer.address, indexerTokens)
+    await grt.connect(indexer.signer).approve(staking.address, indexerTokens)
+    // Give some funds to the curator and approve curation contract to use funds on their behalf
+    await grt.connect(governor.signer).mint(curator.address, curatorTokens)
+    await grt.connect(curator.signer).approve(curation.address, curatorTokens)
+
+    // Stake from indexer
+    await staking.connect(indexer.signer).stake(indexerTokens)
+  })
+
+  beforeEach(async function () {
+    await fixture.setUp()
+  })
+
+  afterEach(async function () {
+    await fixture.tearDown()
+  })
+
+  describe('withdrawRewards', function () {
+    const subgraphDeploymentID = randomHexBytes(32)
+
+    it('should withdraw available rewards', async function () {
+      // Collect some rewards from allocation
+      await curation.connect(curator.signer).mint(subgraphDeploymentID, curatorTokens, 0)
+      await allocateThenTimeAndClose(indexerTokens, subgraphDeploymentID, false)
+
+      // Move after lock period
+      await advanceBlocks(await staking.thawingPeriod())
+
+      // Withdraw
+      await shouldWithdrawRewards()
+    })
+
+    it('should update locking period with weighted average on re-deposit', async function () {
+      // Set long thawing period
+      await staking.setThawingPeriod(200)
+
+      // Collect some rewards from allocation
+      await curation.connect(curator.signer).mint(subgraphDeploymentID, curatorTokens, 0)
+      await allocateThenTimeAndClose(indexerTokens, subgraphDeploymentID, false)
+
+      // Before state
+      const thawingPeriod = await staking.thawingPeriod()
+      const beforeRewardsPool = await staking.rewardsPools(indexer.address)
+
+      // Re-deposit on rewards pool
+      await allocateThenTimeAndClose(indexerTokens, subgraphDeploymentID, false)
+
+      // After state
+      const afterRewardsPool = await staking.rewardsPools(indexer.address)
+      const afterBlock = await latestBlock()
+      const blockDiff = afterBlock.lt(beforeRewardsPool.tokensLockedUntil)
+        ? beforeRewardsPool.tokensLockedUntil.sub(afterBlock)
+        : toBN(0)
+      const newTokens = afterRewardsPool.tokensLocked.sub(beforeRewardsPool.tokensLocked)
+      const newPeriod = await weightedAverage(
+        beforeRewardsPool.tokensLocked,
+        newTokens,
+        blockDiff,
+        toBN(thawingPeriod),
+      )
+
+      // Token lock period should be averaged
+      expect(afterRewardsPool.tokensLocked).gt(beforeRewardsPool.tokensLocked)
+      expect(afterRewardsPool.tokensLockedUntil).eq(afterBlock.add(newPeriod))
+    })
+
+    it('reject withdraw if no tokens available', async function () {
+      const tx = staking.connect(indexer.signer).withdrawRewards(indexer.address)
+      await expect(tx).revertedWith('rewards-empty')
+    })
+
+    it('reject withdraw if empty beneficiary', async function () {
+      // Collect some rewards from allocation
+      await curation.connect(curator.signer).mint(subgraphDeploymentID, curatorTokens, 0)
+      await allocateThenTimeAndClose(indexerTokens, subgraphDeploymentID, false)
+
+      // Move after lock period
+      await advanceBlocks(await staking.thawingPeriod())
+
+      const tx = staking.connect(indexer.signer).withdrawRewards(AddressZero)
+      await expect(tx).revertedWith('!rewards-beneficiary')
+    })
+
+    it('reject withdraw if under lock period', async function () {
+      // Collect some rewards from allocation
+      await curation.connect(curator.signer).mint(subgraphDeploymentID, curatorTokens, 0)
+      await allocateThenTimeAndClose(indexerTokens, subgraphDeploymentID, false)
+
+      const tx = staking.connect(indexer.signer).withdrawRewards(indexer.address)
+      await expect(tx).revertedWith('rewards-locked')
+    })
+  })
+})

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -12,21 +12,13 @@ import {
   getAccounts,
   randomHexBytes,
   latestBlock,
+  weightedAverage,
   toBN,
   toGRT,
   Account,
 } from '../lib/testHelpers'
 
 const { AddressZero } = constants
-
-function weightedAverage(
-  valueA: BigNumber,
-  valueB: BigNumber,
-  periodA: BigNumber,
-  periodB: BigNumber,
-) {
-  return periodA.mul(valueA).add(periodB.mul(valueB)).div(valueA.add(valueB))
-}
 
 describe('Staking:Stakes', () => {
   let me: Account


### PR DESCRIPTION
This PR introduces a number of changes in how rewards are managed:

### Main Changes

- Indexers can set whether to stake rewards or send them to a rewards pool by passing a __restake_ boolean to both closeAllocation() and claim(). This allows efficient and flexible change of strategy from the indexer agent.

- A function called `withdrawRewards(address _beneficiary)` is available to claim accrued tokens, according to a thawing period, from both indexing rewards and query fees that were send to the rewards pool. This function allows withdrawing rewards to an arbitrary address.

### Additional Considerations

- Perform some changes to reduce the bytecode size of Staking contract, such as moving some math logic to `MathUtils`, use `_pushTokens()` and `_pullTokens()` for token operations.
- Move structs that are related to Staking contract storage to IStakingData file.

Related-to: GIP-0004
Discussed in: https://forum.thegraph.com/t/rewards-destination-for-indexers-indexing-rewards/1279/64