### PR TITLE
Disputes with separate slashing percentages for queries and indexing

### DIFF
--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -136,13 +136,21 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
      */
     event DisputeLinked(bytes32 indexed disputeID1, bytes32 indexed disputeID2);
 
+    // -- Modifiers --
+
+    function _onlyArbitrator() internal view {
+        require(msg.sender == arbitrator, "Caller is not the Arbitrator");
+    }
+
     /**
      * @dev Check if the caller is the arbitrator.
      */
     modifier onlyArbitrator {
-        require(msg.sender == arbitrator, "Caller is not the Arbitrator");
+        _onlyArbitrator();
         _;
     }
+
+    // -- Functions --
 
     /**
      * @dev Initialize this contract.

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -53,14 +53,17 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
 
     // -- Constants --
 
-    uint256 private constant ATTESTATION_SIZE_BYTES = 161;
+    // Attestation size is the sum of the receipt (96) + signature (65)
+    uint256 private constant ATTESTATION_SIZE_BYTES = RECEIPT_SIZE_BYTES + SIG_SIZE_BYTES;
     uint256 private constant RECEIPT_SIZE_BYTES = 96;
 
     uint256 private constant SIG_R_LENGTH = 32;
     uint256 private constant SIG_S_LENGTH = 32;
+    uint256 private constant SIG_V_LENGTH = 1;
     uint256 private constant SIG_R_OFFSET = RECEIPT_SIZE_BYTES;
     uint256 private constant SIG_S_OFFSET = RECEIPT_SIZE_BYTES + SIG_R_LENGTH;
     uint256 private constant SIG_V_OFFSET = RECEIPT_SIZE_BYTES + SIG_R_LENGTH + SIG_S_LENGTH;
+    uint256 private constant SIG_SIZE_BYTES = SIG_R_LENGTH + SIG_S_LENGTH + SIG_V_LENGTH;
 
     uint256 private constant UINT8_BYTE_LENGTH = 1;
     uint256 private constant BYTES32_BYTE_LENGTH = 32;

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -548,6 +548,9 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
 
     /**
      * @dev The arbitrator accepts a dispute as being valid.
+     * This function will revert if the indexer is not slashable, whether because it does not have
+     * any stake available or the slashing percentage is configured to be zero. In those cases
+     * a dispute must be resolved using drawDispute or rejectDispute.
      * @notice Accept a dispute with ID `_disputeID`
      * @param _disputeID ID of the dispute to be accepted
      */

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -279,7 +279,8 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
         );
         qrySlashingPercentage = _qryPercentage;
         idxSlashingPercentage = _idxPercentage;
-        emit ParameterUpdated("slashingPercentage");
+        emit ParameterUpdated("qrySlashingPercentage");
+        emit ParameterUpdated("idxSlashingPercentage");
     }
 
     /**

--- a/contracts/disputes/DisputeManagerStorage.sol
+++ b/contracts/disputes/DisputeManagerStorage.sol
@@ -23,7 +23,8 @@ contract DisputeManagerV1Storage is Managed {
 
     // Percentage of indexer stake to slash on disputes
     // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
-    uint32 public slashingPercentage;
+    uint32 public qrySlashingPercentage;
+    uint32 public idxSlashingPercentage;
 
     // Disputes created : disputeID => Dispute
     // disputeID - check creation functions to see how disputeID is built

--- a/contracts/disputes/DisputeManagerStorage.sol
+++ b/contracts/disputes/DisputeManagerStorage.sol
@@ -17,6 +17,7 @@ contract DisputeManagerV1Storage is Managed {
     // Minimum deposit required to create a Dispute
     uint256 public minimumDeposit;
 
+    // -- Slot 0xf
     // Percentage of indexer slashed funds to assign as a reward to fisherman in successful dispute
     // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
     uint32 public fishermanRewardPercentage;
@@ -26,6 +27,7 @@ contract DisputeManagerV1Storage is Managed {
     uint32 public qrySlashingPercentage;
     uint32 public idxSlashingPercentage;
 
+    // -- Slot 0x10
     // Disputes created : disputeID => Dispute
     // disputeID - check creation functions to see how disputeID is built
     mapping(bytes32 => IDisputeManager.Dispute) public disputes;

--- a/contracts/disputes/IDisputeManager.sol
+++ b/contracts/disputes/IDisputeManager.sol
@@ -6,7 +6,7 @@ pragma experimental ABIEncoderV2;
 interface IDisputeManager {
     // -- Dispute --
 
-    enum DisputeType { IndexingDispute, QueryDispute }
+    enum DisputeType { Null, IndexingDispute, QueryDispute }
 
     // Disputes contain info necessary for the Arbitrator to verify and resolve
     struct Dispute {

--- a/contracts/disputes/IDisputeManager.sol
+++ b/contracts/disputes/IDisputeManager.sol
@@ -6,12 +6,15 @@ pragma experimental ABIEncoderV2;
 interface IDisputeManager {
     // -- Dispute --
 
+    enum DisputeType { IndexingDispute, QueryDispute }
+
     // Disputes contain info necessary for the Arbitrator to verify and resolve
     struct Dispute {
         address indexer;
         address fisherman;
         uint256 deposit;
         bytes32 relatedDisputeID;
+        DisputeType disputeType;
     }
 
     // -- Attestation --
@@ -41,7 +44,7 @@ interface IDisputeManager {
 
     function setFishermanRewardPercentage(uint32 _percentage) external;
 
-    function setSlashingPercentage(uint32 _percentage) external;
+    function setSlashingPercentage(uint32 _qryPercentage, uint32 _idxPercentage) external;
 
     // -- Getters --
 
@@ -55,10 +58,6 @@ interface IDisputeManager {
     ) external pure returns (bool);
 
     function getAttestationIndexer(Attestation memory _attestation) external view returns (address);
-
-    function getTokensToReward(address _indexer) external view returns (uint256);
-
-    function getTokensToSlash(address _indexer) external view returns (uint256);
 
     // -- Dispute --
 

--- a/test/disputes/common.ts
+++ b/test/disputes/common.ts
@@ -1,0 +1,42 @@
+import { utils } from 'ethers'
+import { Attestation, Receipt } from '@graphprotocol/common-ts'
+
+export const MAX_PPM = 1000000
+
+const { defaultAbiCoder: abi, arrayify, concat, hexlify, solidityKeccak256, joinSignature } = utils
+
+export interface Dispute {
+  id: string
+  attestation: Attestation
+  encodedAttestation: string
+  indexerAddress: string
+  receipt: Receipt
+}
+
+export function createQueryDisputeID(
+  attestation: Attestation,
+  indexerAddress: string,
+  submitterAddress: string,
+): string {
+  return solidityKeccak256(
+    ['bytes32', 'bytes32', 'bytes32', 'address', 'address'],
+    [
+      attestation.requestCID,
+      attestation.responseCID,
+      attestation.subgraphDeploymentID,
+      indexerAddress,
+      submitterAddress,
+    ],
+  )
+}
+
+export function encodeAttestation(attestation: Attestation): string {
+  const data = arrayify(
+    abi.encode(
+      ['bytes32', 'bytes32', 'bytes32'],
+      [attestation.requestCID, attestation.responseCID, attestation.subgraphDeploymentID],
+    ),
+  )
+  const sig = joinSignature(attestation)
+  return hexlify(concat([data, sig]))
+}

--- a/test/disputes/configuration.test.ts
+++ b/test/disputes/configuration.test.ts
@@ -103,23 +103,30 @@ describe('DisputeManager:Config', () => {
 
     describe('slashingPercentage', function () {
       it('should set `slashingPercentage`', async function () {
-        const newValue = defaults.dispute.slashingPercentage
+        const qryNewValue = defaults.dispute.qrySlashingPercentage
+        const idxNewValue = defaults.dispute.idxSlashingPercentage
 
         // Set right in the constructor
-        expect(await disputeManager.slashingPercentage()).eq(newValue)
+        expect(await disputeManager.qrySlashingPercentage()).eq(qryNewValue)
+        expect(await disputeManager.idxSlashingPercentage()).eq(idxNewValue)
 
         // Set new value
-        await disputeManager.connect(governor.signer).setSlashingPercentage(0)
-        await disputeManager.connect(governor.signer).setSlashingPercentage(newValue)
+        await disputeManager.connect(governor.signer).setSlashingPercentage(0, 0)
+        await disputeManager
+          .connect(governor.signer)
+          .setSlashingPercentage(qryNewValue, idxNewValue)
       })
 
       it('reject set `slashingPercentage` if out of bounds', async function () {
-        const tx = disputeManager.connect(governor.signer).setSlashingPercentage(MAX_PPM + 1)
-        await expect(tx).revertedWith('Slashing percentage must be below or equal to MAX_PPM')
+        const tx1 = disputeManager.connect(governor.signer).setSlashingPercentage(0, MAX_PPM + 1)
+        await expect(tx1).revertedWith('Slashing percentage must be below or equal to MAX_PPM')
+
+        const tx2 = disputeManager.connect(governor.signer).setSlashingPercentage(MAX_PPM + 1, 0)
+        await expect(tx2).revertedWith('Slashing percentage must be below or equal to MAX_PPM')
       })
 
       it('reject set `slashingPercentage` if not allowed', async function () {
-        const tx = disputeManager.connect(me.signer).setSlashingPercentage(50)
+        const tx = disputeManager.connect(me.signer).setSlashingPercentage(50, 50)
         await expect(tx).revertedWith('Caller must be Controller governor')
       })
     })

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -22,7 +22,7 @@ import { MAX_PPM } from './common'
 
 const { keccak256 } = utils
 
-describe.only('DisputeManager:POI', async () => {
+describe('DisputeManager:POI', async () => {
   let other: Account
   let governor: Account
   let arbitrator: Account

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -18,9 +18,11 @@ import {
   Account,
 } from '../lib/testHelpers'
 
+import { MAX_PPM } from './common'
+
 const { keccak256 } = utils
 
-describe('DisputeManager:POI', async () => {
+describe.only('DisputeManager:POI', async () => {
   let other: Account
   let governor: Account
   let arbitrator: Account
@@ -47,6 +49,16 @@ describe('DisputeManager:POI', async () => {
   const subgraphDeploymentID = randomHexBytes(32)
   const metadata = randomHexBytes(32)
   const poi = randomHexBytes(32) // proof of indexing
+
+  async function calculateSlashConditions(indexerAddress: string) {
+    const idxSlashingPercentage = await disputeManager.idxSlashingPercentage()
+    const fishermanRewardPercentage = await disputeManager.fishermanRewardPercentage()
+    const stakeAmount = await staking.getIndexerStakedTokens(indexerAddress)
+    const slashAmount = stakeAmount.mul(idxSlashingPercentage).div(toBN(MAX_PPM))
+    const rewardsAmount = slashAmount.mul(fishermanRewardPercentage).div(toBN(MAX_PPM))
+
+    return { slashAmount, rewardsAmount }
+  }
 
   async function setupIndexers() {
     // Dispute manager is allowed to slash
@@ -180,6 +192,8 @@ describe('DisputeManager:POI', async () => {
       })
 
       context('> when dispute is created', function () {
+        // NOTE: other dispute resolution paths are tested in query.test.ts
+
         beforeEach(async function () {
           // Create dispute
           await disputeManager
@@ -192,6 +206,46 @@ describe('DisputeManager:POI', async () => {
             .connect(fisherman.signer)
             .createIndexingDispute(allocationID, fishermanDeposit)
           await expect(tx).revertedWith('Dispute already created')
+        })
+
+        describe('accept a dispute', function () {
+          it('should resolve dispute, slash indexer and reward the fisherman', async function () {
+            const disputeID = keccak256(allocationID)
+
+            // Before state
+            const beforeIndexerStake = await staking.getIndexerStakedTokens(indexer.address)
+            const beforeFishermanBalance = await grt.balanceOf(fisherman.address)
+            const beforeTotalSupply = await grt.totalSupply()
+
+            // Calculations
+            const { slashAmount, rewardsAmount } = await calculateSlashConditions(indexer.address)
+
+            // Perform transaction (accept)
+            const tx = disputeManager.connect(arbitrator.signer).acceptDispute(disputeID)
+            await expect(tx)
+              .emit(disputeManager, 'DisputeAccepted')
+              .withArgs(
+                disputeID,
+                indexer.address,
+                fisherman.address,
+                fishermanDeposit.add(rewardsAmount),
+              )
+
+            // After state
+            const afterFishermanBalance = await grt.balanceOf(fisherman.address)
+            const afterIndexerStake = await staking.getIndexerStakedTokens(indexer.address)
+            const afterTotalSupply = await grt.totalSupply()
+
+            // Fisherman reward properly assigned + deposit returned
+            expect(afterFishermanBalance).eq(
+              beforeFishermanBalance.add(fishermanDeposit).add(rewardsAmount),
+            )
+            // Indexer slashed
+            expect(afterIndexerStake).eq(beforeIndexerStake.sub(slashAmount))
+            // Slashed funds burned
+            const tokensToBurn = slashAmount.sub(rewardsAmount)
+            expect(afterTotalSupply).eq(beforeTotalSupply.sub(tokensToBurn))
+          })
         })
       })
     })

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -33,7 +33,8 @@ export const defaults = {
   dispute: {
     minimumDeposit: toGRT('100'),
     fishermanRewardPercentage: toBN('1000'), // in basis points
-    slashingPercentage: toBN('1000'), // in basis points
+    qrySlashingPercentage: toBN('1000'), // in basis points
+    idxSlashingPercentage: toBN('100000'), // in basis points
   },
   epochs: {
     lengthInBlocks: toBN((15 * 60) / 15), // 15 minutes in blocks
@@ -149,7 +150,8 @@ export async function deployDisputeManager(
       arbitrator,
       defaults.dispute.minimumDeposit.toString(),
       defaults.dispute.fishermanRewardPercentage.toString(),
-      defaults.dispute.slashingPercentage.toString(),
+      defaults.dispute.qrySlashingPercentage.toString(),
+      defaults.dispute.idxSlashingPercentage.toString(),
     ],
     deployer,
     false,


### PR DESCRIPTION
### Description

The DisputeManager is the contract where actors in the protocol can create disputes about indexers misbehaving. There are two types of disputes: indexing and query ones. Indexing disputes are created based on one allocation that was closed with a wrong POI (proof of indexing) while query disputes are created presenting an attestation for a wrong query returned. After a dispute is created, the Arbitrator can resolve it and slash a percentage of the indexer's stake.

The PR adds a different slashing percentage for Indexing Disputes and Query Disputes.

### Motivation

The current contract uses the same slashing percentage for indexing and query disputes. However, more flexibility is desirable as one indexing offense can carry much more weight than a single bad query returned. Having a too high slashing percentage for a single wrong query can be a disincentive for indexers to serve queries.

### Solution

- Add a type to the dispute to categorize it when someone creates it.
- Create new storage var for a separate indexer and query slashing percentages.
- Add setters for each new slashing governance variable.
- Pick the right slashing percentage when the dispute is resolved.
- Additional minor refactors.