### PR TITLE
Update rewards snapshot when closeAllocation with empty POI

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1195,6 +1195,8 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         // Distribute rewards if proof of indexing was presented by the indexer or operator
         if (isIndexer && _poi != 0) {
             _distributeRewards(_allocationID, alloc.indexer);
+        } else {
+            _updateRewards(alloc.subgraphDeploymentID);
         }
 
         // Free allocated tokens from use


### PR DESCRIPTION
### Description

Indexers get rewards for indexing subgraphs. These rewards are minted whenever an indexer close an allocation with a non-zero POI. A function called `distributeRewards()` within the Staking contract is used for that purpose. This function calls `RewardsManager.takeRewards()` that updates the snapshots used for rewards calculations and then mint the tokens. In some cases the snapshot calculation is not called.

### Problem

When an indexer calls `closeAllocation()` with a POI=0x0 the function `distributeRewards()` is not called, as a consequence, `takeRewards()` is not called and in turn the snapshots are not updated before unallocating tokens. This creates a situation where the rewards manager considers there are a different amount of allocated tokens and distort calculations until it is called next time.

https://github.com/graphprotocol/contracts/blob/master/contracts/staking/Staking.sol#L1186

### Solution

Call `_updateRewards()` when the POI presented is 0x0 before unallocating the tokens.
