### PR TITLE
Stable cut for indexing and query rewards

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -104,19 +104,19 @@ export const setDelegationParameters = async (
   cli: CLIEnvironment,
   cliArgs: CLIArgs,
 ): Promise<void> => {
-  const indexingRewardCut = cliArgs.indexingRewardCut
-  const queryFeeCut = cliArgs.queryFeeCut
+  const indexRewardsCut = cliArgs.indexRewardsCut
+  const queryRewardsCut = cliArgs.queryRewardsCut
   const cooldownBlocks = cliArgs.cooldownBlocks
   const staking = cli.contracts.Staking
 
   logger.info(`Setting the following delegation parameters for indexer ${cli.walletAddress}
-      indexingRewardCut = ${indexingRewardCut}
-      queryFeeCut       = ${queryFeeCut}
+      indexRewardsCut = ${indexRewardsCut}
+      queryRewardsCut       = ${queryRewardsCut}
       cooldownBlocks    = ${cooldownBlocks}
   `)
   await sendTransaction(cli.wallet, staking, 'setDelegationParameters', [
-    indexingRewardCut,
-    queryFeeCut,
+    indexRewardsCut,
+    queryRewardsCut,
     cooldownBlocks,
   ])
 }
@@ -341,14 +341,14 @@ export const stakingCommand = {
         describe: 'Sets the delegation parameters for an indexer',
         builder: (yargs: Argv) => {
           return yargs
-            .option('indexingRewardCut', {
-              description: 'Percentage of indexing rewards left for delegators',
+            .option('indexRewardsCut', {
+              description: 'Share of index rewards that the indexer keeps (in PPM)',
               type: 'number',
               requiresArg: true,
               demandOption: true,
             })
-            .option('queryFeeCut', {
-              description: 'Percentage of query fees left for delegators',
+            .option('queryRewardsCut', {
+              description: 'Share of query rewards that the indexer keeps (in PPM)',
               type: 'number',
               requiresArg: true,
               demandOption: true,

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -38,8 +38,8 @@ interface IStaking is IStakingData {
     function setDelegationRatio(uint32 _delegationRatio) external;
 
     function setDelegationParameters(
-        uint32 _indexingRewardCut,
-        uint32 _queryFeeCut,
+        uint32 _indexRewardsCut,
+        uint32 _queryRewardsCut,
         uint32 _cooldownBlocks
     ) external;
 

--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -16,8 +16,8 @@ interface IStakingData {
         uint256 collectedFees; // Collected fees for the allocation
         uint256 effectiveAllocation; // Effective allocation when closed
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
-        uint32 delegatorsIndexingRewardsCut; // Share of indexing rewards for delegators (PPM)
-        uint32 delegatorsQueryFeeCut; // Share of query fees for delegators (PPM)
+        uint32 delegatorIndexRewardsCut; // Share of index rewards for delegators (PPM)
+        uint32 delegatorQueryRewardsCut; // Share of query rewards for delegators (PPM)
     }
 
     /**
@@ -37,8 +37,8 @@ interface IStakingData {
      */
     struct DelegationPool {
         uint32 cooldownBlocks; // Blocks to wait before updating parameters
-        uint32 indexingRewardCut; // in PPM
-        uint32 queryFeeCut; // in PPM
+        uint32 indexRewardsCut; // Share of index rewards for delegators (PPM)
+        uint32 queryRewardsCut; // Share of query rewards for delegators (PPM)
         uint256 updatedAtBlock; // Block when the pool was last updated
         uint256 tokens; // Total tokens as pool reserves
         uint256 shares; // Total shares minted in the pool

--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -16,8 +16,8 @@ interface IStakingData {
         uint256 collectedFees; // Collected fees for the allocation
         uint256 effectiveAllocation; // Effective allocation when closed
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
-        uint32 delegatorIndexRewardsCut; // Share of index rewards for delegators (PPM)
-        uint32 delegatorQueryRewardsCut; // Share of query rewards for delegators (PPM)
+        uint32 delegatorTotalIndexRewardsCut; // Share of total index rewards for delegators (PPM)
+        uint32 delegatorTotalQueryRewardsCut; // Share of total query rewards for delegators (PPM)
     }
 
     /**

--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -16,6 +16,8 @@ interface IStakingData {
         uint256 collectedFees; // Collected fees for the allocation
         uint256 effectiveAllocation; // Effective allocation when closed
         uint256 accRewardsPerAllocatedToken; // Snapshot used for reward calc
+        uint32 delegatorsIndexingRewardsCut; // Share of indexing rewards for delegators (PPM)
+        uint32 delegatorsQueryFeeCut; // Share of query fees for delegators (PPM)
     }
 
     /**

--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -37,8 +37,8 @@ interface IStakingData {
      */
     struct DelegationPool {
         uint32 cooldownBlocks; // Blocks to wait before updating parameters
-        uint32 indexRewardsCut; // Share of index rewards for delegators (PPM)
-        uint32 queryRewardsCut; // Share of query rewards for delegators (PPM)
+        uint32 indexRewardsCut; // Share of index rewards for indexers (PPM)
+        uint32 queryRewardsCut; // Share of query rewards for indexers (PPM)
         uint256 updatedAtBlock; // Block when the pool was last updated
         uint256 tokens; // Total tokens as pool reserves
         uint256 shares; // Total shares minted in the pool

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1168,7 +1168,6 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         pure
         returns (uint32)
     {
-        if (_indexerDelegationRatio == 0 || _indexerRewardsCut == MathUtils.MAX_PPM) return 0;
         return
             MathUtils.percentOfPercent(
                 MathUtils.percentFlip(_indexerRewardsCut),

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -628,8 +628,8 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      */
     function getIndexerCapacity(address _indexer) public view override returns (uint256) {
         Stakes.Indexer memory indexerStake = stakes[_indexer];
-        uint256 tokensDelegated = delegationPools[_indexer].tokens;
 
+        uint256 tokensDelegated = delegationPools[_indexer].tokens;
         uint256 tokensDelegatedCap = indexerStake.tokensSecureStake().mul(uint256(delegationRatio));
         uint256 tokensDelegatedCapacity = MathUtils.min(tokensDelegated, tokensDelegatedCap);
 
@@ -1166,13 +1166,14 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     /**
      * @dev Calculate the delegator rewards cut from the total staked amount (indexer + delegations).
      *
-     * Formula:
-     * 1) indexerDelegationTotalRatio = delegatedStake / totalStake
-     * 2) indexerRewardsCut = Percentage of the rewards earned by the delegators
-     *    stake part that the indexer keeps
-     * 3) delegatorTotalRewardsCut = (1 - indexerRewardsCut) * indexerDelegationTotalRatio
+     * Parameters:
+     * indexerDelegationTotalRatio = delegatedStake / totalStake
+     * indexerRewardsCut = Percentage of the rewards earned by the delegators stake part, that the indexer keeps
      *
-     * Deduct the part that the indexer takes from the delegated stake earnings.
+     * Formula:
+     * delegatorTotalRewardsCut = (1 - indexerRewardsCut) * indexerDelegationTotalRatio
+     *
+     * Note: Deduct the part that the indexer takes from the delegated stake earnings.
      *
      * @param _indexerDelegationTotalRatio Delegation to total-stake ratio (in PPM)
      * @param _indexerRewardsCut Indexer rewards cut (in PPM)

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -24,7 +24,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
 
     // For safety purposes we define an activation epoch for using the new rewards
     // distribution formula
-    uint256 private constant GIP_ACTIVATION_EPOCH = 0; // TODO: change before deployment of implementation
+    uint256 private constant GIP_ACTIVATION_EPOCH = 1000; // TODO: change before deployment of implementation
 
     // -- Events --
 

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1171,6 +1171,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         pure
         returns (uint32)
     {
+        if (_indexerRewardsCut == 0) return 0;
         return
             SafeCast.toUint32(
                 uint256(_indexerRewardsCut).sub(
@@ -1458,6 +1459,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      * This function will assign the collected tokens to the delegation pool.
      * @param _indexer Indexer to which the tokens to distribute are related
      * @param _tokens Total tokens received used to calculate the amount to collect
+     * @param _rewardsCut Percentage of rewards that the delegators will get (PPM)
      * @return Amount of delegation rewards
      */
     function _collectDelegationRewards(
@@ -1467,9 +1469,8 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     ) private returns (uint256) {
         uint256 delegationRewards = 0;
         DelegationPool storage pool = delegationPools[_indexer];
-        if (pool.tokens > 0 && _rewardsCut < MathUtils.MAX_PPM) {
-            uint256 indexerCut = MathUtils.percentOf(_rewardsCut, _tokens);
-            delegationRewards = _tokens.sub(indexerCut);
+        if (_rewardsCut > 0 && pool.tokens > 0) {
+            delegationRewards = MathUtils.percentOf(_rewardsCut, _tokens);
             pool.tokens = pool.tokens.add(delegationRewards);
         }
         return delegationRewards;

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -187,7 +187,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     /**
      * @dev Check if the caller is the slasher.
      */
-    modifier onlySlasher {
+    modifier onlySlasher() {
         require(slashers[msg.sender] == true, "!slasher");
         _;
     }
@@ -1151,8 +1151,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         // Used for rewards calculations
         subgraphAllocations[alloc.subgraphDeploymentID] = subgraphAllocations[
             alloc.subgraphDeploymentID
-        ]
-        .add(alloc.tokens);
+        ].add(alloc.tokens);
 
         emit AllocationCreated(
             _indexer,
@@ -1185,7 +1184,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     ) private pure returns (uint32) {
         return
             MathUtils.percentMul(
-                MathUtils.percentFlip(_indexerRewardsCut),
+                MathUtils.percentInverse(_indexerRewardsCut),
                 _indexerDelegationTotalRatio
             );
     }
@@ -1240,7 +1239,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         if (isIndexer && _poi != 0) {
             uint32 delegatorTotalRewardsCut = (alloc.createdAtEpoch >= GIP_ACTIVATION_EPOCH)
                 ? alloc.delegatorTotalIndexRewardsCut
-                : MathUtils.percentFlip(delegationPools[alloc.indexer].indexRewardsCut);
+                : MathUtils.percentInverse(delegationPools[alloc.indexer].indexRewardsCut);
             _distributeRewards(_allocationID, alloc.indexer, delegatorTotalRewardsCut);
         } else {
             _updateRewards(alloc.subgraphDeploymentID);
@@ -1253,8 +1252,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         // Used for rewards calculations
         subgraphAllocations[alloc.subgraphDeploymentID] = subgraphAllocations[
             alloc.subgraphDeploymentID
-        ]
-        .sub(alloc.tokens);
+        ].sub(alloc.tokens);
 
         emit AllocationClosed(
             alloc.indexer,
@@ -1292,7 +1290,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         // Add delegation rewards to the delegation pool
         uint32 delegatorTotalRewardsCut = (alloc.createdAtEpoch >= GIP_ACTIVATION_EPOCH)
             ? alloc.delegatorTotalQueryRewardsCut
-            : MathUtils.percentFlip(delegationPools[alloc.indexer].queryRewardsCut);
+            : MathUtils.percentInverse(delegationPools[alloc.indexer].queryRewardsCut);
         uint256 delegationRewards = _collectDelegationRewards(
             tokensToClaim,
             alloc.indexer,

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1570,11 +1570,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      * @param _subgraphDeploymentID Subgraph deployment updated
      */
     function _updateRewards(bytes32 _subgraphDeploymentID) private returns (uint256) {
-        IRewardsManager rewardsManager = rewardsManager();
-        if (address(rewardsManager) == address(0)) {
-            return 0;
-        }
-        return rewardsManager.onSubgraphAllocationUpdate(_subgraphDeploymentID);
+        return rewardsManager().onSubgraphAllocationUpdate(_subgraphDeploymentID);
     }
 
     /**
@@ -1588,15 +1584,10 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         address _indexer,
         uint32 _delegatorRewardsCut
     ) private {
-        IRewardsManager rewardsManager = rewardsManager();
-        if (address(rewardsManager) == address(0)) {
-            return;
-        }
-
         // Automatically triggers update of rewards snapshot as allocation will change
         // after this call. Take rewards mint tokens for the Staking contract to distribute
         // between indexer and delegators
-        uint256 totalRewards = rewardsManager.takeRewards(_allocationID);
+        uint256 totalRewards = rewardsManager().takeRewards(_allocationID);
         if (totalRewards == 0) {
             return;
         }

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -70,6 +70,7 @@ library MathUtils {
      * @param value Value to calculate the percentage of
      */
     function percentOf(uint32 percentage, uint256 value) internal pure returns (uint256) {
+        if (percentage == 0 || value == 0) return 0;
         return percentage >= MAX_PPM ? value : uint256(percentage).mul(value).div(MAX_PPM);
     }
 

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -79,7 +79,7 @@ library MathUtils {
      * @param a First percentage (PPM)
      * @param b Second percentage (PPM)
      */
-    function percentOfPercent(uint32 a, uint32 b) internal pure returns (uint32) {
+    function percentMul(uint32 a, uint32 b) internal pure returns (uint32) {
         return toPercent(percentOf(a, uint256(b)));
     }
 

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -22,6 +22,7 @@ library MathUtils {
      * @param weightA The weight to use for value A
      * @param valueB The amount for value B
      * @param weightB The weight to use for value B
+     * @return Weighted average
      */
     function weightedAverage(
         uint256 valueA,
@@ -34,6 +35,7 @@ library MathUtils {
 
     /**
      * @dev Returns the minimum of two numbers.
+     * @return Minimum of two numbers
      */
     function min(uint256 x, uint256 y) internal pure returns (uint256) {
         return x <= y ? x : y;
@@ -41,6 +43,7 @@ library MathUtils {
 
     /**
      * @dev Returns the difference between two numbers or zero if negative.
+     * @return Difference between two numbers or zero if negative
      */
     function diffOrZero(uint256 x, uint256 y) internal pure returns (uint256) {
         return (x > y) ? x.sub(y) : 0;
@@ -49,6 +52,7 @@ library MathUtils {
     /**
      * @dev Returns the ratio a/(a+b) using PPM scaling precision.
      * Both `a` and `b` must have the same scaling.
+     * @return Ratio a/(a+b) in PPM
      */
     function totalRatio(uint256 a, uint256 b) internal pure returns (uint32) {
         return a > 0 ? toPercent(a.mul(MAX_PPM).div(a.add(b))) : 0;
@@ -58,6 +62,7 @@ library MathUtils {
      * @dev Cast a number to uint32 and ensures that it is within percent expressed
      * in parts-per-million max bound.
      * @param value Value to cast and check is PPM
+     * @return Number within a percentage bounds (PPM)
      */
     function toPercent(uint256 value) internal pure returns (uint32) {
         require(value <= MAX_PPM, "PercentCast: out of bounds");
@@ -66,8 +71,10 @@ library MathUtils {
 
     /**
      * @dev Returns the value after applying percentage with parts-per-million precision.
+     * This function will not allow percentages over 100%
      * @param percentage Percentage (PPM)
      * @param value Value to calculate the percentage of
+     * @return Percentage of a number
      */
     function percentOf(uint32 percentage, uint256 value) internal pure returns (uint256) {
         if (percentage == 0 || value == 0) return 0;
@@ -78,6 +85,7 @@ library MathUtils {
      * @dev Returns the percentage of a percentage expressed in parts-per-million.
      * @param a First percentage (PPM)
      * @param b Second percentage (PPM)
+     * @return Percentage of a percentage (PPM)
      */
     function percentMul(uint32 a, uint32 b) internal pure returns (uint32) {
         return toPercent(percentOf(a, uint256(b)));
@@ -86,6 +94,7 @@ library MathUtils {
     /**
      * @dev Returns (1 - percentage) in parts-per-million.
      * @param percentage Percentage (PPM)
+     * @return Inverse of a percentage (PPM)
      */
     function percentInverse(uint32 percentage) internal pure returns (uint32) {
         return toPercent(uint256(MathUtils.MAX_PPM).sub(percentage));

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -52,7 +52,7 @@ library MathUtils {
      * Both `a` and `b` must have the same scaling.
      */
     function ratio(uint256 a, uint256 b) internal pure returns (uint32) {
-        return SafeCast.toUint32(a.mul(MAX_PPM).div(b));
+        return a > 0 ? SafeCast.toUint32(a.mul(MAX_PPM).div(b)) : 0;
     }
 
     /**
@@ -61,6 +61,7 @@ library MathUtils {
      * @param value Value to calcuate the percentage of
      */
     function percentOf(uint32 percentage, uint256 value) internal pure returns (uint256) {
+        if (percentage >= MAX_PPM) return value; // bound-check
         return uint256(percentage).mul(value).div(MAX_PPM);
     }
 }

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -3,13 +3,17 @@
 pragma solidity ^0.7.3;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/SafeCast.sol";
 
 /**
  * @title MathUtils Library
- * @notice A collection of functions to perform math operations
+ * @notice A collection of functions to perform math operations.
  */
 library MathUtils {
     using SafeMath for uint256;
+
+    // 100% in parts per million
+    uint32 public constant MAX_PPM = 1000000;
 
     /**
      * @dev Calculates the weighted average of two values pondering each of these
@@ -41,5 +45,22 @@ library MathUtils {
      */
     function diffOrZero(uint256 x, uint256 y) internal pure returns (uint256) {
         return (x > y) ? x.sub(y) : 0;
+    }
+
+    /**
+     * @dev Returns the ratio a/b using PPM scaling precision.
+     * Both `a` and `b` must have the same scaling.
+     */
+    function ratio(uint256 a, uint256 b) internal pure returns (uint32) {
+        return SafeCast.toUint32(a.mul(MAX_PPM).div(b));
+    }
+
+    /**
+     * @dev Returns the percentage of value with parts-per-million precision.
+     * @param percentage Percentage in parts-per-million (PPM)
+     * @param value Value to calcuate the percentage of
+     */
+    function percentOf(uint32 percentage, uint256 value) internal pure returns (uint256) {
+        return uint256(percentage).mul(value).div(MAX_PPM);
     }
 }

--- a/contracts/staking/libs/MathUtils.sol
+++ b/contracts/staking/libs/MathUtils.sol
@@ -87,7 +87,7 @@ library MathUtils {
      * @dev Returns (1 - percentage) in parts-per-million.
      * @param percentage Percentage (PPM)
      */
-    function percentFlip(uint32 percentage) internal pure returns (uint32) {
+    function percentInverse(uint32 percentage) internal pure returns (uint32) {
         return toPercent(uint256(MathUtils.MAX_PPM).sub(percentage));
     }
 }

--- a/contracts/tests/MathUtilsMock.sol
+++ b/contracts/tests/MathUtilsMock.sol
@@ -6,4 +6,8 @@ contract MathUtilsMock {
     function totalRatio(uint256 a, uint256 b) public pure returns (uint32) {
         return MathUtils.totalRatio(a, b);
     }
+
+    function percentOf(uint32 percentage, uint256 value) public pure returns (uint256) {
+        return MathUtils.percentOf(percentage, value);
+    }
 }

--- a/contracts/tests/MathUtilsMock.sol
+++ b/contracts/tests/MathUtilsMock.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+import "../staking/libs/MathUtils.sol";
+
+contract MathUtilsMock {
+    function totalRatio(uint256 a, uint256 b) public pure returns (uint32) {
+        return MathUtils.totalRatio(a, b);
+    }
+}

--- a/tasks/query/allocations.ts
+++ b/tasks/query/allocations.ts
@@ -54,7 +54,7 @@ task('query:allos', 'List allocations').setAction(async (_, hre: HardhatRuntimeE
         allo.subgraphDeployment.id,
         formatEther(allo.allocatedTokens),
         formatEther(r),
-        pool.indexingRewardCut / 10000,
+        pool.indexRewardsCut / 10000,
         pool.updatedAtBlock.add(pool.cooldownBlocks).toNumber() - currentBlock,
         allo.createdAtEpoch,
       ])

--- a/tasks/query/allocations.ts
+++ b/tasks/query/allocations.ts
@@ -43,7 +43,6 @@ task('query:allos', 'List allocations').setAction(async (_, hre: HardhatRuntimeE
   const queue = new PQueue({ concurrency: 4 })
   for (const allo of allos) {
     queue.add(async () => {
-      console.log('coso')
       const [pool, r] = await Promise.all([
         contracts.Staking.delegationPools(allo.indexer.id),
         contracts.RewardsManager.getRewards(allo.id),

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -31,7 +31,7 @@ export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
 
 // Protocol Math
 
-export function getDelegatorRewardsCut(
+export function getDelegatorTotalRewardsCut(
   delegatedTokens: BigNumber,
   stakedTokens: BigNumber,
   rewardsCut: BigNumber,

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -16,7 +16,7 @@ export const formatGRT = (value: BigNumber): string => formatUnits(value, '18')
 export const randomHexBytes = (n = 32): string => hexlify(randomBytes(n))
 export const randomAddress = (): string => getAddress(randomHexBytes(20))
 export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
-  value.sub(ppm.mul(value).div(MAX_PPM))
+  ppm.mul(value).div(MAX_PPM)
 
 export const MAX_PPM = toBN('1000000')
 

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -8,17 +8,37 @@ import { EpochManager } from '../../build/types/EpochManager'
 
 const { hexlify, parseUnits, randomBytes } = utils
 
+// Conversions
+
 export const toBN = (value: string | number): BigNumber => BigNumber.from(value)
 export const toGRT = (value: string | number): BigNumber => {
   return parseUnits(typeof value === 'number' ? value.toString() : value, '18')
 }
 export const formatGRT = (value: BigNumber): string => formatUnits(value, '18')
+
+// Symbols
+
 export const randomHexBytes = (n = 32): string => hexlify(randomBytes(n))
 export const randomAddress = (): string => getAddress(randomHexBytes(20))
+
+// Core Math
+
+export const MAX_PPM = toBN('1000000')
+export const totalRatio = (a: BigNumber, b: BigNumber): BigNumber => a.mul(MAX_PPM).div(a.add(b))
+export const percentageFlip = (ppm: BigNumber): BigNumber => MAX_PPM.sub(ppm)
 export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
   ppm.mul(value).div(MAX_PPM)
 
-export const MAX_PPM = toBN('1000000')
+// Protocol Math
+
+export function getDelegatorRewardsCut(
+  delegatedTokens: BigNumber,
+  stakedTokens: BigNumber,
+  rewardsCut: BigNumber,
+): BigNumber {
+  const indexerDelegationRatio = totalRatio(delegatedTokens, stakedTokens)
+  return percentageOf(percentageFlip(rewardsCut), indexerDelegationRatio)
+}
 
 // Network
 

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -27,7 +27,7 @@ export const MAX_PPM = toBN('1000000')
 export const totalRatio = (a: BigNumber, b: BigNumber): BigNumber => a.mul(MAX_PPM).div(a.add(b))
 export const percentageFlip = (ppm: BigNumber): BigNumber => MAX_PPM.sub(ppm)
 export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
-  ppm.mul(value).div(MAX_PPM)
+  ppm.gt(MAX_PPM) ? value : ppm.mul(value).div(MAX_PPM)
 
 // Protocol Math
 

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -15,6 +15,10 @@ export const toGRT = (value: string | number): BigNumber => {
 export const formatGRT = (value: BigNumber): string => formatUnits(value, '18')
 export const randomHexBytes = (n = 32): string => hexlify(randomBytes(n))
 export const randomAddress = (): string => getAddress(randomHexBytes(20))
+export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
+  value.sub(ppm.mul(value).div(MAX_PPM))
+
+export const MAX_PPM = toBN('1000000')
 
 // Network
 

--- a/test/payments/allocationExchange.test.ts
+++ b/test/payments/allocationExchange.test.ts
@@ -123,7 +123,7 @@ describe('AllocationExchange', () => {
     it('reject set an authority if not allowed', async function () {
       const newAuthority = randomAddress()
       const tx = allocationExchange.connect(indexer.signer).setAuthority(newAuthority)
-      await expect(tx).revertedWith(' Only Governor can call')
+      await expect(tx).revertedWith('Only Governor can call')
     })
 
     it('reject set an empty authority', async function () {

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -498,8 +498,8 @@ describe('Rewards', () => {
 
     describe('takeRewards', function () {
       interface DelegationParameters {
-        indexingRewardCut: BigNumber
-        queryFeeCut: BigNumber
+        indexRewardsCut: BigNumber
+        queryRewardsCut: BigNumber
         cooldownBlocks: number
       }
 
@@ -543,8 +543,8 @@ describe('Rewards', () => {
         await staking
           .connect(indexer1.signer)
           .setDelegationParameters(
-            delegationParams.indexingRewardCut,
-            delegationParams.queryFeeCut,
+            delegationParams.indexRewardsCut,
+            delegationParams.queryRewardsCut,
             delegationParams.cooldownBlocks,
           )
 
@@ -667,8 +667,8 @@ describe('Rewards', () => {
       it('should distribute rewards on closed allocation w/delegators', async function () {
         // Setup
         const delegationParams = {
-          indexingRewardCut: toBN('823000'), // 82.30%
-          queryFeeCut: toBN('80000'), // 8%
+          indexRewardsCut: toBN('823000'), // 82.30%
+          queryRewardsCut: toBN('80000'), // 8%
           cooldownBlocks: 5,
         }
         const tokensToDelegate = toGRT('2000')
@@ -697,8 +697,8 @@ describe('Rewards', () => {
         const expectedIndexingRewards = toGRT('1454109066')
         // Calculate delegators cut
         const indexerDelegationRatio = tokensToDelegate.mul(MAX_PPM).div(beforeIndexer1Stake)
-        const delegatorsRewardsCut = delegationParams.indexingRewardCut.sub(
-          delegationParams.indexingRewardCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
+        const delegatorsRewardsCut = delegationParams.indexRewardsCut.sub(
+          delegationParams.indexRewardsCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
         )
         const delegatorsRewards = percentageOf(delegatorsRewardsCut, expectedIndexingRewards)
 

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -16,6 +16,7 @@ import {
   toGRT,
   Account,
   MAX_PPM,
+  getDelegatorRewardsCut,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
@@ -165,6 +166,7 @@ describe('Staking:Allocation', () => {
     const shouldAllocate = async (tokensToAllocate: BigNumber) => {
       // Before state
       const beforeStake = await staking.stakes(indexer.address)
+      const beforeDelegationPool = await staking.delegationPools(indexer.address)
 
       // Allocate
       const currentEpoch = await epochManager.currentEpoch()
@@ -194,6 +196,20 @@ describe('Staking:Allocation', () => {
       expect(afterAlloc.collectedFees).eq(toGRT('0'))
       expect(afterAlloc.closedAtEpoch).eq(toBN('0'))
       expect(afterAlloc.effectiveAllocation).eq(toGRT('0'))
+      expect(afterAlloc.delegatorIndexRewardsCut).eq(
+        getDelegatorRewardsCut(
+          beforeDelegationPool.tokens,
+          beforeStake.tokensStaked,
+          BigNumber.from(beforeDelegationPool.indexRewardsCut),
+        ),
+      )
+      expect(afterAlloc.delegatorQueryRewardsCut).eq(
+        getDelegatorRewardsCut(
+          beforeDelegationPool.tokens,
+          beforeStake.tokensStaked,
+          BigNumber.from(beforeDelegationPool.queryRewardsCut),
+        ),
+      )
     }
 
     it('reject allocate zero tokens', async function () {

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -15,11 +15,10 @@ import {
   toBN,
   toGRT,
   Account,
+  MAX_PPM,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
-
-const MAX_PPM = toBN('1000000')
 
 enum AllocationState {
   Null,

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -16,7 +16,7 @@ import {
   toGRT,
   Account,
   MAX_PPM,
-  getDelegatorRewardsCut,
+  getDelegatorTotalRewardsCut,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
@@ -196,15 +196,15 @@ describe('Staking:Allocation', () => {
       expect(afterAlloc.collectedFees).eq(toGRT('0'))
       expect(afterAlloc.closedAtEpoch).eq(toBN('0'))
       expect(afterAlloc.effectiveAllocation).eq(toGRT('0'))
-      expect(afterAlloc.delegatorIndexRewardsCut).eq(
-        getDelegatorRewardsCut(
+      expect(afterAlloc.delegatorTotalIndexRewardsCut).eq(
+        getDelegatorTotalRewardsCut(
           beforeDelegationPool.tokens,
           beforeStake.tokensStaked,
           BigNumber.from(beforeDelegationPool.indexRewardsCut),
         ),
       )
-      expect(afterAlloc.delegatorQueryRewardsCut).eq(
-        getDelegatorRewardsCut(
+      expect(afterAlloc.delegatorTotalQueryRewardsCut).eq(
+        getDelegatorTotalRewardsCut(
           beforeDelegationPool.tokens,
           beforeStake.tokensStaked,
           BigNumber.from(beforeDelegationPool.queryRewardsCut),

--- a/test/staking/configuration.test.ts
+++ b/test/staking/configuration.test.ts
@@ -5,11 +5,9 @@ import { Staking } from '../../build/types/Staking'
 
 import { defaults } from '../lib/deployment'
 import { NetworkFixture } from '../lib/fixtures'
-import { getAccounts, toBN, toGRT, Account } from '../lib/testHelpers'
+import { getAccounts, toBN, toGRT, Account, MAX_PPM } from '../lib/testHelpers'
 
 const { AddressZero } = constants
-
-const MAX_PPM = toBN('1000000')
 
 describe('Staking:Config', () => {
   let me: Account

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -18,6 +18,7 @@ import {
   advanceBlock,
   percentageOf,
   MAX_PPM,
+  getDelegatorRewardsCut,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
@@ -626,9 +627,10 @@ describe('Staking::Delegation', () => {
 
       // Calculate tokens to claim and expected delegation fees
       const beforeAlloc = await staking.getAllocation(allocationID)
-      const indexerDelegationRatio = tokensToDelegate.mul(MAX_PPM).div(tokensToStake)
-      const delegatorsRewardsCut = queryRewardsCut.sub(
-        queryRewardsCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
+      const delegatorsRewardsCut = getDelegatorRewardsCut(
+        tokensToDelegate,
+        tokensToStake,
+        queryRewardsCut,
       )
       const delegationFees = percentageOf(delegatorsRewardsCut, beforeAlloc.collectedFees)
       const tokensToClaim = beforeAlloc.collectedFees.sub(delegationFees)

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -257,20 +257,20 @@ describe('Staking::Delegation', () => {
     })
 
     describe('delegationParameters', function () {
-      const indexingRewardCut = toBN('50000')
-      const queryFeeCut = toBN('80000')
+      const indexRewardsCut = toBN('50000')
+      const queryRewardsCut = toBN('80000')
       const cooldownBlocks = 5
 
       it('reject to set if under cooldown period', async function () {
         // Set parameters
         await staking
           .connect(indexer.signer)
-          .setDelegationParameters(indexingRewardCut, queryFeeCut, cooldownBlocks)
+          .setDelegationParameters(indexRewardsCut, queryRewardsCut, cooldownBlocks)
 
         // Try to set before cooldown period passed
         const tx = staking
           .connect(indexer.signer)
-          .setDelegationParameters(indexingRewardCut, queryFeeCut, cooldownBlocks)
+          .setDelegationParameters(indexRewardsCut, queryRewardsCut, cooldownBlocks)
         await expect(tx).revertedWith('!cooldown')
       })
 
@@ -281,7 +281,7 @@ describe('Staking::Delegation', () => {
         // Try to set delegation cooldown below global cooldown parameter
         const tx = staking
           .connect(indexer.signer)
-          .setDelegationParameters(indexingRewardCut, queryFeeCut, cooldownBlocks - 1)
+          .setDelegationParameters(indexRewardsCut, queryRewardsCut, cooldownBlocks - 1)
         await expect(tx).revertedWith('<cooldown')
       })
 
@@ -289,29 +289,29 @@ describe('Staking::Delegation', () => {
         // Indexing reward out of bounds
         const tx1 = staking
           .connect(indexer.signer)
-          .setDelegationParameters(MAX_PPM.add('1'), queryFeeCut, cooldownBlocks)
-        await expect(tx1).revertedWith('>indexingRewardCut')
+          .setDelegationParameters(MAX_PPM.add('1'), queryRewardsCut, cooldownBlocks)
+        await expect(tx1).revertedWith('>indexRewardsCut')
 
         // Query fee out of bounds
         const tx2 = staking
           .connect(indexer.signer)
-          .setDelegationParameters(indexingRewardCut, MAX_PPM.add('1'), cooldownBlocks)
-        await expect(tx2).revertedWith('>queryFeeCut')
+          .setDelegationParameters(indexRewardsCut, MAX_PPM.add('1'), cooldownBlocks)
+        await expect(tx2).revertedWith('>queryRewardsCut')
       })
 
       it('should set parameters', async function () {
         // Set parameters
         const tx = staking
           .connect(indexer.signer)
-          .setDelegationParameters(indexingRewardCut, queryFeeCut, cooldownBlocks)
+          .setDelegationParameters(indexRewardsCut, queryRewardsCut, cooldownBlocks)
         await expect(tx)
           .emit(staking, 'DelegationParametersUpdated')
-          .withArgs(indexer.address, indexingRewardCut, queryFeeCut, cooldownBlocks)
+          .withArgs(indexer.address, indexRewardsCut, queryRewardsCut, cooldownBlocks)
 
         // State updated
         const params = await staking.delegationPools(indexer.address)
-        expect(params.indexingRewardCut).eq(indexingRewardCut)
-        expect(params.queryFeeCut).eq(queryFeeCut)
+        expect(params.indexRewardsCut).eq(indexRewardsCut)
+        expect(params.queryRewardsCut).eq(queryRewardsCut)
         expect(params.cooldownBlocks).eq(cooldownBlocks)
         expect(params.updatedAtBlock).eq(await latestBlock())
       })
@@ -319,8 +319,8 @@ describe('Staking::Delegation', () => {
       it('should init delegation parameters on first stake', async function () {
         // Before
         const beforeParams = await staking.delegationPools(indexer.address)
-        expect(beforeParams.indexingRewardCut).eq(0)
-        expect(beforeParams.queryFeeCut).eq(0)
+        expect(beforeParams.indexRewardsCut).eq(0)
+        expect(beforeParams.queryRewardsCut).eq(0)
         expect(beforeParams.cooldownBlocks).eq(0)
         expect(beforeParams.updatedAtBlock).eq(0)
 
@@ -332,8 +332,8 @@ describe('Staking::Delegation', () => {
 
         // State updated
         const afterParams = await staking.delegationPools(indexer.address)
-        expect(afterParams.indexingRewardCut).eq(MAX_PPM)
-        expect(afterParams.queryFeeCut).eq(MAX_PPM)
+        expect(afterParams.indexRewardsCut).eq(MAX_PPM)
+        expect(afterParams.queryRewardsCut).eq(MAX_PPM)
         expect(afterParams.cooldownBlocks).eq(0)
         expect(afterParams.updatedAtBlock).eq(await latestBlock())
       })
@@ -341,8 +341,8 @@ describe('Staking::Delegation', () => {
       it('should init delegation parameters on first stake using stakeTo()', async function () {
         // Before
         const beforeParams = await staking.delegationPools(indexer.address)
-        expect(beforeParams.indexingRewardCut).eq(0)
-        expect(beforeParams.queryFeeCut).eq(0)
+        expect(beforeParams.indexRewardsCut).eq(0)
+        expect(beforeParams.queryRewardsCut).eq(0)
         expect(beforeParams.cooldownBlocks).eq(0)
         expect(beforeParams.updatedAtBlock).eq(0)
 
@@ -354,8 +354,8 @@ describe('Staking::Delegation', () => {
 
         // State updated
         const afterParams = await staking.delegationPools(indexer.address)
-        expect(afterParams.indexingRewardCut).eq(MAX_PPM)
-        expect(afterParams.queryFeeCut).eq(MAX_PPM)
+        expect(afterParams.indexRewardsCut).eq(MAX_PPM)
+        expect(afterParams.queryRewardsCut).eq(MAX_PPM)
         expect(afterParams.cooldownBlocks).eq(0)
         expect(afterParams.updatedAtBlock).eq(await latestBlock())
       })
@@ -596,12 +596,12 @@ describe('Staking::Delegation', () => {
       await staking.connect(governor.signer).setDelegationRatio(10)
 
       // Set delegation rules for the indexer
-      const indexingRewardCut = toBN('800000') // indexer keep 80%
-      const queryFeeCut = toBN('950000') // indexer keeps 95%
+      const indexRewardsCut = toBN('800000') // indexer keep 80%
+      const queryRewardsCut = toBN('950000') // indexer keeps 95%
       const cooldownBlocks = 5
       await staking
         .connect(indexer.signer)
-        .setDelegationParameters(indexingRewardCut, queryFeeCut, cooldownBlocks)
+        .setDelegationParameters(indexRewardsCut, queryRewardsCut, cooldownBlocks)
 
       // Delegate
       await staking.connect(delegator.signer).delegate(indexer.address, tokensToDelegate)
@@ -627,8 +627,8 @@ describe('Staking::Delegation', () => {
       // Calculate tokens to claim and expected delegation fees
       const beforeAlloc = await staking.getAllocation(allocationID)
       const indexerDelegationRatio = tokensToDelegate.mul(MAX_PPM).div(tokensToStake)
-      const delegatorsRewardsCut = queryFeeCut.sub(
-        queryFeeCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
+      const delegatorsRewardsCut = queryRewardsCut.sub(
+        queryRewardsCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
       )
       const delegationFees = percentageOf(delegatorsRewardsCut, beforeAlloc.collectedFees)
       const tokensToClaim = beforeAlloc.collectedFees.sub(delegationFees)

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -16,11 +16,11 @@ import {
   toBN,
   Account,
   advanceBlock,
+  percentageOf,
+  MAX_PPM,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
-const MAX_PPM = toBN('1000000')
-const percentageOf = (ppm: BigNumber, value): BigNumber => value.sub(ppm.mul(value).div(MAX_PPM))
 
 describe('Staking::Delegation', () => {
   let me: Account
@@ -626,7 +626,11 @@ describe('Staking::Delegation', () => {
 
       // Calculate tokens to claim and expected delegation fees
       const beforeAlloc = await staking.getAllocation(allocationID)
-      const delegationFees = percentageOf(queryFeeCut, beforeAlloc.collectedFees)
+      const indexerDelegationRatio = tokensToDelegate.mul(MAX_PPM).div(tokensToStake)
+      const delegatorsRewardsCut = queryFeeCut.sub(
+        queryFeeCut.mul(MAX_PPM).div(MAX_PPM.add(indexerDelegationRatio)),
+      )
+      const delegationFees = percentageOf(delegatorsRewardsCut, beforeAlloc.collectedFees)
       const tokensToClaim = beforeAlloc.collectedFees.sub(delegationFees)
 
       // Claim from rebate pool

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -18,7 +18,7 @@ import {
   advanceBlock,
   percentageOf,
   MAX_PPM,
-  getDelegatorRewardsCut,
+  getDelegatorTotalRewardsCut,
 } from '../lib/testHelpers'
 
 const { AddressZero, HashZero } = constants
@@ -597,7 +597,7 @@ describe('Staking::Delegation', () => {
       await staking.connect(governor.signer).setDelegationRatio(10)
 
       // Set delegation rules for the indexer
-      const indexRewardsCut = toBN('800000') // indexer keep 80%
+      const indexRewardsCut = toBN('800000') // indexer keeps 80%
       const queryRewardsCut = toBN('950000') // indexer keeps 95%
       const cooldownBlocks = 5
       await staking
@@ -627,12 +627,12 @@ describe('Staking::Delegation', () => {
 
       // Calculate tokens to claim and expected delegation fees
       const beforeAlloc = await staking.getAllocation(allocationID)
-      const delegatorsRewardsCut = getDelegatorRewardsCut(
+      const delegatorsTotalRewardsCut = getDelegatorTotalRewardsCut(
         tokensToDelegate,
         tokensToStake,
         queryRewardsCut,
       )
-      const delegationFees = percentageOf(delegatorsRewardsCut, beforeAlloc.collectedFees)
+      const delegationFees = percentageOf(delegatorsTotalRewardsCut, beforeAlloc.collectedFees)
       const tokensToClaim = beforeAlloc.collectedFees.sub(delegationFees)
 
       // Claim from rebate pool

--- a/test/utils/math-utils.test.ts
+++ b/test/utils/math-utils.test.ts
@@ -1,10 +1,18 @@
 import { expect } from 'chai'
-import { constants, BigNumber } from 'ethers'
+import { BigNumber } from 'ethers'
 
 import { MathUtilsMock } from '../../build/types/MathUtilsMock'
 
 import * as deployment from '../lib/deployment'
-import { getAccounts, toGRT, Account, MAX_PPM, totalRatio } from '../lib/testHelpers'
+import {
+  getAccounts,
+  toGRT,
+  Account,
+  MAX_PPM,
+  totalRatio,
+  percentageOf,
+  formatGRT,
+} from '../lib/testHelpers'
 
 describe('MathUtils', () => {
   let me: Account
@@ -65,5 +73,29 @@ describe('MathUtils', () => {
       const c = await mathUtils.totalRatio(a, b)
       expect(c).eq(MAX_PPM)
     })
+  })
+
+  describe('percentage', () => {
+    const percentTests: BigNumber[] = [
+      0,
+      1,
+      2,
+      1e6 * 0.1,
+      1e6 * 0.25,
+      1e6 * 0.5,
+      1e6 * 0.75,
+      1e6 * 0.9,
+      1e6 * 1.0,
+    ].map((e) => BigNumber.from(e))
+    const valueTests: BigNumber[] = [1, 2, 3, toGRT(5000)].map((e) => BigNumber.from(e))
+
+    for (const percent of percentTests) {
+      for (const value of valueTests) {
+        it(`${(percent.toNumber() / 1e6) * 100}% of ${formatGRT(value)} GRT`, async function () {
+          const c = (await mathUtils.percentOf(percent, value)) as BigNumber
+          expect(c).eq(percentageOf(percent, value))
+        })
+      }
+    }
   })
 })

--- a/test/utils/math-utils.test.ts
+++ b/test/utils/math-utils.test.ts
@@ -86,6 +86,7 @@ describe('MathUtils', () => {
       1e6 * 0.75,
       1e6 * 0.9,
       1e6 * 1.0,
+      1e6 * 1.1,
     ].map((e) => BigNumber.from(e))
     const valueTests: BigNumber[] = [1, 2, 3, toGRT(5000)].map((e) => BigNumber.from(e))
 

--- a/test/utils/math-utils.test.ts
+++ b/test/utils/math-utils.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai'
+import { constants, BigNumber } from 'ethers'
+
+import { MathUtilsMock } from '../../build/types/MathUtilsMock'
+
+import * as deployment from '../lib/deployment'
+import { getAccounts, toGRT, Account, MAX_PPM, totalRatio } from '../lib/testHelpers'
+
+describe('MathUtils', () => {
+  let me: Account
+
+  let mathUtils: MathUtilsMock
+
+  beforeEach(async function () {
+    ;[me] = await getAccounts()
+    mathUtils = (await deployment.deployContract('MathUtilsMock', me.signer)) as MathUtilsMock
+  })
+
+  describe('ratio', () => {
+    it('a = b', async function () {
+      const a = toGRT('1')
+      const b = toGRT('1')
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(totalRatio(a, b))
+    })
+
+    it('a > b', async function () {
+      const a = toGRT('1000')
+      const b = toGRT('1')
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(totalRatio(a, b))
+    })
+
+    it('a < b', async function () {
+      const a = toGRT('1')
+      const b = toGRT('1000')
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(totalRatio(a, b))
+    })
+
+    it('edge a < b', async function () {
+      const a = 1
+      const b = toGRT('1000')
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(0) // not enough precision
+    })
+
+    it('edge a > b', async function () {
+      const a = toGRT('1000')
+      const b = 1
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(totalRatio(a, BigNumber.from(b)))
+    })
+
+    it('edge a=0 b=~', async function () {
+      const a = 0
+      const b = toGRT('1000')
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(0)
+    })
+
+    it('edge a=~ b=0', async function () {
+      const a = toGRT('1000')
+      const b = 0
+      const c = await mathUtils.totalRatio(a, b)
+      expect(c).eq(MAX_PPM)
+    })
+  })
+})


### PR DESCRIPTION
### Summary

New delegations and undelegations dramatically change the staking income for indexers and validators unless the cut rate is regularly adjusted.

Why is this happening? Staking income for the indexer and delegators is pooled before the Indexer cut is calculated.

This PR is inspired by https://forum.thegraph.com/t/proposal-to-change-the-indexer-cut-mechanism/1422

### Solution

Distribute any new rewards based on the delegation to total-stake ratio at the moment the allocation was created. In addition, the indexer cut will be defined as the share of delegator rewards the indexer gets.

**Example:**
If you delegate to an indexer with a ‘rewards cut’ and ‘fee cut’ of 10%, it means you will get 90% of whatever your staked GRT earns and your indexer will get the other 10%. If you run an indexer, you will earn your pro-rata staking income in full and a 10% commission on your delegators’ staking income.

### Features

- Save the delegators rewards cut at the moment when the allocation is created. This avoids any manipulation of the cuts before closing an allocation. This means changing the allocation struct.
- Calculate the`indexerDelegationRatio` as the ratio of delegation to total stake for a particular indexer.
- Rename some delegation pool variables to make them clearer.
- Improve comments.
- Use a single function to collect any delegators rewards.

