### PR TITLE
Add multicall to staking contract

### DIFF
--- a/cli/commands/contracts/staking.ts
+++ b/cli/commands/contracts/staking.ts
@@ -36,7 +36,8 @@ export const allocate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   const staking = cli.contracts.Staking
 
   logger.info(`Allocating ${cliArgs.amount} tokens on ${subgraphDeploymentID}...`)
-  await sendTransaction(cli.wallet, staking, 'allocate', [
+  await sendTransaction(cli.wallet, staking, 'allocateFrom', [
+    cli.walletAddress,
     subgraphDeploymentID,
     amount,
     allocationID,

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -113,24 +113,9 @@ interface IStaking is IStakingData {
 
     function closeAllocation(address _allocationID, bytes32 _poi) external;
 
-    function closeAllocationMany(CloseAllocationRequest[] calldata _requests) external;
-
-    function closeAndAllocate(
-        address _oldAllocationID,
-        bytes32 _poi,
-        address _indexer,
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokens,
-        address _allocationID,
-        bytes32 _metadata,
-        bytes calldata _proof
-    ) external;
-
     function collect(uint256 _tokens, address _allocationID) external;
 
     function claim(address _allocationID, bool _restake) external;
-
-    function claimMany(address[] calldata _allocationID, bool _restake) external;
 
     // -- Getters and calculations --
 

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -94,14 +94,6 @@ interface IStaking is IStakingData {
 
     // -- Channel management and allocations --
 
-    function allocate(
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokens,
-        address _allocationID,
-        bytes32 _metadata,
-        bytes calldata _proof
-    ) external;
-
     function allocateFrom(
         address _indexer,
         bytes32 _subgraphDeploymentID,

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 
+import "../base/Multicall.sol";
 import "../upgrades/GraphUpgradeable.sol";
 import "../utils/TokenUtils.sol";
 
@@ -20,7 +21,7 @@ import "./libs/Stakes.sol";
  * Allocations on a Subgraph. It also allows Delegators to Delegate towards an Indexer. The
  * contract also has the slashing functionality.
  */
-contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
+contract Staking is StakingV2Storage, GraphUpgradeable, IStaking, Multicall {
     using SafeMath for uint256;
     using Stakes for Stakes.Indexer;
     using Rebates for Rebates.Pool;
@@ -909,49 +910,6 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
     }
 
     /**
-     * @dev Close multiple allocations and free the staked tokens.
-     * To be eligible for rewards a proof of indexing must be presented.
-     * Presenting a bad proof is subject to slashable condition.
-     * To opt out for rewards set _poi to 0x0
-     * @param _requests An array of CloseAllocationRequest
-     */
-    function closeAllocationMany(CloseAllocationRequest[] calldata _requests)
-        external
-        override
-        notPaused
-    {
-        for (uint256 i = 0; i < _requests.length; i++) {
-            _closeAllocation(_requests[i].allocationID, _requests[i].poi);
-        }
-    }
-
-    /**
-     * @dev Close and allocate. This will perform a close and then create a new Allocation
-     * atomically on the same transaction.
-     * @param _closingAllocationID The identifier of the allocation to be closed
-     * @param _poi Proof of indexing submitted for the allocated period
-     * @param _indexer Indexer address to allocate funds from.
-     * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
-     * @param _tokens Amount of tokens to allocate
-     * @param _allocationID The allocation identifier
-     * @param _metadata IPFS hash for additional information about the allocation
-     * @param _proof A 65-bytes Ethereum signed message of `keccak256(indexerAddress,allocationID)`
-     */
-    function closeAndAllocate(
-        address _closingAllocationID,
-        bytes32 _poi,
-        address _indexer,
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokens,
-        address _allocationID,
-        bytes32 _metadata,
-        bytes calldata _proof
-    ) external override notPaused {
-        _closeAllocation(_closingAllocationID, _poi);
-        _allocate(_indexer, _subgraphDeploymentID, _tokens, _allocationID, _metadata, _proof);
-    }
-
-    /**
      * @dev Collect query fees from state channels and assign them to an allocation.
      * Funds received are only accepted from a valid sender.
      * To avoid reverting on the withdrawal from channel flow this function will:
@@ -1034,21 +992,6 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      */
     function claim(address _allocationID, bool _restake) external override notPaused {
         _claim(_allocationID, _restake);
-    }
-
-    /**
-     * @dev Claim tokens from the rebate pool for many allocations.
-     * @param _allocationID Array of allocations from where we are claiming tokens
-     * @param _restake True if restake fees instead of transfer to indexer
-     */
-    function claimMany(address[] calldata _allocationID, bool _restake)
-        external
-        override
-        notPaused
-    {
-        for (uint256 i = 0; i < _allocationID.length; i++) {
-            _claim(_allocationID[i], _restake);
-        }
     }
 
     /**

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -861,24 +861,6 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking, Multicall {
 
     /**
      * @dev Allocate available tokens to a subgraph deployment.
-     * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
-     * @param _tokens Amount of tokens to allocate
-     * @param _allocationID The allocation identifier
-     * @param _metadata IPFS hash for additional information about the allocation
-     * @param _proof A 65-bytes Ethereum signed message of `keccak256(indexerAddress,allocationID)`
-     */
-    function allocate(
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokens,
-        address _allocationID,
-        bytes32 _metadata,
-        bytes calldata _proof
-    ) external override notPaused {
-        _allocate(msg.sender, _subgraphDeploymentID, _tokens, _allocationID, _metadata, _proof);
-    }
-
-    /**
-     * @dev Allocate available tokens to a subgraph deployment.
      * @param _indexer Indexer address to allocate funds from.
      * @param _subgraphDeploymentID ID of the SubgraphDeployment where tokens will be allocated
      * @param _tokens Amount of tokens to allocate

--- a/test/disputes/poi.test.ts
+++ b/test/disputes/poi.test.ts
@@ -79,7 +79,8 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(indexerAccount.signer).stake(indexerTokens)
       await staking
         .connect(indexerAccount.signer)
-        .allocate(
+        .allocateFrom(
+          indexerAccount.address,
           subgraphDeploymentID,
           indexerAllocatedTokens,
           allocationID,
@@ -147,7 +148,8 @@ describe('DisputeManager:POI', async () => {
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
-        .allocate(
+        .allocateFrom(
+          indexer.address,
           subgraphDeploymentID,
           indexerAllocatedTokens,
           allocationID,

--- a/test/disputes/query.test.ts
+++ b/test/disputes/query.test.ts
@@ -113,7 +113,8 @@ describe('DisputeManager:Query', async () => {
       await staking.connect(indexerAccount.signer).stake(indexerTokens)
       await staking
         .connect(indexerAccount.signer)
-        .allocate(
+        .allocateFrom(
+          indexerAccount.address,
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
           allocationID,
@@ -194,7 +195,8 @@ describe('DisputeManager:Query', async () => {
       await staking.connect(indexer.signer).stake(indexerTokens)
       const tx1 = await staking
         .connect(indexer.signer)
-        .allocate(
+        .allocateFrom(
+          indexer.address,
           dispute.receipt.subgraphDeploymentID,
           indexerAllocatedTokens,
           indexer1ChannelKey.address,

--- a/test/payments/allocationExchange.test.ts
+++ b/test/payments/allocationExchange.test.ts
@@ -102,7 +102,8 @@ describe('AllocationExchange', () => {
     await staking.connect(indexer.signer).stake(stakeTokens)
     await staking
       .connect(indexer.signer)
-      .allocate(
+      .allocateFrom(
+        indexer.address,
         subgraphDeploymentID,
         stakeTokens,
         allocationID,

--- a/test/payments/withdrawHelper.test.ts
+++ b/test/payments/withdrawHelper.test.ts
@@ -86,7 +86,8 @@ describe('WithdrawHelper', () => {
       await staking.connect(indexer.signer).stake(stakeTokens)
       await staking
         .connect(indexer.signer)
-        .allocate(
+        .allocateFrom(
+          indexer.address,
           subgraphDeploymentID,
           stakeTokens,
           allocationID,

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -391,7 +391,8 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(
+          .allocateFrom(
+            indexer1.address,
             subgraphDeploymentID1,
             tokensToAllocate,
             allocationID,
@@ -428,7 +429,8 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(
+          .allocateFrom(
+            indexer1.address,
             subgraphDeploymentID1,
             tokensToAllocate,
             allocationID,
@@ -471,7 +473,8 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(
+          .allocateFrom(
+            indexer1.address,
             subgraphDeploymentID1,
             tokensToAllocate,
             allocationID,
@@ -516,7 +519,8 @@ describe('Rewards', () => {
         await staking.connect(indexer1.signer).stake(tokensToAllocate)
         await staking
           .connect(indexer1.signer)
-          .allocate(
+          .allocateFrom(
+            indexer1.address,
             subgraphDeploymentID1,
             tokensToAllocate,
             allocationID,
@@ -558,7 +562,8 @@ describe('Rewards', () => {
         // Allocate
         await staking
           .connect(indexer1.signer)
-          .allocate(
+          .allocateFrom(
+            indexer1.address,
             subgraphDeploymentID1,
             tokensToAllocate,
             allocationID,
@@ -754,7 +759,8 @@ describe('Rewards', () => {
       await staking.connect(indexer1.signer).stake(tokensToAllocate)
       await staking
         .connect(indexer1.signer)
-        .allocate(
+        .allocateFrom(
+          indexer1.address,
           subgraphDeploymentID1,
           tokensToAllocate,
           allocationID,

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { constants, BigNumber } from 'ethers'
+import { constants, BigNumber, PopulatedTransaction } from 'ethers'
 
 import { Curation } from '../../build/types/Curation'
 import { EpochManager } from '../../build/types/EpochManager'
@@ -644,17 +644,21 @@ describe('Staking:Allocation', () => {
       await advanceToNextEpoch(epochManager)
 
       // Close multiple allocations in one tx
-      const requests = [
-        {
-          allocationID: allocationID,
-          poi: poi,
-        },
-        {
-          allocationID: allocationID2,
-          poi: poi,
-        },
-      ]
-      await staking.connect(indexer.signer).closeAllocationMany(requests)
+      const requests = await Promise.all(
+        [
+          {
+            allocationID: allocationID,
+            poi: poi,
+          },
+          {
+            allocationID: allocationID2,
+            poi: poi,
+          },
+        ].map(({ allocationID, poi }) =>
+          staking.connect(indexer.signer).populateTransaction.closeAllocation(allocationID, poi),
+        ),
+      ).then((e) => e.map((e: PopulatedTransaction) => e.data))
+      await staking.connect(indexer.signer).multicall(requests)
     })
   })
 
@@ -672,19 +676,21 @@ describe('Staking:Allocation', () => {
       // Close and allocate
       const newChannelKey = deriveChannelKey()
       const newAllocationID = newChannelKey.address
-      const tx = staking
-        .connect(indexer.signer)
-        .closeAndAllocate(
-          allocationID,
-          HashZero,
-          indexer.address,
-          subgraphDeploymentID,
-          tokensToAllocate,
-          newAllocationID,
-          metadata,
-          await newChannelKey.generateProof(indexer.address),
-        )
-      await tx
+
+      // Close multiple allocations in one tx
+      const requests = await Promise.all([
+        staking.connect(indexer.signer).populateTransaction.closeAllocation(allocationID, poi),
+        staking
+          .connect(indexer.signer)
+          .populateTransaction.allocate(
+            subgraphDeploymentID,
+            tokensToAllocate,
+            newAllocationID,
+            metadata,
+            await newChannelKey.generateProof(indexer.address),
+          ),
+      ]).then((e) => e.map((e: PopulatedTransaction) => e.data))
+      await staking.connect(indexer.signer).multicall(requests)
     })
   })
 
@@ -870,7 +876,10 @@ describe('Staking:Allocation', () => {
 
         // Claim with restake
         expect(await staking.getAllocationState(allocationID)).eq(AllocationState.Finalized)
-        await staking.connect(indexer.signer).claimMany([allocationID], true)
+        const tx = await staking
+          .connect(indexer.signer)
+          .populateTransaction.claim(allocationID, true)
+        await staking.connect(indexer.signer).multicall([tx.data])
 
         // Verify that the claimed tokens are restaked
         const afterIndexerStake = await staking.getIndexerStakedTokens(indexer.address)

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -67,7 +67,8 @@ describe('Staking:Allocation', () => {
   const allocate = async (tokens: BigNumber) => {
     return staking
       .connect(indexer.signer)
-      .allocate(
+      .allocateFrom(
+        indexer.address,
         subgraphDeploymentID,
         tokens,
         allocationID,
@@ -206,7 +207,14 @@ describe('Staking:Allocation', () => {
     it('reject allocate with invalid allocationID', async function () {
       const tx = staking
         .connect(indexer.signer)
-        .allocate(subgraphDeploymentID, tokensToAllocate, AddressZero, metadata, randomHexBytes(20))
+        .allocateFrom(
+          indexer.address,
+          subgraphDeploymentID,
+          tokensToAllocate,
+          AddressZero,
+          metadata,
+          randomHexBytes(20),
+        )
       await expect(tx).revertedWith('!alloc')
     })
 
@@ -273,7 +281,8 @@ describe('Staking:Allocation', () => {
           const invalidProof = await channelKey.generateProof(randomHexBytes(20))
           const tx = staking
             .connect(indexer.signer)
-            .allocate(
+            .allocateFrom(
+              indexer.address,
               subgraphDeploymentID,
               tokensToAllocate,
               indexer.address,
@@ -286,7 +295,8 @@ describe('Staking:Allocation', () => {
         it('invalid proof signature format', async function () {
           const tx = staking
             .connect(indexer.signer)
-            .allocate(
+            .allocateFrom(
+              indexer.address,
               subgraphDeploymentID,
               tokensToAllocate,
               indexer.address,
@@ -631,7 +641,8 @@ describe('Staking:Allocation', () => {
       const allocationID2 = channelKey2.address
       await staking
         .connect(indexer.signer)
-        .allocate(
+        .allocateFrom(
+          indexer.address,
           subgraphDeploymentID,
           tokensToAllocate,
           allocationID2,
@@ -682,7 +693,8 @@ describe('Staking:Allocation', () => {
         staking.connect(indexer.signer).populateTransaction.closeAllocation(allocationID, poi),
         staking
           .connect(indexer.signer)
-          .populateTransaction.allocate(
+          .populateTransaction.allocateFrom(
+            indexer.address,
             subgraphDeploymentID,
             tokensToAllocate,
             newAllocationID,

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -534,7 +534,8 @@ describe('Staking::Delegation', () => {
     const setupAllocation = async (tokens: BigNumber) => {
       return staking
         .connect(indexer.signer)
-        .allocate(
+        .allocateFrom(
+          indexer.address,
           subgraphDeploymentID,
           tokens,
           allocationID,

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -53,7 +53,8 @@ describe('Staking:Stakes', () => {
   const allocate = async (tokens: BigNumber) => {
     return staking
       .connect(indexer.signer)
-      .allocate(
+      .allocateFrom(
+        indexer.address,
         subgraphDeploymentID,
         tokens,
         allocationID,


### PR DESCRIPTION
### Summary

Expose a way to batch multiple calls into a single transaction. It provides great flexibility for indexer agents to combine multiple functions in different ways. It also reduce the gas cost by saving the initial gas, and in some cases, accessing a "used" slot by the other bundled transactions.

### Solution

By using a multicall a user can batch an arbitrary number of operations into a single transaction.

### Breaking

This implementation removes the following functions from the interface to save contract bytecode. They can be now used through a multicall.

- closeAllocationMany()
- closeAndAllocate()
- claimMany()
- allocate() `since allocateFrom() already covers this use case and it's not currently used in production`