### PR TITLE
Remove bonding curve external call at the GNS level

### DIFF
--- a/contracts/discovery/GNSStorage.sol
+++ b/contracts/discovery/GNSStorage.sol
@@ -15,8 +15,8 @@ contract GNSV1Storage is Managed {
     // In parts per hundred
     uint32 public ownerTaxPercentage;
 
-    // Bonding curve formula
-    address public bondingCurve;
+    // [DEPRECATED] Bonding curve formula
+    address private __DEPRECATED_bondingCurve;
 
     // graphAccountID => subgraphNumber => subgraphDeploymentID
     // subgraphNumber = A number associated to a graph accounts deployed subgraph. This

--- a/contracts/discovery/IGNS.sol
+++ b/contracts/discovery/IGNS.sol
@@ -10,7 +10,7 @@ interface IGNS {
         uint256 nSignal; // The token of the name curation bonding curve
         mapping(address => uint256) curatorNSignal;
         bytes32 subgraphDeploymentID;
-        uint32 reserveRatio;
+        uint32 __DEPRECATED_reserveRatio;
         bool disabled;
         uint256 withdrawableGRT;
     }

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -9,6 +9,8 @@ import { Curation } from '../build/types/Curation'
 
 import { toBN, formatGRT } from './lib/testHelpers'
 
+const MAX_RESERVE_RATIO = 1000000
+
 interface Subgraph {
   graphAccount: Account
   subgraphDeploymentID: string
@@ -153,10 +155,6 @@ describe('GNS', () => {
         subgraphNumber,
         subgraphToPublish.subgraphMetadata,
       )
-
-    const pool = await gns.nameSignals(graphAccount, subgraphNumber)
-    const reserveRatio = pool[3]
-    expect(reserveRatio).eq(1000000)
     return tx
   }
 
@@ -895,7 +893,7 @@ describe('GNS', () => {
           const expectedNSignal = await calcGNSBondingCurve(
             poolOld.nSignal,
             poolOld.vSignal,
-            poolOld.reserveRatio,
+            MAX_RESERVE_RATIO,
             tokensToDeposit.sub(curationTax),
             poolOld.subgraphDeploymentID,
           )

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -175,13 +175,12 @@ export async function deployGNS(
 ): Promise<GNS> {
   // Dependency
   const didRegistry = await deployEthereumDIDRegistry(deployer)
-  const bondingCurve = (await deployContract('BancorFormula', deployer)) as unknown as BancorFormula
 
   // Deploy
   return network.deployContractWithProxy(
     proxyAdmin,
     'GNS',
-    [controller, bondingCurve.address, didRegistry.address],
+    [controller, didRegistry.address],
     deployer,
   ) as unknown as GNS
 }


### PR DESCRIPTION
### Summary

Saves an SSTORE of the reserve ratio in the namePool struct and avoids doing an external call to calculate shares conversion.