### PR TITLE
Allow unstake passing a larger amount than available

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -707,13 +707,16 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
 
     /**
      * @dev Unstake tokens from the indexer stake, lock them until thawing period expires.
+     * NOTE: The function accepts an amount greater than the currently staked tokens.
+     * If that happens, it will try to unstake the max amount of tokens it can.
+     * The reason for this behaviour is to avoid time conditions while the transaction
+     * is in flight.
      * @param _tokens Amount of tokens to unstake
      */
     function unstake(uint256 _tokens) external override notPartialPaused {
         address indexer = msg.sender;
         Stakes.Indexer storage indexerStake = stakes[indexer];
 
-        require(_tokens > 0, "!tokens");
         require(indexerStake.tokensStaked > 0, "!stake");
 
         // Tokens to lock is capped to the available tokens

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -282,7 +282,7 @@ describe('Staking:Stakes', () => {
 
       it('reject unstake zero tokens', async function () {
         const tx = staking.connect(indexer.signer).unstake(toGRT('0'))
-        await expect(tx).revertedWith('!tokens')
+        await expect(tx).revertedWith('!stake-avail')
       })
 
       it('reject unstake under the minimum indexer stake', async function () {

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -14,10 +14,11 @@ import {
   latestBlock,
   toBN,
   toGRT,
+  provider,
   Account,
 } from '../lib/testHelpers'
 
-const { AddressZero } = constants
+const { AddressZero, MaxUint256 } = constants
 
 function weightedAverage(
   valueA: BigNumber,
@@ -269,15 +270,19 @@ describe('Staking:Stakes', () => {
         expect(afterIndexerBalance).eq(beforeIndexerBalance.add(tokensToUnstake))
       })
 
+      it('should unstake available tokens even if passed a higher amount', async function () {
+        // Try to unstake a bit more than currently staked
+        const tokensOverCapacity = tokensToStake.add(toGRT('1'))
+        await staking.connect(indexer.signer).unstake(tokensOverCapacity)
+
+        // Check state
+        const tokensLocked = (await staking.stakes(indexer.address)).tokensLocked
+        expect(tokensLocked).eq(tokensToStake)
+      })
+
       it('reject unstake zero tokens', async function () {
         const tx = staking.connect(indexer.signer).unstake(toGRT('0'))
         await expect(tx).revertedWith('!tokens')
-      })
-
-      it('reject unstake more than available tokens', async function () {
-        const tokensOverCapacity = tokensToStake.add(toGRT('1'))
-        const tx = staking.connect(indexer.signer).unstake(tokensOverCapacity)
-        await expect(tx).revertedWith('!stake-avail')
       })
 
       it('reject unstake under the minimum indexer stake', async function () {
@@ -304,6 +309,28 @@ describe('Staking:Stakes', () => {
       it('should allow unstake of full amount', async function () {
         await staking.connect(indexer.signer).unstake(tokensToStake)
         expect(await staking.getIndexerCapacity(indexer.address)).eq(0)
+      })
+
+      it('should allow unstake of full amount with no upper limits', async function () {
+        // Use manual mining
+        await provider().send('evm_setAutomine', [false])
+
+        // Setup
+        const newTokens = toGRT('2')
+        const stakedTokens = await staking.getIndexerStakedTokens(indexer.address)
+        const tokensToUnstake = stakedTokens.add(newTokens)
+
+        // StakeTo & Unstake
+        await staking.connect(indexer.signer).stakeTo(indexer.address, newTokens)
+        await staking.connect(indexer.signer).unstake(MaxUint256)
+        await provider().send('evm_mine', [])
+
+        // Check state
+        const tokensLocked = (await staking.stakes(indexer.address)).tokensLocked
+        expect(tokensLocked).eq(tokensToUnstake)
+
+        // Restore automine
+        await provider().send('evm_setAutomine', [true])
       })
     })
 


### PR DESCRIPTION
### Description

When an indexer decides to unstake their stake completely there might be an opportunity to frontrun that operation through the `stakeTo()` function, making unstake to fail with stake under minimum tokens.

### Solution

Allow `unstake()` to accept a larger amount than the currently staked tokens. The function will try to unstake the passed amount capped to the available stake.
