### PR TITLE
Average delegation unbonding on multiple requests

### DIFF
--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -49,6 +49,6 @@ interface IStakingData {
     struct Delegation {
         uint256 shares; // Shares owned by a delegator in the pool
         uint256 tokensLocked; // Tokens locked for undelegation
-        uint256 tokensLockedUntil; // Block when locked tokens can be withdrawn
+        uint256 tokensLockedUntil; // Epoch when locked tokens can be withdrawn
     }
 }

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -8,6 +8,8 @@ import { EpochManager } from '../../build/types/EpochManager'
 
 const { hexlify, parseUnits, randomBytes } = utils
 
+// Conversion
+
 export const toBN = (value: string | number): BigNumber => BigNumber.from(value)
 export const toGRT = (value: string | number): BigNumber => {
   return parseUnits(typeof value === 'number' ? value.toString() : value, '18')
@@ -86,6 +88,24 @@ export const advanceToNextEpoch = async (epochManager: EpochManager): Promise<vo
 
 export const evmSnapshot = async (): Promise<number> => provider().send('evm_snapshot', [])
 export const evmRevert = async (id: number): Promise<boolean> => provider().send('evm_revert', [id])
+
+// Math
+
+export const MAX_PPM = toBN('1000000')
+
+export function weightedAverage(
+  valueA: BigNumber,
+  valueB: BigNumber,
+  weightA: BigNumber,
+  weightB: BigNumber,
+): BigNumber {
+  return valueA.mul(weightA).add(valueB.mul(weightB)).div(weightA.add(weightB))
+}
+
+export const percentageOf = (ppm: BigNumber, value: BigNumber): BigNumber =>
+  ppm.mul(value).div(MAX_PPM)
+
+export const diffOrZero = (a: BigNumber, b: BigNumber): BigNumber => (a.gt(b) ? a.sub(b) : toBN(0))
 
 // Allocation keys
 

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -14,19 +14,11 @@ import {
   latestBlock,
   toBN,
   toGRT,
+  weightedAverage,
   Account,
 } from '../lib/testHelpers'
 
 const { AddressZero } = constants
-
-function weightedAverage(
-  valueA: BigNumber,
-  valueB: BigNumber,
-  periodA: BigNumber,
-  periodB: BigNumber,
-) {
-  return periodA.mul(valueA).add(periodB.mul(valueB)).div(valueA.add(valueB))
-}
 
 describe('Staking:Stakes', () => {
   let me: Account


### PR DESCRIPTION
### Summary

When a delegator undelegates some tokens a `delegationUnbondingPeriod` is used to calculate the epoch when the tokens will be unlocked. On each new undelegation the period is reset to the unbonding period even if there are tokens waiting to be unlocked. This PR change this behaviour to use a weighted average of time and tokens like on the indexer thawing period.

### Current Behavior

It currently works by resetting the unlock epoch on each undelegation.

Example:
- Epoch 1: Undelegation for 100 GRT, unlock epoch is set to 29
- Epoch 2: 27 epochs to go for unlocking the tokens
- Epoch 3: 26 epochs to go for unlocking the tokens 
- Epoch 4: Undelegation for 50 GRT, unlock epoch is set to 32 <- the period is reset for the 150 GRT total tokens

### Solution

Use a weighted average formula that consider the time some tokens have already been locked, weighted by the old tokens and the new tokens being undelegated. The formula will round up any fractional epoch value as there is no such thing as half an epoch.
