### PR TITLE
Use a minimal proxy for the curation shares ERC20

### DIFF
--- a/cli/commands/migrate.ts
+++ b/cli/commands/migrate.ts
@@ -22,6 +22,7 @@ const allContracts = [
   'Controller',
   'EpochManager',
   'GraphToken',
+  'GraphCurationToken',
   'ServiceRegistry',
   'Curation',
   'GNS',

--- a/contracts/curation/CurationStorage.sol
+++ b/contracts/curation/CurationStorage.sol
@@ -2,28 +2,39 @@
 
 pragma solidity ^0.7.6;
 
-import "./ICuration.sol";
 import "../governance/Managed.sol";
 
-contract CurationV1Storage is Managed {
+abstract contract CurationV1Storage is Managed, ICuration {
+    // -- Pool --
+
+    struct CurationPool {
+        uint256 tokens; // GRT Tokens stored as reserves for the subgraph deployment
+        uint32 reserveRatio; // Ratio for the bonding curve
+        IGraphCurationToken gcs; // Curation token contract for this curation pool
+    }
+
     // -- State --
 
     // Tax charged when curator deposit funds
     // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
-    uint32 internal _curationTaxPercentage;
+    uint32 public override curationTaxPercentage;
 
     // Default reserve ratio to configure curator shares bonding curve
     // Parts per million. (Allows for 4 decimal points, 999,999 = 99.9999%)
     uint32 public defaultReserveRatio;
 
+    // Master copy address that holds implementation of curation token
+    // This is used as the target for GraphCurationToken clones
+    address public curationTokenMaster;
+
     // Minimum amount allowed to be deposited by curators to initialize a pool
     // This is the `startPoolBalance` for the bonding curve
     uint256 public minimumCurationDeposit;
 
-    // Bonding curve formula
+    // Bonding curve library
     address public bondingCurve;
 
     // Mapping of subgraphDeploymentID => CurationPool
     // There is only one CurationPool per SubgraphDeploymentID
-    mapping(bytes32 => ICuration.CurationPool) public pools;
+    mapping(bytes32 => CurationPool) public pools;
 }

--- a/contracts/curation/GraphCurationToken.sol
+++ b/contracts/curation/GraphCurationToken.sol
@@ -2,11 +2,12 @@
 
 pragma solidity ^0.7.6;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
 import "../governance/Governed.sol";
 
 /**
+ * TODO: update to reflect that it is now a cloneable
  * @title GraphCurationToken contract
  * @dev This is the implementation of the Curation ERC20 token (GCS).
  * GCS are created for each subgraph deployment curated in the Curation contract.
@@ -14,13 +15,14 @@ import "../governance/Governed.sol";
  * burn them. GCS tokens are transferrable and their holders can do any action allowed
  * in a standard ERC20 token implementation except for burning them.
  */
-contract GraphCurationToken is ERC20, Governed {
+contract GraphCurationToken is ERC20Upgradeable, Governed {
     /**
-     * @dev Graph Curation Token Contract Constructor.
+     * @dev Graph Curation Token Contract initializer.
      * @param _owner Address of the contract issuing this token
      */
-    constructor(address _owner) ERC20("Graph Curation Share", "GCS") {
+    function initialize(address _owner) external initializer {
         Governed._initialize(_owner);
+        ERC20Upgradeable.__ERC20_init("Graph Curation Share", "GCS");
     }
 
     /**

--- a/contracts/curation/GraphCurationToken.sol
+++ b/contracts/curation/GraphCurationToken.sol
@@ -7,13 +7,16 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "../governance/Governed.sol";
 
 /**
- * TODO: update to reflect that it is now a cloneable
  * @title GraphCurationToken contract
  * @dev This is the implementation of the Curation ERC20 token (GCS).
+ *
  * GCS are created for each subgraph deployment curated in the Curation contract.
  * The Curation contract is the owner of GCS tokens and the only one allowed to mint or
  * burn them. GCS tokens are transferrable and their holders can do any action allowed
  * in a standard ERC20 token implementation except for burning them.
+ *
+ * This contract is meant to be used as the implementation for Minimal Proxy clones for
+ * gas-saving purposes.
  */
 contract GraphCurationToken is ERC20Upgradeable, Governed {
     /**

--- a/contracts/curation/ICuration.sol
+++ b/contracts/curation/ICuration.sol
@@ -5,14 +5,6 @@ pragma solidity ^0.7.6;
 import "./IGraphCurationToken.sol";
 
 interface ICuration {
-    // -- Pool --
-
-    struct CurationPool {
-        uint256 tokens; // GRT Tokens stored as reserves for the subgraph deployment
-        uint32 reserveRatio; // Ratio for the bonding curve
-        IGraphCurationToken gcs; // Curation token contract for this curation pool
-    }
-
     // -- Configuration --
 
     function setDefaultReserveRatio(uint32 _defaultReserveRatio) external;

--- a/contracts/curation/ICuration.sol
+++ b/contracts/curation/ICuration.sol
@@ -13,6 +13,8 @@ interface ICuration {
 
     function setCurationTaxPercentage(uint32 _percentage) external;
 
+    function setCurationTokenMaster(address _curationTokenMaster) external;
+
     // -- Curation --
 
     function mint(

--- a/contracts/curation/IGraphCurationToken.sol
+++ b/contracts/curation/IGraphCurationToken.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.7.6;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
-interface IGraphCurationToken is IERC20 {
+interface IGraphCurationToken is IERC20Upgradeable {
+    function initialize(address _owner) external;
+
     function burnFrom(address _account, uint256 _amount) external;
 
     function mint(address _to, uint256 _amount) external;

--- a/graph.config.yml
+++ b/graph.config.yml
@@ -39,12 +39,13 @@ contracts:
       initialSupply: "10000000000000000000000000000" # 10,000,000,000 GRT
     calls:
       - fn: "addMinter"
-        minter: "${{RewardsManager.address}}"
+        minter: "${{RewardsManager.address}}"    
   Curation:
     proxy: true
     init:
       controller: "${{Controller.address}}"
       bondingCurve: "${{BancorFormula.address}}"
+      curationTokenMaster: "${{GraphCurationToken.address}}"
       reserveRatio: 500000 # 50% (parts per million)
       curationTaxPercentage: 25000 # 2.5% (parts per million)
       minimumCurationDeposit: "1000000000000000000" # 1 GRT

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.4.1",
+    "@openzeppelin/contracts-upgradeable": "3.4.2",
     "@openzeppelin/hardhat-upgrades": "^1.6.0",
     "@tenderly/hardhat-tenderly": "^1.0.11",
     "@typechain/ethers-v5": "^7.0.0",

--- a/test/curation/configuration.test.ts
+++ b/test/curation/configuration.test.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai'
+import { constants } from 'ethers'
 
 import { Curation } from '../../build/types/Curation'
 
 import { defaults } from '../lib/deployment'
 import { NetworkFixture } from '../lib/fixtures'
-import { getAccounts, toBN, Account } from '../lib/testHelpers'
+import { getAccounts, toBN, Account, randomAddress } from '../lib/testHelpers'
+
+const { AddressZero } = constants
 
 const MAX_PPM = 1000000
 
@@ -96,6 +99,31 @@ describe('Curation:Config', () => {
 
     it('reject set `curationTaxPercentage` if not allowed', async function () {
       const tx = curation.connect(me.signer).setCurationTaxPercentage(0)
+      await expect(tx).revertedWith('Caller must be Controller governor')
+    })
+  })
+
+  describe('curationTokenMaster', function () {
+    it('should set `curationTokenMaster`', async function () {
+      const newCurationTokenMaster = curation.address
+      await curation.connect(governor.signer).setCurationTokenMaster(newCurationTokenMaster)
+    })
+
+    it('reject set `curationTokenMaster` to empty value', async function () {
+      const newCurationTokenMaster = AddressZero
+      const tx = curation.connect(governor.signer).setCurationTokenMaster(newCurationTokenMaster)
+      await expect(tx).revertedWith('Token master must be non-empty')
+    })
+
+    it('reject set `curationTokenMaster` to non-contract', async function () {
+      const newCurationTokenMaster = randomAddress()
+      const tx = curation.connect(governor.signer).setCurationTokenMaster(newCurationTokenMaster)
+      await expect(tx).revertedWith('Token master must be a contract')
+    })
+
+    it('reject set `curationTokenMaster` if not allowed', async function () {
+      const newCurationTokenMaster = curation.address
+      const tx = curation.connect(me.signer).setCurationTokenMaster(newCurationTokenMaster)
       await expect(tx).revertedWith('Caller must be Controller governor')
     })
   })

--- a/test/curation/curation.test.ts
+++ b/test/curation/curation.test.ts
@@ -456,6 +456,22 @@ describe('Curation', () => {
         .burn(subgraphDeploymentID, signalToRedeem, expectedTokens.add(1))
       await expect(tx).revertedWith('Slippage protection')
     })
+
+    it('should not re-deploy the curation token when signal is reset', async function () {
+      const beforeSubgraphPool = await curation.pools(subgraphDeploymentID)
+
+      // Burn all the signal
+      const signalToRedeem = await curation.getCuratorSignal(curator.address, subgraphDeploymentID)
+      const expectedTokens = tokensToDeposit
+      await shouldBurn(signalToRedeem, expectedTokens)
+
+      // Mint again on the same subgraph
+      await curation.connect(curator.signer).mint(subgraphDeploymentID, tokensToDeposit, 0)
+
+      // Check state
+      const afterSubgraphPool = await curation.pools(subgraphDeploymentID)
+      expect(afterSubgraphPool.gcs).eq(beforeSubgraphPool.gcs)
+    })
   })
 
   describe('conservation', async function () {

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -117,6 +117,7 @@ export async function deployCuration(
 ): Promise<Curation> {
   // Dependency
   const bondingCurve = (await deployContract('BancorFormula', deployer)) as unknown as BancorFormula
+  const curationTokenMaster = await deployContract('GraphCurationToken', deployer)
 
   // Deploy
   return network.deployContractWithProxy(
@@ -125,6 +126,7 @@ export async function deployCuration(
     [
       controller,
       bondingCurve.address,
+      curationTokenMaster.address,
       defaults.curation.reserveRatio,
       defaults.curation.curationTaxPercentage,
       defaults.curation.minimumCurationDeposit,

--- a/test/staking/delegation.test.ts
+++ b/test/staking/delegation.test.ts
@@ -465,7 +465,6 @@ describe('Staking::Delegation', () => {
         await staking.setDelegationUnbondingPeriod('2')
         await shouldDelegate(delegator, toGRT('100'))
         await shouldUndelegate(delegator, toGRT('50'))
-        await advanceBlock()
         await advanceToNextEpoch(epochManager) // epoch 1
         await advanceToNextEpoch(epochManager) // epoch 2
         await shouldUndelegate(delegator, toGRT('10'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.2.tgz#2c2a1b0fa748235a1f495b6489349776365c51b3"
+  integrity sha512-mDlBS17ymb2wpaLcrqRYdnBAmP1EwqhOXMvqWk2c5Q1N1pm5TkiCtXM9Xzznh4bYsQBq0aIWEkFFE2+iLSN1Tw==
+
 "@openzeppelin/contracts@^3.4.1":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"


### PR DESCRIPTION
### Description

Signal on a subgraph deployment is represented by a subgraph-specific ERC20 token. When signal is minted for a subgraph deployment for the first time, the Curation contract deploys a new ERC20 token. This is costly, about 1.2M gas.

### Solution

Use a Minimal Proxy to clone the Signal-ERC20 based on an implementation. First mint goes from  1,230,118 gas to 432,840