### PR TITLE
Fix deployments and inject cli-env into configuration

### DIFF
--- a/cli/commands/migrate.ts
+++ b/cli/commands/migrate.ts
@@ -26,6 +26,7 @@ let allContracts = [
   'ServiceRegistry',
   'Curation',
   'SubgraphNFTDescriptor',
+  'SubgraphNFT',
   'GNS',
   'Staking',
   'RewardsManager',
@@ -58,6 +59,7 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   const deployContracts = contractName ? [contractName] : allContracts
   const pendingContractCalls = []
 
+  // Deploy contracts
   logger.info(`>>> Contracts deployment\n`)
   for (const name of deployContracts) {
     // Get address book info
@@ -80,7 +82,7 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
     }
 
     // Get config and deploy contract
-    const contractConfig = getContractConfig(graphConfig, cli.addressBook, name)
+    const contractConfig = getContractConfig(graphConfig, cli.addressBook, name, cli)
     const deployFn = contractConfig.proxy ? deployContractWithProxyAndSave : deployContractAndSave
     const contract = await deployFn(
       name,
@@ -113,7 +115,7 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
           cli.wallet,
           entry.contract,
           call.fn,
-          loadCallParams(call.params, cli.addressBook),
+          loadCallParams(call.params, cli.addressBook, cli),
         )
       }
       logger.info('')

--- a/graph.config.yml
+++ b/graph.config.yml
@@ -1,5 +1,5 @@
 general:
-  arbitrator: &arbitrator "0xE1FDD398329C6b74C14cf19100316f0826a492d3"
+  arbitrator: &arbitrator "0xE1FDD398329C6b74C14cf19100316f0826a492d3" # Arbitration Council
   governor: &governor "0x48301Fe520f72994d32eAd72E2B6A8447873CF50" # Graph Council
   authority: &authority "0x79fd74da4c906509862c8fe93e87a9602e370bc4" # Authority that signs payment vouchers
 
@@ -41,7 +41,7 @@ contracts:
       initialSupply: "10000000000000000000000000000" # 10,000,000,000 GRT
     calls:
       - fn: "addMinter"
-        minter: "${{RewardsManager.address}}"    
+        minter: "${{RewardsManager.address}}"
   Curation:
     proxy: true
     init:
@@ -65,9 +65,15 @@ contracts:
     init:
       controller: "${{Controller.address}}"
       bondingCurve: "${{BancorFormula.address}}"
-      tokenDescriptor: "${{SubgraphNFTDescriptor.address}}"
+      subgraphNFT: "${{SubgraphNFT.address}}"
     calls:
       - fn: "approveAll"
+  SubgraphNFT:
+    init:
+      governor: "${{Env.deployer}}"
+    calls:
+      - fn: "setTokenDescriptor"
+        tokenDescriptor: "${{SubgraphNFTDescriptor.address}}"
   Staking:
     proxy: true
     init:

--- a/test/curation/curation.test.ts
+++ b/test/curation/curation.test.ts
@@ -546,6 +546,8 @@ describe('Curation', () => {
     })
 
     it('should mint when using the edge case of linear function', async function () {
+      this.timeout(60000) // increase timeout for test runner
+
       // Setup edge case like linear function: 1 GRT = 1 GCS
       await curation.setMinimumCurationDeposit(toGRT('1'))
       await curation.setDefaultReserveRatio(1000000)


### PR DESCRIPTION
- Injects `Env` as a variable you can use in the `grapg.config` deployment file to get CLI environment parameters.
- Ensure that deployments from scratch are properly configured for the lastest features in the repo