### PR TITLE
Allow anyone to close allocation after max allocation period

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -134,7 +134,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
      * An amount of `tokens` get unallocated from `subgraphDeploymentID`.
      * The `effectiveAllocation` are the tokens allocated from creation to closing.
      * This event also emits the POI (proof of indexing) submitted by the indexer.
-     * `isDelegator` is true if the sender was one of the indexer's delegators.
+     * `isPublic` is true if the sender was someone other than the indexer.
      */
     event AllocationClosed(
         address indexed indexer,
@@ -145,7 +145,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         uint256 effectiveAllocation,
         address sender,
         bytes32 poi,
-        bool isDelegator
+        bool isPublic
     );
 
     /**
@@ -1176,9 +1176,7 @@ contract Staking is StakingV2Storage, GraphUpgradeable, IStaking {
         // Indexer or operator can close an allocation
         // Delegators are also allowed but only after maxAllocationEpochs passed
         bool isIndexer = _isAuth(alloc.indexer);
-        if (epochs > maxAllocationEpochs) {
-            require(isIndexer || isDelegator(alloc.indexer, msg.sender), "!auth-or-del");
-        } else {
+        if (epochs <= maxAllocationEpochs) {
             require(isIndexer, "!auth");
         }
 

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -84,6 +84,12 @@ export const advanceToNextEpoch = async (epochManager: EpochManager): Promise<vo
   await advanceBlockTo(nextEpochBlock)
 }
 
+export const advanceEpochs = async (epochManager: EpochManager, n: number): Promise<void> => {
+  for (let i = 0; i < n + 1; i++) {
+    await advanceToNextEpoch(epochManager)
+  }
+}
+
 export const evmSnapshot = async (): Promise<number> => provider().send('evm_snapshot', [])
 export const evmRevert = async (id: number): Promise<boolean> => provider().send('evm_revert', [id])
 


### PR DESCRIPTION
### Goal

Provide a mechanism so that anyone can close stale allocations.

### Motivation

Stale allocations affect the stability of the network when an indexer that has a big proportional allocated stake on a subgraph does not keep it active, as other indexer won't want to allocate if it already has a big allocation. Stale allocation also reduce the speed of how value flows through the protocol, reducing the frequency at which curators and delegators get their share of rewards/fees. 

Currently delegators for an indexer are the only one that can close them, but this is an unnecessary validation considering that anyone could turn into a delegator, even with the smallest amount of tokens, and then close it.

### Reference

Forum: https://forum.thegraph.com/t/rewarded-force-close-mechanism-to-eliminate-stale-allocations/2951/8