### PR TITLE
Change the way blocks are mined during testing

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -125,7 +125,7 @@ const config: HardhatUserConfig = {
         mnemonic: DEFAULT_TEST_MNEMONIC,
       },
       mining: {
-        auto: true,
+        auto: false,
         interval: 30000,
       },
       hardfork: 'london',

--- a/scripts/test
+++ b/scripts/test
@@ -41,7 +41,7 @@ fi
 mkdir -p reports
 
 # Run using the standalone evm instance
-npx hardhat test --network hardhat
+npx hardhat test --network hardhat $@
 
 ### Cleanup
 

--- a/test/lib/fixtures.ts
+++ b/test/lib/fixtures.ts
@@ -2,7 +2,7 @@
 import { utils, Wallet, Signer } from 'ethers'
 
 import * as deployment from './deployment'
-import { evmSnapshot, evmRevert } from './testHelpers'
+import { evmSnapshot, evmRevert, provider } from './testHelpers'
 
 export class NetworkFixture {
   lastSnapshotId: number
@@ -16,6 +16,12 @@ export class NetworkFixture {
     slasher: Signer = Wallet.createRandom() as Signer,
     arbitrator: Signer = Wallet.createRandom() as Signer,
   ): Promise<any> {
+    // Enable automining with each transaction, and disable
+    // the mining interval. Individual tests may modify this
+    // behavior as needed.
+    provider().send('evm_setIntervalMining', [0])
+    provider().send('evm_setAutomine', [true])
+
     // Roles
     const arbitratorAddress = await arbitrator.getAddress()
     const slasherAddress = await slasher.getAddress()


### PR DESCRIPTION
Since #517, our hardhat local network mines blocks in two ways:
- Automatically when any transaction is sent
- Every 30 seconds

I _suspect_ this is breaking our unit tests for a few reasons:
- CI has started failing quite frequently since that commit
- Several of the failed tests look like timing issues
- I manually timed running tests and noticed errors tend to happen close to 30-second boundaries (though this was a bit of a handwavy measurement).

This PR changes things in two ways:
- For the default local network, disable automining, so transactions will not trigger a mined block, and instead they will _only_ be mined every 30 seconds (@fordN could you confirm if this is the desired behavior?)
- For the unit tests, enable automining and disable the mining interval.

I've run `yarn test` several times in this branch and haven't seen it fail so far (whereas it often fails if I run it from the main dev branch).

An additional small change: we allow passing file paths to `yarn test` so that we can optionally run only specific testfiles.