### PR TITLE
Make block/epoch alignment in tests more predictable

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -125,7 +125,7 @@ const config: HardhatUserConfig = {
         mnemonic: DEFAULT_TEST_MNEMONIC,
       },
       mining: {
-        auto: true,
+        auto: false,
         interval: 30000,
       },
       hardfork: 'london',

--- a/scripts/test
+++ b/scripts/test
@@ -41,7 +41,7 @@ fi
 mkdir -p reports
 
 # Run using the standalone evm instance
-npx hardhat test --network hardhat
+npx hardhat test --network hardhat $@
 
 ### Cleanup
 

--- a/test/lib/fixtures.ts
+++ b/test/lib/fixtures.ts
@@ -2,7 +2,7 @@
 import { utils, Wallet, Signer } from 'ethers'
 
 import * as deployment from './deployment'
-import { evmSnapshot, evmRevert } from './testHelpers'
+import { evmSnapshot, evmRevert, provider } from './testHelpers'
 
 export class NetworkFixture {
   lastSnapshotId: number
@@ -16,6 +16,12 @@ export class NetworkFixture {
     slasher: Signer = Wallet.createRandom() as Signer,
     arbitrator: Signer = Wallet.createRandom() as Signer,
   ): Promise<any> {
+    // Enable automining with each transaction, and disable
+    // the mining interval. Individual tests may modify this
+    // behavior as needed.
+    provider().send('evm_setIntervalMining', [0])
+    provider().send('evm_setAutomine', [true])
+
     // Roles
     const arbitratorAddress = await arbitrator.getAddress()
     const slasherAddress = await slasher.getAddress()

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -74,14 +74,13 @@ export const advanceBlocks = async (blocks: string | number | BigNumber): Promis
   const steps = typeof blocks === 'number' || typeof blocks === 'string' ? toBN(blocks) : blocks
   const currentBlock = await latestBlock()
   const toBlock = currentBlock.add(steps)
-  await advanceBlockTo(toBlock)
+  return advanceBlockTo(toBlock)
 }
 
 export const advanceToNextEpoch = async (epochManager: EpochManager): Promise<void> => {
-  const currentBlock = await latestBlock()
-  const epochLength = await epochManager.epochLength()
-  const nextEpochBlock = currentBlock.add(epochLength)
-  await advanceBlockTo(nextEpochBlock)
+  const blocksSinceEpoch = await epochManager.currentEpochBlockSinceStart()
+  const epochLen = await epochManager.epochLength()
+  return advanceBlocks(epochLen.sub(blocksSinceEpoch))
 }
 
 export const evmSnapshot = async (): Promise<number> => provider().send('evm_snapshot', [])

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -573,11 +573,14 @@ describe('Rewards', () => {
       }
 
       it('should distribute rewards on closed allocation and stake', async function () {
+
+        // Align with the epoch boundary
+        await advanceToNextEpoch(epochManager)
         // Setup
         await setupIndexerAllocation()
 
         // Jump
-        await advanceBlocks(await epochManager.epochLength())
+        await advanceToNextEpoch(epochManager)
 
         // Before state
         const beforeTokenSupply = await grt.totalSupply()
@@ -585,7 +588,14 @@ describe('Rewards', () => {
         const beforeIndexer1Balance = await grt.balanceOf(indexer1.address)
         const beforeStakingBalance = await grt.balanceOf(staking.address)
 
-        const expectedIndexingRewards = toGRT('1471954234')
+        // All the rewards in this subgraph go to this allocation.
+        // Rewards per token will be (totalSupply * issuanceRate^nBlocks - totalSupply) / allocatedTokens
+        // The first snapshot is after allocating, that is 2 blocks after the signal is minted:
+        // startRewardsPerToken = (10004000000 * 1.01227 ^ 2 - 10004000000) / 12500 = 122945.16
+        // The final snapshot is when we close the allocation, that happens 9 blocks later:
+        // endRewardsPerToken = (10004000000 * 1.01227 ^ 9 - 10004000000) / 12500 = 92861.24
+        // Then our expected rewards are (endRewardsPerToken - startRewardsPerToken) * 12500.
+        const expectedIndexingRewards = toGRT('913715958')
 
         // Close allocation. At this point rewards should be collected for that indexer
         const tx = await staking
@@ -623,11 +633,13 @@ describe('Rewards', () => {
         const destinationAddress = randomHexBytes(20)
         await staking.connect(indexer1.signer).setRewardsDestination(destinationAddress)
 
+        // Align with the epoch boundary
+        await advanceToNextEpoch(epochManager)
         // Setup
         await setupIndexerAllocation()
 
         // Jump
-        await advanceBlocks(await epochManager.epochLength())
+        await advanceToNextEpoch(epochManager)
 
         // Before state
         const beforeTokenSupply = await grt.totalSupply()
@@ -635,7 +647,14 @@ describe('Rewards', () => {
         const beforeDestinationBalance = await grt.balanceOf(destinationAddress)
         const beforeStakingBalance = await grt.balanceOf(staking.address)
 
-        const expectedIndexingRewards = toGRT('1471954234')
+        // All the rewards in this subgraph go to this allocation.
+        // Rewards per token will be (totalSupply * issuanceRate^nBlocks - totalSupply) / allocatedTokens
+        // The first snapshot is after allocating, that is 2 blocks after the signal is minted:
+        // startRewardsPerToken = (10004000000 * 1.01227 ^ 2 - 10004000000) / 12500 = 122945.16
+        // The final snapshot is when we close the allocation, that happens 9 blocks later:
+        // endRewardsPerToken = (10004000000 * 1.01227 ^ 9 - 10004000000) / 12500 = 92861.24
+        // Then our expected rewards are (endRewardsPerToken - startRewardsPerToken) * 12500.
+        const expectedIndexingRewards = toGRT('913715958')
 
         // Close allocation. At this point rewards should be collected for that indexer
         const tx = await staking
@@ -678,10 +697,13 @@ describe('Rewards', () => {
         }
         const tokensToDelegate = toGRT('2000')
 
+        // Align with the epoch boundary
+        await advanceToNextEpoch(epochManager)
+        // Setup the allocation and delegators
         await setupIndexerAllocationWithDelegation(tokensToDelegate, delegationParams)
 
         // Jump
-        await advanceBlocks(await epochManager.epochLength())
+        await advanceToNextEpoch(epochManager)
 
         // Before state
         const beforeTokenSupply = await grt.totalSupply()
@@ -698,8 +720,15 @@ describe('Rewards', () => {
 
         // Check that rewards are put into indexer stake (only indexer cut)
         // Check that rewards are put into delegators pool accordingly
-        // NOTE: calculated manually on a spreadsheet
-        const expectedIndexingRewards = toGRT('1454109066')
+
+        // All the rewards in this subgraph go to this allocation.
+        // Rewards per token will be (totalSupply * issuanceRate^nBlocks - totalSupply) / allocatedTokens
+        // The first snapshot is after allocating, that is 2 blocks after the signal is minted:
+        // startRewardsPerToken = (10004000000 * 1.01227 ^ 2 - 10004000000) / 14500 = 8466.995
+        // The final snapshot is when we close the allocation, that happens 4 blocks later:
+        // endRewardsPerToken = (10004000000 * 1.01227 ^ 4 - 10004000000) / 14500 = 34496.55
+        // Then our expected rewards are (endRewardsPerToken - startRewardsPerToken) * 14500.
+        const expectedIndexingRewards = toGRT('377428566.77')
         // Calculate delegators cut
         const indexerRewards = delegationParams.indexingRewardCut
           .mul(expectedIndexingRewards)
@@ -725,7 +754,7 @@ describe('Rewards', () => {
         await setupIndexerAllocation()
 
         // Jump
-        await advanceBlocks(await epochManager.epochLength())
+        await advanceToNextEpoch(epochManager)
 
         // Close allocation. At this point rewards should be collected for that indexer
         const tx = staking.connect(indexer1.signer).closeAllocation(allocationID, randomHexBytes())
@@ -769,7 +798,7 @@ describe('Rewards', () => {
         )
 
       // Jump
-      await advanceBlocks(await epochManager.epochLength())
+      await advanceToNextEpoch(epochManager)
 
       // Remove all signal from the subgraph
       const curatorShares = await curation.getCuratorSignal(curator1.address, subgraphDeploymentID1)


### PR DESCRIPTION
(Temporarily targeting the pcv/fix-tests branch as this builds on #554)

Now that blocks are mined predictably in our unit tests (i.e. one block per transaction), any tests that rely on a specific number of blocks passing can break if the number of transactions changes. This was evident when I incorporated the changes from #554 into #552, see: https://github.com/graphprotocol/contracts/runs/5728132209?check_suite_focus=true - adding a transaction in the fixtures bringup caused the test to spill over into the next epoch, changing the results.

So this PR makes a few changes to make tests hopefully more predictable and robust:
- Change the `advanceToNextEpoch` function to always advance to the first block in the next epoch, rather than always advancing a full epoch
- Change several tests that advanced an epochLength to use advanceToNextEpoch instead
- In takeRewards tests that expect an amount for indexer rewards, align to the first block in an epoch and recalculate the expected rewards using the number of blocks, that is now a bit easier to calculate by just counting the number of transactions in the test code.
