### PR TITLE
feat: make GNS signal transferable

### DIFF
--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -212,10 +212,9 @@ contract GNS is GNSV2Storage, GraphUpgradeable, IGNS, Multicall {
      * @param _subgraphNFT Address of the ERC721 contract
      */
     function _setSubgraphNFT(address _subgraphNFT) private {
-        require(
-            _subgraphNFT != address(0) && Address.isContract(_subgraphNFT),
-            "NFT must be valid"
-        );
+        require(_subgraphNFT != address(0), "NFT address cant be zero");
+        require(Address.isContract(_subgraphNFT), "NFT must be valid");
+
         subgraphNFT = ISubgraphNFT(_subgraphNFT);
         emit SubgraphNFTUpdated(_subgraphNFT);
     }
@@ -475,7 +474,7 @@ contract GNS is GNSV2Storage, GraphUpgradeable, IGNS, Multicall {
         uint256 _subgraphID,
         address _recipient,
         uint256 _amount
-    ) external override notPartialPaused returns (bool) {
+    ) external override notPartialPaused {
         require(_recipient != address(0), "GNS: Curator cannot transfer to the zero address");
 
         // Subgraph checks
@@ -493,8 +492,6 @@ contract GNS is GNSV2Storage, GraphUpgradeable, IGNS, Multicall {
         );
 
         emit SignalTransferred(_subgraphID, curator, _recipient, _amount);
-
-        return true;
     }
 
     /**

--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -87,6 +87,16 @@ contract GNS is GNSV2Storage, GraphUpgradeable, IGNS, Multicall {
     );
 
     /**
+     * @dev Emitted when a curator transfers signal.
+     */
+    event SignalTransferred(
+        uint256 indexed subgraphID,
+        address indexed from,
+        address indexed to,
+        uint256 nSignalTransferred
+    );
+
+    /**
      * @dev Emitted when a subgraph is created.
      */
     event SubgraphPublished(
@@ -453,6 +463,38 @@ contract GNS is GNSV2Storage, GraphUpgradeable, IGNS, Multicall {
         require(graphToken().transfer(curator, tokens), "GNS: Error sending tokens");
 
         emit SignalBurned(_subgraphID, curator, _nSignal, vSignal, tokens);
+    }
+
+    /**
+     * @dev Move subgraph signal from sender to `_recipient`
+     * @param _subgraphID Subgraph ID
+     * @param _recipient Address to send the signal to
+     * @param _amount The amount of nSignal to transfer
+     */
+    function transferSignal(
+        uint256 _subgraphID,
+        address _recipient,
+        uint256 _amount
+    ) external override notPartialPaused returns (bool) {
+        require(_recipient != address(0), "GNS: Curator cannot transfer to the zero address");
+
+        // Subgraph checks
+        SubgraphData storage subgraphData = _getSubgraphOrRevert(_subgraphID);
+
+        // Balance checks
+        address curator = msg.sender;
+        uint256 curatorBalance = subgraphData.curatorNSignal[curator];
+        require(curatorBalance >= _amount, "GNS: Curator transfer amount exceeds balance");
+
+        // Move the signal
+        subgraphData.curatorNSignal[curator] = subgraphData.curatorNSignal[curator].sub(_amount);
+        subgraphData.curatorNSignal[_recipient] = subgraphData.curatorNSignal[_recipient].add(
+            _amount
+        );
+
+        emit SignalTransferred(_subgraphID, curator, _recipient, _amount);
+
+        return true;
     }
 
     /**

--- a/contracts/discovery/IGNS.sol
+++ b/contracts/discovery/IGNS.sol
@@ -65,6 +65,12 @@ interface IGNS {
         uint256 _tokensOutMin
     ) external;
 
+    function transferSignal(
+        uint256 _subgraphID,
+        address _recipient,
+        uint256 _amount
+    ) external returns (bool);
+
     function withdraw(uint256 _subgraphID) external;
 
     // -- Getters --

--- a/contracts/discovery/IGNS.sol
+++ b/contracts/discovery/IGNS.sol
@@ -69,7 +69,7 @@ interface IGNS {
         uint256 _subgraphID,
         address _recipient,
         uint256 _amount
-    ) external returns (bool);
+    ) external;
 
     function withdraw(uint256 _subgraphID) external;
 

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -560,7 +560,7 @@ describe('GNS', () => {
 
       it('revert set to empty address', async function () {
         const tx = gns.connect(governor.signer).setSubgraphNFT(AddressZero)
-        await expect(tx).revertedWith('NFT must be valid')
+        await expect(tx).revertedWith('NFT address cant be zero')
       })
 
       it('revert set to non-contract', async function () {


### PR DESCRIPTION
See https://forum.thegraph.com/t/gip-0032-make-gns-signal-transferrable/3338

### Motivation

From GIP32:

> Curators can mint curation shares from a Subgraph Deployment directly on the Curation contract and get fully transferrable ERC20 shares. However, when they curate a Subgraph at the GNS level, the GNS contract is the one keeping all the signal shares under its control. The subgraph curators cannot transfer those shares because the GNS is not exposing any function to do that.

### Changes

This PR adds a `transferSignal` function to the GNS contract that allows a curator to transfer ownership of their `nSignal` to another address.

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>