### PR TITLE
Verify contracts with sourcify

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -108,7 +108,7 @@ const config: HardhatUserConfig = {
           },
           outputSelection: {
             '*': {
-              '*': ['storageLayout', 'metadata'],
+              '*': ['storageLayout'],
             },
           },
         },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -28,7 +28,7 @@ const SKIP_LOAD = process.env.SKIP_LOAD === 'true'
 
 function loadTasks() {
   require('./tasks/gre.ts')
-  ;['contracts', 'misc', 'deployment', 'actions'].forEach((folder) => {
+  ;['contracts', 'misc', 'deployment', 'actions', 'verify'].forEach((folder) => {
     const tasksPath = path.join(__dirname, 'tasks', folder)
     fs.readdirSync(tasksPath)
       .filter((pth) => pth.includes('.ts'))
@@ -103,9 +103,12 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 200,
           },
+          metadata: {
+            useLiteralContent: true,
+          },
           outputSelection: {
             '*': {
-              '*': ['storageLayout'],
+              '*': ['storageLayout', 'metadata'],
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-prettier": "^3.4.0",
     "ethereum-waffle": "^3.3.0",
+    "form-data": "^4.0.0",
     "graphql-tag": "^2.12.4",
     "hardhat": "^2.9.5",
     "hardhat-abi-exporter": "^2.2.0",

--- a/tasks/verify/sourcify.ts
+++ b/tasks/verify/sourcify.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import axios from 'axios'
+import FormData from 'form-data'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { Readable } from 'stream'
+import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
+
+// Modified from: https://github.com/wighawag/hardhat-deploy/blob/9c8cd433a37188e793181b727222e2d22aef34b0/src/sourcify.ts
+function ensureTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s : `${s}/`
+}
+
+export async function submitSourcesToSourcify(
+  hre: HardhatRuntimeEnvironment,
+  config: {
+    endpoint: string
+    contract: {
+      source: string
+      name: string
+      address: string
+    }
+    writeFailingMetadata?: boolean
+  },
+): Promise<void> {
+  const { contract } = config
+  const chainId = hre.network.config.chainId
+  const sourcifyUrl = ensureTrailingSlash(config.endpoint)
+
+  // Get contract metadata
+  const contractFQN = getFullyQualifiedName(contract.source, contract.name)
+  const contractBuildInfo = await hre.artifacts.getBuildInfo(contractFQN)
+  const contractMetadata = (
+    contractBuildInfo.output.contracts[contract.source][contract.name] as any
+  ).metadata
+
+  // const contractMetadata = JSON.stringify(contractBuildInfo)
+  if (!contractMetadata) {
+    throw new Error(
+      `Contract ${contract.name} was deployed without saving metadata. Cannot submit to sourcify, skipping.`,
+    )
+  }
+
+  // Check if contract already verified
+  try {
+    const checkResponse = await axios.get(
+      `${sourcifyUrl}checkByAddresses?addresses=${contract.address.toLowerCase()}&chainIds=${chainId}`,
+    )
+    const { data: checkData } = checkResponse
+    if (checkData[0].status === 'perfect') {
+      console.log(`already verified: ${contract.name} (${contract.address}), skipping.`)
+      return
+    }
+  } catch (e) {
+    console.error(((e as any).response && JSON.stringify((e as any).response.data)) || e)
+  }
+
+  console.log(`verifying ${contract.name} (${contract.address} on chain ${chainId}) ...`)
+
+  // Build form data
+  const formData = new FormData()
+  formData.append('address', contract.address)
+  formData.append('chain', chainId)
+
+  const fileStream = new Readable()
+  fileStream.push(contractMetadata)
+  fileStream.push(null)
+  formData.append('files', fileStream)
+
+  // Verify contract
+  try {
+    const submissionResponse = await axios.post(sourcifyUrl, formData, {
+      headers: formData.getHeaders(),
+    })
+    if (submissionResponse.data.result[0].status === 'perfect') {
+      console.log(` => contract ${contract.name} is now verified`)
+    } else {
+      console.error(` => contract ${contract.name} is not verified`)
+    }
+  } catch (e) {
+    console.error(((e as any).response && JSON.stringify((e as any).response.data)) || e)
+  }
+}

--- a/tasks/verify/sourcify.ts
+++ b/tasks/verify/sourcify.ts
@@ -31,7 +31,7 @@ export async function submitSourcesToSourcify(
     contractBuildInfo.output.contracts[contract.source][contract.name] as any
   ).metadata
 
-  if (!contractMetadata) {
+  if (contractMetadata === undefined) {
     throw new Error(
       `Contract ${contract.name} was deployed without saving metadata. Cannot submit to sourcify, skipping.`,
     )

--- a/tasks/verify/verify.ts
+++ b/tasks/verify/verify.ts
@@ -1,0 +1,31 @@
+import { task } from 'hardhat/config'
+import * as types from 'hardhat/internal/core/params/argumentTypes'
+import { submitSourcesToSourcify } from './sourcify'
+
+task('verify:sourcify', 'submit contract source code to sourcify (https://sourcify.dev)')
+  .addParam(
+    'contractSource',
+    'path to the source file of the contract to verify',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'endpoint',
+    'endpoint url for sourcify',
+    'https://sourcify.dev/server/',
+    types.string,
+  )
+  .addFlag('writeFailingMetadata', 'write to disk failing metadata for easy debugging')
+  .setAction(async (args, hre) => {
+    const contractName = args.contractSource.split('/').pop().split('.').shift()
+    const contract = hre.contracts[contractName]
+    const config = {
+      endpoint: args.endpoint,
+      contract: {
+        source: args.contractSource,
+        name: contractName,
+        address: contract.address,
+      },
+    }
+    await submitSourcesToSourcify(hre, config)
+  })

--- a/tasks/verify/verify.ts
+++ b/tasks/verify/verify.ts
@@ -1,31 +1,42 @@
 import { task } from 'hardhat/config'
 import * as types from 'hardhat/internal/core/params/argumentTypes'
 import { submitSourcesToSourcify } from './sourcify'
+import { getAddressBook } from '../../cli/address-book'
+import { cliOpts } from '../../cli/defaults'
 
 task('verify:sourcify', 'submit contract source code to sourcify (https://sourcify.dev)')
   .addParam(
     'contractSource',
-    'path to the source file of the contract to verify',
+    'Path to the source file of the contract to verify.',
     undefined,
     types.string,
   )
   .addOptionalParam(
-    'endpoint',
-    'endpoint url for sourcify',
+    'sourcifyEndpoint',
+    "Sourcify's endpoint url.",
     'https://sourcify.dev/server/',
     types.string,
   )
-  .addFlag('writeFailingMetadata', 'write to disk failing metadata for easy debugging')
+  .addParam('addressBook', cliOpts.addressBook.description, cliOpts.addressBook.default)
   .setAction(async (args, hre) => {
+    const chainId = hre.network.config.chainId.toString()
     const contractName = args.contractSource.split('/').pop().split('.').shift()
-    const contract = hre.contracts[contractName]
+    const addressBook = getAddressBook(args.addressBook, chainId)
+    const contract = addressBook.getEntry(contractName)
+
     const config = {
-      endpoint: args.endpoint,
+      endpoint: args.sourcifyEndpoint,
       contract: {
         source: args.contractSource,
         name: contractName,
-        address: contract.address,
+        address: contract.implementation.address,
       },
     }
+
+    console.log('## Verify contract with sourcify ##')
+    console.log(`Network: ${hre.network.name}`)
+    console.log(`Contract: ${contractName}`)
+    console.log(`Address: ${contract.implementation.address}`)
+
     await submitSourcesToSourcify(hre, config)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5402,6 +5402,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"


### PR DESCRIPTION
### Motivation

We currently verify our contracts on Etherscan. Sourcify provides a verification service that includes contract metadata verification and a more decentralized approac. See https://blog.soliditylang.org/2020/06/25/sourcify-faq/ for details. 

### Changes

- Add a `sourcify` hardhat task to verify a contract on https://sourcify.dev/
- Modify solidity settings to generate metadata file on compilation

Usage: 
```bash
npx hardhat sourcify <CONTRACT_ADDRESS> --contract <CONTRACT_FQN> --network mainnet

# Example
npx hardhat sourcify 0x147A7758EA71d91D545407927b34DD77A5f7C21A --contract contracts/curation/Curation.sol:Curation --network mainnet
```
Unlike Etherscan, Sourcify requires uploading metadata file generated when contract is compiled. We use the contract's fully qualified name to grab this file.


**Verified contracts**

- [x]  **GraphProxyAdmin**
- [x]  **BancorFormula**
- [x]  **Controller**
- [x]  **EpochManager**
    - [x]  proxy
    - [x]  implementation
- [x]  **GraphToken**
- [x]  **ServiceRegistry**
    - [x]  proxy
    - [x]  implementation
- [x]  **Curation**
    - [x]  proxy
    - [x]  implementation
- [x]  **GNS**
    - [x]  proxy
    - [x]  implementation
- [x]  **Staking**
    - [x]  proxy
    - [x]  implementation
- [x]  **RewardsManager**
    - [x]  proxy
    - [x]  implementation
- [x]  **DisputeManager**
    - [x]  proxy
    - [x]  implementation
- [x]  **AllocationExchange**
- [x]  **SubgraphNFTDescriptor**
- [x]  **SubgraphNFT**