### PR TITLE
Add GraphCurationToken to addressbook

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -59,6 +59,12 @@
       "runtimeCodeHash": "0xb964f76194a04272e7582382a4d6bd6271bbb90deb5c1fd3ae3913504ea3a830",
       "txHash": "0x079625b9f58a40f1948b396b7007d09ff4aa193d7ec798923910fc179294cab8"
     },
+    "GraphCurationToken": {
+      "address": "0xb2e26f17aea8efa534e15bde5c79c25d0c3dfa2e",
+      "creationCodeHash": "",
+      "runtimeCodeHash": "",
+      "txHash": "0x68eb11f4d6eaec5036c97b4c6102a509ac31933f1fe011f275b3e5fee30b6590"
+    },
     "ServiceRegistry": {
       "address": "0xaD0C9DaCf1e515615b0581c8D7E295E296Ec26E6",
       "initArgs": [
@@ -338,6 +344,12 @@
       "creationCodeHash": "0x30da7a30d71fbd41d3327e4d0183401f257af3e905a0c68ebfd18b590b27b530",
       "runtimeCodeHash": "0xb964f76194a04272e7582382a4d6bd6271bbb90deb5c1fd3ae3913504ea3a830",
       "txHash": "0xfd3da9962b88397134b71259287bb056b60cdd092f91c114dcd7c794e6237c78"
+    },
+    "GraphCurationToken": {
+      "address": "",
+      "creationCodeHash": "",
+      "runtimeCodeHash": "",
+      "txHash": ""
     },
     "ServiceRegistry": {
       "address": "0xB2cD4D1205A55303ef0DeC2e4EfB5338f9c182bc",

--- a/addresses.json
+++ b/addresses.json
@@ -59,12 +59,6 @@
       "runtimeCodeHash": "0xb964f76194a04272e7582382a4d6bd6271bbb90deb5c1fd3ae3913504ea3a830",
       "txHash": "0x079625b9f58a40f1948b396b7007d09ff4aa193d7ec798923910fc179294cab8"
     },
-    "GraphCurationToken": {
-      "address": "0xb2e26f17aea8efa534e15bde5c79c25d0c3dfa2e",
-      "creationCodeHash": "",
-      "runtimeCodeHash": "",
-      "txHash": "0x68eb11f4d6eaec5036c97b4c6102a509ac31933f1fe011f275b3e5fee30b6590"
-    },
     "ServiceRegistry": {
       "address": "0xaD0C9DaCf1e515615b0581c8D7E295E296Ec26E6",
       "initArgs": [
@@ -83,6 +77,12 @@
         "runtimeCodeHash": "0x9856d2c2985f410f2f77e456fe6163827ea5251eb5e3f3768d3d4f8868187882",
         "txHash": "0xdf811598fbfbc487b16b5bb3444ed47ae3107d3dcde8dbd770e8810315f942b5"
       }
+    },
+    "GraphCurationToken": {
+      "address": "0xb2e26f17aea8efa534e15bde5c79c25d0c3dfa2e",
+      "creationCodeHash": "0x7e9a56b6fc05d428d1c1116eaa88a658f05487b493d847bfe5c69e35ec34f092",
+      "runtimeCodeHash": "0x587f9d4e9ecf9e7048d9f42f027957ca34ee6a95ca37d9758d8cd0ee16e89818",
+      "txHash": "0x68eb11f4d6eaec5036c97b4c6102a509ac31933f1fe011f275b3e5fee30b6590"
     },
     "Curation": {
       "address": "0x8FE00a685Bcb3B2cc296ff6FfEaB10acA4CE1538",
@@ -345,12 +345,6 @@
       "runtimeCodeHash": "0xb964f76194a04272e7582382a4d6bd6271bbb90deb5c1fd3ae3913504ea3a830",
       "txHash": "0xfd3da9962b88397134b71259287bb056b60cdd092f91c114dcd7c794e6237c78"
     },
-    "GraphCurationToken": {
-      "address": "",
-      "creationCodeHash": "",
-      "runtimeCodeHash": "",
-      "txHash": ""
-    },
     "ServiceRegistry": {
       "address": "0xB2cD4D1205A55303ef0DeC2e4EfB5338f9c182bc",
       "initArgs": [
@@ -369,6 +363,12 @@
         "runtimeCodeHash": "0x9856d2c2985f410f2f77e456fe6163827ea5251eb5e3f3768d3d4f8868187882",
         "txHash": "0xd17bdc8e05933c7146105e0e22ab5390677544cad224eb0dcd56c8088585d29a"
       }
+    },
+    "GraphCurationToken": {
+      "address": "0x37014c7b321da7927b6662859dc9a929543386c6",
+      "creationCodeHash": "0x7e9a56b6fc05d428d1c1116eaa88a658f05487b493d847bfe5c69e35ec34f092",
+      "runtimeCodeHash": "0x587f9d4e9ecf9e7048d9f42f027957ca34ee6a95ca37d9758d8cd0ee16e89818",
+      "txHash": "0xd108447808e285fcde0b9aaee9e8446af91e9983041aa47ff9410c2c2862938b"
     },
     "Curation": {
       "address": "0x5cCaB32d30Ca0969a8f3D495e1F67b3A90d39b14",


### PR DESCRIPTION
`GraphCurationToken` addresses were missing from the address book on both mainnet and rinkeby. Code hashes created with [this](https://github.com/tmigone/hello-eth/blob/297998981dfa189ec9dccd4649a75f21eae295f7/scripts/codeHash.ts) script.

