### PR TITLE
fix: ensure subgraphNFT handles metadata with leading zeros correctly

### DIFF
--- a/contracts/discovery/SubgraphNFT.sol
+++ b/contracts/discovery/SubgraphNFT.sol
@@ -150,7 +150,7 @@ contract SubgraphNFT is Governed, ERC721, ISubgraphNFT {
         // Default token URI
         uint256 metadata = uint256(_subgraphMetadataHashes[_tokenId]);
 
-        string memory _subgraphURI = metadata > 0 ? HexStrings.toString(metadata) : "";
+        string memory _subgraphURI = metadata > 0 ? HexStrings.toHexString(metadata, 32) : "";
         string memory base = baseURI();
 
         // If there is no base URI, return the token URI.

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -1067,5 +1067,22 @@ describe('GNS', () => {
       const tokenURI = await subgraphNFT.connect(me.signer).tokenURI(subgraph0.id)
       expect('ipfs://' + subgraph0.id).eq(tokenURI)
     })
+
+    it('without token descriptor and metadata with leading zeros', async function () {
+      const newSubgraph = buildSubgraph()
+      newSubgraph.subgraphMetadata = `0x00${newSubgraph.subgraphMetadata.slice(4)}`
+
+      const subgraph0 = await publishNewSubgraph(me, newSubgraph)
+
+      const subgraphNFTAddress = await gns.subgraphNFT()
+      const subgraphNFT = getContractAt('SubgraphNFT', subgraphNFTAddress) as SubgraphNFT
+      await subgraphNFT.connect(governor.signer).setTokenDescriptor(AddressZero)
+      await subgraphNFT.connect(governor.signer).setBaseURI('ipfs://')
+      const tokenURI = await subgraphNFT.connect(me.signer).tokenURI(subgraph0.id)
+
+      const sub = new SubgraphDeploymentID(newSubgraph.subgraphMetadata)
+
+      expect('ipfs://' + sub.bytes32).eq(tokenURI)
+    })
   })
 })


### PR DESCRIPTION
### Motivation

The tokenURI being reported by SubgraphNFT contract using the `tokenURI` function is incorrect when the subgraph metadata hash contains leading zeroes. #576 describes the problem in detail.

### Changes

- Added test to check for this special case where subgraph metadata hash is of the form `0x00....`
- Fix in SubgraphNFT contract

Closes: #576
Signed-off-by: Tomás Migone <tomas@edgeandnode.com>