### PR TITLE
ci: run tests on PRs targeting all branches

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -3,8 +3,7 @@ name: Node.js CI
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [dev]
+  pull_request: {}
 
 jobs:
   build:


### PR DESCRIPTION
This would allow us to run the tests on PRs that don't target dev because they depend on other PRs, e.g. #571 