### PR TITLE
feat: keeper reward for reservoir drip through token issuance

### DIFF
--- a/contracts/l2/reservoir/IL2Reservoir.sol
+++ b/contracts/l2/reservoir/IL2Reservoir.sol
@@ -22,7 +22,8 @@ interface IL2Reservoir is IReservoir {
      * because it checks an incrementing nonce. If that is the case, the retryable ticket can be redeemed
      * again once the ticket for previous drip has been redeemed.
      * A keeper reward will be sent to the keeper that dripped on L1, and part of it
-     * to whoever redeemed the current retryable ticket (tx.origin)
+     * to whoever redeemed the current retryable ticket (as reported by ArbRetryableTx.getCurrentRedeemer) if
+     * the ticket is not auto-redeemed.
      * @param _issuanceBase Base value for token issuance (approximation for token supply times L2 rewards fraction)
      * @param _issuanceRate Rewards issuance rate, using fixed point at 1e18, and including a +1
      * @param _nonce Incrementing nonce to ensure messages are received in order

--- a/contracts/l2/reservoir/IL2Reservoir.sol
+++ b/contracts/l2/reservoir/IL2Reservoir.sol
@@ -27,7 +27,7 @@ interface IL2Reservoir is IReservoir {
      * @param _issuanceBase Base value for token issuance (approximation for token supply times L2 rewards fraction)
      * @param _issuanceRate Rewards issuance rate, using fixed point at 1e18, and including a +1
      * @param _nonce Incrementing nonce to ensure messages are received in order
-     * @param _keeperReward Keeper reward to distribute between keeper that called drip and keeper that redeemed  the retryable tx
+     * @param _keeperReward Keeper reward to distribute between keeper that called drip and keeper that redeemed the retryable tx
      * @param _l1Keeper Address of the keeper that called drip in L1
      */
     function receiveDrip(

--- a/contracts/l2/reservoir/IL2Reservoir.sol
+++ b/contracts/l2/reservoir/IL2Reservoir.sol
@@ -18,13 +18,22 @@ interface IL2Reservoir is IReservoir {
      * updates the issuanceBase and issuanceRate,
      * and snapshots the accumulated rewards. If issuanceRate changes,
      * it also triggers a snapshot of rewards per signal on the RewardsManager.
+     * Note that the transaction might revert if it's received out-of-order,
+     * because it checks an incrementing nonce. If that is the case, the retryable ticket can be redeemed
+     * again once the ticket for previous drip has been redeemed.
+     * A keeper reward will be sent to the keeper that dripped on L1, and part of it
+     * to whoever redeemed the current retryable ticket (tx.origin)
      * @param _issuanceBase Base value for token issuance (approximation for token supply times L2 rewards fraction)
      * @param _issuanceRate Rewards issuance rate, using fixed point at 1e18, and including a +1
      * @param _nonce Incrementing nonce to ensure messages are received in order
+     * @param _keeperReward Keeper reward to distribute between keeper that called drip and keeper that redeemed  the retryable tx
+     * @param _l1Keeper Address of the keeper that called drip in L1
      */
     function receiveDrip(
         uint256 _issuanceBase,
         uint256 _issuanceRate,
-        uint256 _nonce
+        uint256 _nonce,
+        uint256 _keeperReward,
+        address _l1Keeper
     ) external;
 }

--- a/contracts/l2/reservoir/IL2Reservoir.sol
+++ b/contracts/l2/reservoir/IL2Reservoir.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.7.6;
 
-import "../../reservoir/IReservoir.sol";
+import { IReservoir } from "../../reservoir/IReservoir.sol";
 
 /**
  * @title Interface for the L2 Rewards Reservoir

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -3,14 +3,16 @@
 pragma solidity ^0.7.6;
 pragma abicoder v2;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "arbos-precompiles/arbos/builtin/ArbRetryableTx.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { ArbRetryableTx } from "arbos-precompiles/arbos/builtin/ArbRetryableTx.sol";
 
-import "../../arbitrum/AddressAliasHelper.sol";
-import "../../reservoir/IReservoir.sol";
-import "../../reservoir/Reservoir.sol";
-import "./IL2Reservoir.sol";
-import "./L2ReservoirStorage.sol";
+import { Managed } from "../../governance/Managed.sol";
+import { IGraphToken } from "../../token/IGraphToken.sol";
+import { AddressAliasHelper } from "../../arbitrum/AddressAliasHelper.sol";
+import { IReservoir } from "../../reservoir/IReservoir.sol";
+import { Reservoir } from "../../reservoir/Reservoir.sol";
+import { IL2Reservoir } from "./IL2Reservoir.sol";
+import { L2ReservoirV2Storage } from "./L2ReservoirStorage.sol";
 
 /**
  * @dev ArbRetryableTx with additional interface to query the current redeemer.

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -126,7 +126,8 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
      * because it checks an incrementing nonce. If that is the case, the retryable ticket can be redeemed
      * again once the ticket for previous drip has been redeemed.
      * A keeper reward will be sent to the keeper that dripped on L1, and part of it
-     * to whoever redeemed the current retryable ticket (tx.origin)
+     * to whoever redeemed the current retryable ticket (as reported by ArbRetryableTx.getCurrentRedeemer) if
+     * the ticket is not auto-redeemed.
      * @param _issuanceBase Base value for token issuance (approximation for token supply times L2 rewards fraction)
      * @param _issuanceRate Rewards issuance rate, using fixed point at 1e18, and including a +1
      * @param _nonce Incrementing nonce to ensure messages are received in order
@@ -157,7 +158,9 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
         // unless this was an autoredeem, in which case the "redeemer" is the sender, i.e. L1Reservoir
         address redeemer = IArbTxWithRedeemer(ARB_TX_ADDRESS).getCurrentRedeemer();
         if (redeemer != l1ReservoirAddress) {
-            uint256 _l2KeeperReward = _keeperReward.mul(l2KeeperRewardFraction).div(FIXED_POINT_SCALING_FACTOR);
+            uint256 _l2KeeperReward = _keeperReward.mul(l2KeeperRewardFraction).div(
+                FIXED_POINT_SCALING_FACTOR
+            );
             grt.transfer(redeemer, _l2KeeperReward);
             grt.transfer(_l1Keeper, _keeperReward.sub(_l2KeeperReward));
         } else {

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -6,6 +6,7 @@ pragma abicoder v2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "arbos-precompiles/arbos/builtin/ArbRetryableTx.sol";
 
+import "../../arbitrum/AddressAliasHelper.sol";
 import "../../reservoir/IReservoir.sol";
 import "../../reservoir/Reservoir.sol";
 import "./IL2Reservoir.sol";
@@ -166,7 +167,7 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
         // Part of the reward always goes to whoever redeemed the  ticket in L2,
         // unless this was an autoredeem, in which case the "redeemer" is the sender, i.e. L1Reservoir
         address redeemer = IArbTxWithRedeemer(ARB_TX_ADDRESS).getCurrentRedeemer();
-        if (redeemer != l1ReservoirAddress) {
+        if (redeemer != AddressAliasHelper.applyL1ToL2Alias(l1ReservoirAddress)) {
             uint256 _l2KeeperReward = _keeperReward.mul(l2KeeperRewardFraction).div(
                 FIXED_POINT_SCALING_FACTOR
             );

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -35,11 +35,16 @@ interface IArbTxWithRedeemer is ArbRetryableTx {
 contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
     using SafeMath for uint256;
 
+    // Address for the ArbRetryableTx interface provided by Arbitrum
     address public constant ARB_TX_ADDRESS = 0x000000000000000000000000000000000000006E;
 
+    // Emitted when a rewards drip is received from L1
     event DripReceived(uint256 issuanceBase);
+    // Emitted when the next drip nonce is manually updated by governance
     event NextDripNonceUpdated(uint256 nonce);
+    // Emitted when the L1Reservoir's address is updated
     event L1ReservoirAddressUpdated(address l1ReservoirAddress);
+    // Emitted when the L2 keeper reward fraction is updated
     event L2KeeperRewardFractionUpdated(uint256 l2KeeperRewardFraction);
 
     /**

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -31,10 +31,10 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
 
     address public constant ARB_TX_ADDRESS = 0x000000000000000000000000000000000000006E;
 
-    event DripReceived(uint256 _issuanceBase);
-    event NextDripNonceUpdated(uint256 _nonce);
-    event L1ReservoirAddressUpdated(address _l1ReservoirAddress);
-    event L2KeeperRewardFractionUpdated(uint256 _l2KeeperRewardFraction);
+    event DripReceived(uint256 issuanceBase);
+    event NextDripNonceUpdated(uint256 nonce);
+    event L1ReservoirAddressUpdated(address l1ReservoirAddress);
+    event L2KeeperRewardFractionUpdated(uint256 l2KeeperRewardFraction);
 
     /**
      * @dev Checks that the sender is the L2GraphTokenGateway as configured on the Controller.
@@ -50,6 +50,10 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
      * are not set here because they are set from L1 through the drip function.
      * The RewardsManager's address might also not be available in the controller at initialization
      * time, so approveRewardsManager() must be called separately.
+     * The l1ReservoirAddress must also be set separately through setL1ReservoirAddress
+     * for the same reason.
+     * In the same vein, the l2KeeperRewardFraction is assumed to be zero at initialization,
+     * so it must be set through setL2KeeperRewardFraction.
      * @param _controller Address of the Controller that manages this contract
      */
     function initialize(address _controller) external onlyImpl {

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -83,6 +83,7 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
      * @param _l1ReservoirAddress New address for the L1Reservoir on L1
      */
     function setL1ReservoirAddress(address _l1ReservoirAddress) external onlyGovernor {
+        require(_l1ReservoirAddress != address(0), "INVALID_L1_RESERVOIR");
         l1ReservoirAddress = _l1ReservoirAddress;
         emit L1ReservoirAddressUpdated(_l1ReservoirAddress);
     }

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -11,7 +11,12 @@ import "../../reservoir/Reservoir.sol";
 import "./IL2Reservoir.sol";
 import "./L2ReservoirStorage.sol";
 
-interface IArbTxWithRedeemer {
+/**
+ * @dev ArbRetryableTx with additional interface to query the current redeemer.
+ * This is being added by the Arbitrum team but hasn't made it into the arbos-precompiles
+ * package yet.
+ */
+interface IArbTxWithRedeemer is ArbRetryableTx {
     /**
      * @notice Gets the redeemer of the current retryable redeem attempt.
      * Returns the zero address if the current transaction is not a retryable redeem attempt.

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -114,11 +114,15 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
             snapshotAccumulatedRewards();
         }
         issuanceBase = _issuanceBase;
-        uint256 _l2KeeperReward = _keeperReward.mul(l2KeeperRewardFraction).div(TOKEN_DECIMALS);
         IGraphToken grt = graphToken();
-        // solhint-disable-next-line avoid-tx-origin
-        grt.transfer(tx.origin, _l2KeeperReward);
-        grt.transfer(_l1Keeper, _keeperReward.sub(_l2KeeperReward));
+        // We'd like to reward the keeper that redeemed the tx in L2
+        // but this won't work right now as tx.origin will actually be the L1 sender.
+        // uint256 _l2KeeperReward = _keeperReward.mul(l2KeeperRewardFraction).div(TOKEN_DECIMALS);
+        // // solhint-disable-next-line avoid-tx-origin
+        // grt.transfer(tx.origin, _l2KeeperReward);
+        // grt.transfer(_l1Keeper, _keeperReward.sub(_l2KeeperReward));
+        // So for now we just send all the rewards to teh L1 keeper:
+        grt.transfer(_l1Keeper, _keeperReward);
         emit DripReceived(issuanceBase);
     }
 

--- a/contracts/l2/reservoir/L2Reservoir.sol
+++ b/contracts/l2/reservoir/L2Reservoir.sol
@@ -135,7 +135,7 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
      * @param _issuanceBase Base value for token issuance (approximation for token supply times L2 rewards fraction)
      * @param _issuanceRate Rewards issuance rate, using fixed point at 1e18, and including a +1
      * @param _nonce Incrementing nonce to ensure messages are received in order
-     * @param _keeperReward Keeper reward to distribute between keeper that called drip and keeper that redeemed  the retryable tx
+     * @param _keeperReward Keeper reward to distribute between keeper that called drip and keeper that redeemed the retryable tx
      * @param _l1Keeper Address of the keeper that called drip in L1
      */
     function receiveDrip(
@@ -168,7 +168,7 @@ contract L2Reservoir is L2ReservoirV2Storage, Reservoir, IL2Reservoir {
             grt.transfer(redeemer, _l2KeeperReward);
             grt.transfer(_l1Keeper, _keeperReward.sub(_l2KeeperReward));
         } else {
-            // In an auto-redeem, we just send all the rewards to teh L1 keeper:
+            // In an auto-redeem, we just send all the rewards to the L1 keeper:
             grt.transfer(_l1Keeper, _keeperReward);
         }
 

--- a/contracts/l2/reservoir/L2ReservoirStorage.sol
+++ b/contracts/l2/reservoir/L2ReservoirStorage.sol
@@ -9,3 +9,8 @@ contract L2ReservoirV1Storage {
     // Expected nonce value for the next drip hook
     uint256 public nextDripNonce;
 }
+
+contract L2ReservoirV2Storage is L2ReservoirV1Storage {
+    // Fraction of the keeper reward to send to the retryable tx redeemer in L2 (fixed point 1e18)
+    uint256 public l2KeeperRewardFraction;
+}

--- a/contracts/l2/reservoir/L2ReservoirStorage.sol
+++ b/contracts/l2/reservoir/L2ReservoirStorage.sol
@@ -3,13 +3,17 @@
 pragma solidity ^0.7.6;
 
 /**
- * @dev Storage variables for the L2Reservoir
+ * @dev Storage variables for the L2Reservoir, version 1
  */
 contract L2ReservoirV1Storage {
     // Expected nonce value for the next drip hook
     uint256 public nextDripNonce;
 }
 
+/**
+ * @dev Storage variables for the L2Reservoir, version 2
+ * This version adds some variables needed when introducing the keeper reward.
+ */
 contract L2ReservoirV2Storage is L2ReservoirV1Storage {
     // Fraction of the keeper reward to send to the retryable tx redeemer in L2 (fixed point 1e18)
     uint256 public l2KeeperRewardFraction;

--- a/contracts/l2/reservoir/L2ReservoirStorage.sol
+++ b/contracts/l2/reservoir/L2ReservoirStorage.sol
@@ -13,4 +13,6 @@ contract L2ReservoirV1Storage {
 contract L2ReservoirV2Storage is L2ReservoirV1Storage {
     // Fraction of the keeper reward to send to the retryable tx redeemer in L2 (fixed point 1e18)
     uint256 public l2KeeperRewardFraction;
+    // Address of the L1Reservoir on L1, used to check if a ticket was auto-redeemed
+    address public l1ReservoirAddress;
 }

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -316,7 +316,9 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
         // N = n - eps
         uint256 tokensToMint;
         {
-            uint256 newRewardsPlusMintedActual = newRewardsToDistribute.add(mintedRewardsActual).add(keeperReward);
+            uint256 newRewardsPlusMintedActual = newRewardsToDistribute
+                .add(mintedRewardsActual)
+                .add(keeperReward);
             require(
                 newRewardsPlusMintedActual >= mintedRewardsTotal,
                 "Would mint negative tokens, wait before calling again"
@@ -348,9 +350,9 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
                     tokensToSendToL2 > l2OffsetAmount,
                     "Negative amount would be sent to L2, wait before calling again"
                 );
-                tokensToSendToL2 = tokensToSendToL2.sub(l2OffsetAmount);
+                tokensToSendToL2 = tokensToSendToL2.add(keeperReward).sub(l2OffsetAmount);
             } else {
-                tokensToSendToL2 = tokensToSendToL2.add(
+                tokensToSendToL2 = tokensToSendToL2.add(keeperReward).add(
                     l2RewardsFraction.mul(mintedRewardsActual.sub(mintedRewardsTotal)).div(
                         FIXED_POINT_SCALING_FACTOR
                     )
@@ -367,7 +369,10 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
                 _keeperRewardBeneficiary
             );
         } else if (l2RewardsFraction > 0) {
-            tokensToSendToL2 = tokensToMint.mul(l2RewardsFraction).div(FIXED_POINT_SCALING_FACTOR);
+            tokensToSendToL2 = tokensToMint
+                .mul(l2RewardsFraction)
+                .div(FIXED_POINT_SCALING_FACTOR)
+                .add(keeperReward);
             _sendNewTokensAndStateToL2(
                 tokensToSendToL2,
                 _l2MaxGas,

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -3,13 +3,16 @@
 pragma solidity ^0.7.6;
 pragma abicoder v2;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
-import "../arbitrum/ITokenGateway.sol";
+import { ITokenGateway } from "../arbitrum/ITokenGateway.sol";
 
-import "../l2/reservoir/IL2Reservoir.sol";
-import "./Reservoir.sol";
-import "./L1ReservoirStorage.sol";
+import { Managed } from "../governance/Managed.sol";
+import { IGraphToken } from "../token/IGraphToken.sol";
+import { IStaking } from "../staking/IStaking.sol";
+import { IL2Reservoir } from "../l2/reservoir/IL2Reservoir.sol";
+import { Reservoir } from "./Reservoir.sol";
+import { L1ReservoirV2Storage } from "./L1ReservoirStorage.sol";
 
 /**
  * @title L1 Rewards Reservoir

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -73,6 +73,8 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
      * to the drip function, that also requires the initial supply snapshot to be taken
      * using initialSnapshot. For this reason, issuanceRate and l2RewardsFraction
      * are not initialized here and instead need a call to setIssuanceRate and setL2RewardsFraction.
+     * The same applies to minDripInterval (set through setMinDripInterval) and dripRewardPerBlock
+     * (set through setDripRewardPerBlock).
      * On the other hand, the l2ReservoirAddress is not expected to be known at initialization
      * time and must therefore be set using setL2ReservoirAddress.
      * The RewardsManager's address might also not be available in the controller at initialization
@@ -292,7 +294,10 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
         uint256 _l2MaxSubmissionCost,
         address _keeperRewardBeneficiary
     ) private {
-        require(block.number > lastRewardsUpdateBlock + minDripInterval, "WAIT_FOR_MIN_INTERVAL");
+        require(
+            block.number > lastRewardsUpdateBlock.add(minDripInterval),
+            "WAIT_FOR_MIN_INTERVAL"
+        );
 
         uint256 mintedRewardsTotal = getNewGlobalRewards(rewardsMintedUntilBlock);
         uint256 mintedRewardsActual = getNewGlobalRewards(block.number);

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -150,6 +150,7 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
      * @param _minDripInterval Minimum number of blocks since last drip for drip to be allowed
      */
     function setMinDripInterval(uint256 _minDripInterval) external onlyGovernor {
+        require(_minDripInterval < dripInterval, "MUST_BE_LT_DRIP_INTERVAL");
         minDripInterval = _minDripInterval;
         emit MinDripIntervalUpdated(_minDripInterval);
     }
@@ -302,6 +303,9 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
             block.number > lastRewardsUpdateBlock.add(minDripInterval),
             "WAIT_FOR_MIN_INTERVAL"
         );
+        // Note we only validate that the beneficiary is nonzero, as the caller might
+        // want to send the reward to an address that is different to the indexer/dripper's address.
+        require(_keeperRewardBeneficiary != address(0), "INVALID_BENEFICIARY");
 
         uint256 mintedRewardsTotal = getNewGlobalRewards(rewardsMintedUntilBlock);
         uint256 mintedRewardsActual = getNewGlobalRewards(block.number);

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -43,9 +43,9 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
     // Emitted when minDripInterval is updated
     event MinDripIntervalUpdated(uint256 minDripInterval);
     // Emitted when a new allowedDripper is added
-    event AllowedDripperAdded(address dripper);
+    event AllowedDripperAdded(address indexed dripper);
     // Emitted when an allowedDripper is revoked
-    event AllowedDripperRevoked(address dripper);
+    event AllowedDripperRevoked(address indexed dripper);
 
     /**
      * @dev Checks that the sender is an indexer with stake on the Staking contract,

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -62,7 +62,8 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
      * @param _indexer Indexer for which the sender must be an operator
      */
     modifier onlyIndexerOperator(address _indexer) {
-        require(_isIndexer(_indexer) && staking().isOperator(msg.sender, _indexer), "UNAUTHORIZED");
+        require(_isIndexer(_indexer), "UNAUTHORIZED_INVALID_INDEXER");
+        require(staking().isOperator(msg.sender, _indexer), "UNAUTHORIZED_INVALID_OPERATOR");
         _;
     }
 

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -170,6 +170,8 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
      * @param _dripper Address that will be an allowed dripper
      */
     function grantDripPermission(address _dripper) external onlyGovernor {
+        require(_dripper != address(0), "INVALID_ADDRESS");
+        require(!allowedDrippers[_dripper], "ALREADY_A_DRIPPER");
         allowedDrippers[_dripper] = true;
         emit AllowedDripperAdded(_dripper);
     }
@@ -179,6 +181,8 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
      * @param _dripper Address that will not be an allowed dripper anymore
      */
     function revokeDripPermission(address _dripper) external onlyGovernor {
+        require(_dripper != address(0), "INVALID_ADDRESS");
+        require(allowedDrippers[_dripper], "NOT_A_DRIPPER");
         allowedDrippers[_dripper] = false;
         emit AllowedDripperRevoked(_dripper);
     }

--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -307,9 +307,7 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
         uint256 mintedRewardsActual = getNewGlobalRewards(block.number);
         // eps = (signed int) mintedRewardsTotal - mintedRewardsActual
 
-        uint256 keeperReward = dripRewardPerBlock.mul(
-            block.number.sub(lastRewardsUpdateBlock).sub(minDripInterval)
-        );
+        uint256 keeperReward = dripRewardPerBlock.mul(block.number.sub(lastRewardsUpdateBlock));
         if (nextIssuanceRate != issuanceRate) {
             rewardsManager().updateAccRewardsPerSignal();
             snapshotAccumulatedRewards(mintedRewardsActual); // This updates lastRewardsUpdateBlock

--- a/contracts/reservoir/L1ReservoirStorage.sol
+++ b/contracts/reservoir/L1ReservoirStorage.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.7.6;
 
 /**
- * @dev Storage variables for the L1Reservoir
+ * @dev Storage variables for the L1Reservoir, version 1
  */
 contract L1ReservoirV1Storage {
     // Fraction of total rewards to be sent by L2, expressed in fixed point at 1e18
@@ -22,6 +22,10 @@ contract L1ReservoirV1Storage {
     uint256 public nextDripNonce;
 }
 
+/**
+ * @dev Storage variables for the L1Reservoir, version 2
+ * This version adds some variables that are needed when introducing keeper rewards.
+ */
 contract L1ReservoirV2Storage is L1ReservoirV1Storage {
     // Minimum number of blocks since last drip for a new drip to be allowed
     uint256 public minDripInterval;

--- a/contracts/reservoir/L1ReservoirStorage.sol
+++ b/contracts/reservoir/L1ReservoirStorage.sol
@@ -27,4 +27,6 @@ contract L1ReservoirV2Storage is L1ReservoirV1Storage {
     uint256 public minDripInterval;
     // Drip reward in GRT for each block since lastRewardsUpdateBlock + dripRewardThreshold
     uint256 public dripRewardPerBlock;
+    // True for addresses that are allowed to call drip()
+    mapping(address => bool) public allowedDrippers;
 }

--- a/contracts/reservoir/L1ReservoirStorage.sol
+++ b/contracts/reservoir/L1ReservoirStorage.sol
@@ -21,3 +21,10 @@ contract L1ReservoirV1Storage {
     // Auto-incrementing nonce that will be used when sending rewards to L2, to ensure ordering
     uint256 public nextDripNonce;
 }
+
+contract L1ReservoirV2Storage is L1ReservoirV1Storage {
+    // Minimum number of blocks since last drip for a new drip to be allowed
+    uint256 public minDripInterval;
+    // Drip reward in GRT for each block since lastRewardsUpdateBlock + dripRewardThreshold
+    uint256 public dripRewardPerBlock;
+}

--- a/contracts/reservoir/Reservoir.sol
+++ b/contracts/reservoir/Reservoir.sol
@@ -19,7 +19,9 @@ import "./IReservoir.sol";
 abstract contract Reservoir is GraphUpgradeable, ReservoirV1Storage, IReservoir {
     using SafeMath for uint256;
 
+    // Scaling factor for all fixed point arithmetics
     uint256 internal constant FIXED_POINT_SCALING_FACTOR = 1e18;
+    // Minimum issuance rate (expressed in fixed point at 1e18)
     uint256 internal constant MIN_ISSUANCE_RATE = 1e18;
 
     /**

--- a/contracts/reservoir/ReservoirStorage.sol
+++ b/contracts/reservoir/ReservoirStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.7.6;
 import "../governance/Managed.sol";
 
 /**
- * @dev Base storage variables for the Reservoir on both layers
+ * @dev Base storage variables for the Reservoir on both layers, version 1
  */
 contract ReservoirV1Storage is Managed {
     // Relative increase of the total supply per block, plus 1, expressed in fixed point at 1e18.

--- a/test/l2/l2Reservoir.test.ts
+++ b/test/l2/l2Reservoir.test.ts
@@ -174,6 +174,10 @@ describe('L2Reservoir', () => {
         .setL1ReservoirAddress(testAccount1.address)
       await expect(tx).revertedWith('Caller must be Controller governor')
     })
+    it('rejects setting a zero address', async function () {
+      const tx = l2Reservoir.connect(governor.signer).setL1ReservoirAddress(constants.AddressZero)
+      await expect(tx).revertedWith('INVALID_L1_RESERVOIR')
+    })
     it('sets the L1Reservoir address', async function () {
       const tx = l2Reservoir.connect(governor.signer).setL1ReservoirAddress(testAccount1.address)
       await expect(tx).emit(l2Reservoir, 'L1ReservoirAddressUpdated').withArgs(testAccount1.address)

--- a/test/l2/l2Reservoir.test.ts
+++ b/test/l2/l2Reservoir.test.ts
@@ -160,7 +160,13 @@ describe('L2Reservoir', () => {
     it('rejects the call when not called by the gateway', async function () {
       const tx = l2Reservoir
         .connect(governor.signer)
-        .receiveDrip(dripNormalizedSupply, dripIssuanceRate, toBN('0'))
+        .receiveDrip(
+          dripNormalizedSupply,
+          dripIssuanceRate,
+          toBN('0'),
+          toBN('0'),
+          testAccount1.address,
+        )
       await expect(tx).revertedWith('ONLY_GATEWAY')
     })
     it('rejects the call when received out of order', async function () {
@@ -169,6 +175,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         dripIssuanceRate,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       const tx = await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -181,6 +189,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply.add(1),
         dripIssuanceRate.add(1),
         toBN('2'),
+        toBN('0'),
+        testAccount1.address,
       )
       const tx2 = gatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -192,6 +202,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         dripIssuanceRate,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       const tx = await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -205,6 +217,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         dripIssuanceRate,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       let tx = await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -216,6 +230,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply.add(1),
         dripIssuanceRate.add(1),
         toBN('1'),
+        toBN('0'),
+        testAccount1.address,
       )
       tx = await gatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -230,6 +246,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         dripIssuanceRate,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       let tx = await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -241,6 +259,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply.add(1),
         dripIssuanceRate,
         toBN('1'),
+        toBN('0'),
+        testAccount1.address,
       )
       tx = await gatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -255,6 +275,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         dripIssuanceRate,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       let tx = await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -267,6 +289,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply.add(1),
         dripIssuanceRate,
         toBN('2'),
+        toBN('0'),
+        testAccount1.address,
       )
       tx = await gatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()
@@ -285,6 +309,8 @@ describe('L2Reservoir', () => {
         dripNormalizedSupply,
         ISSUANCE_RATE_PER_BLOCK,
         toBN('0'),
+        toBN('0'),
+        testAccount1.address,
       )
       await validGatewayFinalizeTransfer(receiveDripTx.data)
       dripBlock = await latestBlock()

--- a/test/l2/l2Reservoir.test.ts
+++ b/test/l2/l2Reservoir.test.ts
@@ -16,6 +16,7 @@ import {
   Account,
   RewardsTracker,
   getL2SignerFromL1,
+  applyL1ToL2Alias,
 } from '../lib/testHelpers'
 import { L2Reservoir } from '../../build/types/L2Reservoir'
 
@@ -143,7 +144,7 @@ describe('L2Reservoir', () => {
     arbTxMock = await smock.fake('IArbTxWithRedeemer', {
       address: '0x000000000000000000000000000000000000006E',
     })
-    arbTxMock.getCurrentRedeemer.returns(mockL1Reservoir.address)
+    arbTxMock.getCurrentRedeemer.returns(applyL1ToL2Alias(mockL1Reservoir.address))
   })
 
   beforeEach(async function () {

--- a/test/reservoir/l1Reservoir.test.ts
+++ b/test/reservoir/l1Reservoir.test.ts
@@ -592,7 +592,6 @@ describe('L1Reservoir', () => {
       const dripBlock = (await latestBlock()).add(1) // We're gonna drip in the next transaction
       const expectedKeeperReward = dripBlock
         .sub(await l1Reservoir.lastRewardsUpdateBlock())
-        .sub(toBN('2'))
         .mul(toGRT('3'))
       const tracker = await RewardsTracker.create(
         issuanceBase,

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -79,7 +79,7 @@ describe('Rewards', () => {
   ) => {
     // -- t0 --
     const tracker = await RewardsTracker.create(initialSupply, ISSUANCE_RATE_PER_BLOCK, dripBlock)
-    tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
+    await tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
     // Jump
     await advanceBlocks(nBlocks)
 
@@ -330,11 +330,11 @@ describe('Rewards', () => {
         await curation.connect(curator1.signer).mint(subgraphDeploymentID1, toGRT('1000'), 0)
         // Minting signal triggers onSubgraphSignalUpgrade before pulling the GRT,
         // so we snapshot using the previous value
-        tracker.snapshotPerSignal(prevSignal)
+        await tracker.snapshotPerSignal(prevSignal)
 
         // Update
         await rewardsManager.updateAccRewardsPerSignal()
-        tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
+        await tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
 
         const contractAccrued = await rewardsManager.accRewardsPerSignal()
 
@@ -359,14 +359,14 @@ describe('Rewards', () => {
         await curation.connect(curator1.signer).mint(subgraphDeploymentID1, toGRT('1000'), 0)
         // Minting signal triggers onSubgraphSignalUpgrade before pulling the GRT,
         // so we snapshot using the previous value
-        tracker.snapshotPerSignal(prevSignal)
+        await tracker.snapshotPerSignal(prevSignal)
 
         // Jump
         await advanceBlocks(ISSUANCE_RATE_PERIODS)
 
         // Update
         await rewardsManager.updateAccRewardsPerSignal()
-        tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
+        await tracker.snapshotPerSignal(await grt.balanceOf(curation.address))
         const contractAccrued = await rewardsManager.accRewardsPerSignal()
 
         const blockNum = await latestBlock()

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -42,6 +42,7 @@ describe('Rewards', () => {
   let indexer1: Account
   let indexer2: Account
   let oracle: Account
+  let keeper: Account
 
   let fixture: NetworkFixture
 
@@ -107,7 +108,8 @@ describe('Rewards', () => {
   }
 
   before(async function () {
-    ;[delegator, governor, curator1, curator2, indexer1, indexer2, oracle] = await getAccounts()
+    ;[delegator, governor, curator1, curator2, indexer1, indexer2, oracle, keeper] =
+      await getAccounts()
 
     fixture = new NetworkFixture()
     ;({ grt, curation, epochManager, staking, rewardsManager, l1Reservoir } = await fixture.load(
@@ -276,7 +278,7 @@ describe('Rewards', () => {
     beforeEach(async function () {
       // 5% minute rate (4 blocks)
       await l1Reservoir.connect(governor.signer).setIssuanceRate(ISSUANCE_RATE_PER_BLOCK)
-      await l1Reservoir.connect(governor.signer).drip(toBN(0), toBN(0), toBN(0))
+      await l1Reservoir.connect(keeper.signer).drip(toBN(0), toBN(0), toBN(0), keeper.address)
       dripBlock = await latestBlock()
     })
 

--- a/test/rewards/rewards.test.ts
+++ b/test/rewards/rewards.test.ts
@@ -122,6 +122,7 @@ describe('Rewards', () => {
       await grt.connect(wallet.signer).approve(staking.address, toGRT('1000000'))
       await grt.connect(wallet.signer).approve(curation.address, toGRT('1000000'))
     }
+    await l1Reservoir.connect(governor.signer).grantDripPermission(keeper.address)
     await l1Reservoir.connect(governor.signer).initialSnapshot(toBN(0))
     supplyBeforeDrip = await grt.totalSupply()
   })
@@ -278,7 +279,9 @@ describe('Rewards', () => {
     beforeEach(async function () {
       // 5% minute rate (4 blocks)
       await l1Reservoir.connect(governor.signer).setIssuanceRate(ISSUANCE_RATE_PER_BLOCK)
-      await l1Reservoir.connect(keeper.signer).drip(toBN(0), toBN(0), toBN(0), keeper.address)
+      await l1Reservoir
+        .connect(keeper.signer)
+        ['drip(uint256,uint256,uint256,address)'](toBN(0), toBN(0), toBN(0), keeper.address)
       dripBlock = await latestBlock()
     })
 
@@ -660,18 +663,15 @@ describe('Rewards', () => {
     describe('takeRewards', function () {
       it('should distribute rewards on closed allocation and stake', async function () {
         // Align with the epoch boundary
-        // dripBlock (81)
         await epochManager.setEpochLength(10)
-        // dripBlock + 1
         await advanceToNextEpoch(epochManager)
-        // dripBlock + 4
+
         // Setup
         await setupIndexerAllocation()
         const firstSnapshotBlocks = new BN((await latestBlock()).sub(dripBlock).toString())
-        // dripBlock + 7
+
         // Jump
         await advanceToNextEpoch(epochManager)
-        // dripBlock + 14
 
         // Before state
         const beforeTokenSupply = await grt.totalSupply()
@@ -797,7 +797,7 @@ describe('Rewards', () => {
 
         // Jump
         await advanceToNextEpoch(epochManager)
-        // dripBlock + 14
+        // dripBlock + 13
 
         // Before state
         const beforeTokenSupply = await grt.totalSupply()
@@ -839,17 +839,23 @@ describe('Rewards', () => {
 
       it('should deny and burn rewards if subgraph on denylist', async function () {
         // Setup
+        // dripBlock (82)
         await epochManager.setEpochLength(10)
+        // dripBlock + 1
         await rewardsManager
           .connect(governor.signer)
           .setSubgraphAvailabilityOracle(governor.address)
+        // dripBlock + 2
         await rewardsManager.connect(governor.signer).setDenied(subgraphDeploymentID1, true)
+        // dripBlock + 3 (epoch boundary!)
         await advanceToNextEpoch(epochManager)
+        // dripBlock + 13
         await setupIndexerAllocation()
         const firstSnapshotBlocks = new BN((await latestBlock()).sub(dripBlock).toString())
 
         // Jump
         await advanceToNextEpoch(epochManager)
+        // dripBlock + 23
 
         const supplyBefore = await grt.totalSupply()
         // Close allocation. At this point rewards should be collected for that indexer


### PR DESCRIPTION
WIP as I still need to fix the tests.

This complements #571 adding a reward for whoever called drip(), to incentivise calling it and offset the gas costs. The reward is produced through additional token issuance that grows linearly with the number of blocks, after a minimum number of blocks since the last drip have passed.

Note the reward is credited on L1 if the l2RewardsFraction is set to 0. If l2RewardsFraction is nonzero, the reward will be credited in L2, and part of it will be given to the address that initiated the retryable ticket transaction, so that if a lazy or malicious keeper does not redeem the tx in L2, there is incentive for someone else to jump in and redeem it.