### PR TITLE
feat: refactor graph runtime environment hardhat extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ MNEMONIC=
 ETHERSCAN_API_KEY=
 INFURA_KEY=
 ADDRESS_BOOK="addresses.json"
-GRAPH_CONFIG=""config/graph.mainnet.yml""
+GRAPH_CONFIG="config/graph.mainnet.yml"
 PROVIDER_URL="http://localhost:8545"

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ MNEMONIC=
 ETHERSCAN_API_KEY=
 INFURA_KEY=
 ADDRESS_BOOK="addresses.json"
-GRAPH_CONFIG=""config/graph.mainnet.yml""
+GRAPH_CONFIG="config/graph.mainnet.yml"
 PROVIDER_URL="http://localhost:8545"
 ```
 

--- a/tasks/deployment/config.ts
+++ b/tasks/deployment/config.ts
@@ -5,9 +5,8 @@ import { writeConfig } from '../../cli/config'
 import YAML from 'yaml'
 
 import { Scalar, YAMLMap } from 'yaml/types'
-import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import fs from 'fs'
 import { confirm } from '../../cli/helpers'
+import { NetworkContracts } from '../../cli/contracts'
 
 interface Contract {
   name: string

--- a/tasks/deployment/config.ts
+++ b/tasks/deployment/config.ts
@@ -1,7 +1,7 @@
 import { task } from 'hardhat/config'
 import '@nomiclabs/hardhat-ethers'
 import { cliOpts } from '../../cli/defaults'
-import { readConfig, writeConfig } from '../../cli/config'
+import { writeConfig } from '../../cli/config'
 import YAML from 'yaml'
 
 import { Scalar, YAMLMap } from 'yaml/types'
@@ -117,7 +117,7 @@ task('update-config', 'Update graph config parameters with onchain data')
       if (!sure) return
     }
 
-    const graphConfig = readConfig(configFile, true)
+    const { graphConfig } = hre.graph
 
     // general parameters
     console.log(`> General`)
@@ -144,7 +144,7 @@ const updateGeneralParams = async (
   param: GeneralParam,
   config: YAML.Document.Parsed,
 ) => {
-  const value = await hre.contracts[param.contract][param.name]()
+  const value = await hre.graph.contracts[param.contract][param.name]()
   const updated = updateItem(config, `general/${param.name}`, value)
   if (updated) {
     console.log(`\t- Updated ${param.name} to ${value}`)
@@ -157,7 +157,7 @@ const updateContractParams = async (
   config: YAML.Document.Parsed,
 ) => {
   for (const param of contract.initParams) {
-    let value = await hre.contracts[contract.name][param.getter ?? param.name]()
+    let value = await hre.graph.contracts[contract.name][param.getter ?? param.name]()
     if (param.type === 'BigNumber') {
       if (param.format === 'number') {
         value = value.toNumber()

--- a/tasks/gre.ts
+++ b/tasks/gre.ts
@@ -15,7 +15,9 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   const addressBookPath = process.env.ADDRESS_BOOK ?? cliOpts.addressBook.default // --address-book
   const graphConfigPath = process.env.GRAPH_CONFIG ?? cliOpts.graphConfig.default // --graph-config
 
-  hre.graph.addressBook = lazyObject(() => getAddressBook(addressBookPath, chainId))
-  hre.graph.graphConfig = lazyObject(() => readConfig(graphConfigPath, true))
-  hre.graph.contracts = lazyObject(() => loadContracts(hre.graph.addressBook, hre.ethers.provider))
+  hre.graph = {
+    addressBook: lazyObject(() => getAddressBook(addressBookPath, chainId)),
+    graphConfig: lazyObject(() => readConfig(graphConfigPath, true)),
+    contracts: lazyObject(() => loadContracts(hre.graph.addressBook, hre.ethers.provider)),
+  }
 })

--- a/tasks/test-upgrade.ts
+++ b/tasks/test-upgrade.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-
 import { task } from 'hardhat/config'
 
 function saveProxyAddresses(data) {

--- a/tasks/type-extensions.d.ts
+++ b/tasks/type-extensions.d.ts
@@ -1,0 +1,12 @@
+import { AddressBook } from '../cli/address-book'
+import { NetworkContracts } from '../cli/contracts'
+
+declare module 'hardhat/types/runtime' {
+  export interface HardhatRuntimeEnvironment {
+    graph: {
+      contracts: NetworkContracts
+      graphConfig: any
+      addressBook: AddressBook
+    }
+  }
+}

--- a/tasks/type-extensions.d.ts
+++ b/tasks/type-extensions.d.ts
@@ -1,9 +1,14 @@
 import { AddressBook } from '../cli/address-book'
 import { NetworkContracts } from '../cli/contracts'
 
+interface GREOptions {
+  addressBook?: string
+  graphConfig?: string
+}
+
 declare module 'hardhat/types/runtime' {
   export interface HardhatRuntimeEnvironment {
-    graph: {
+    graph: (opts?: GREOptions) => {
       contracts: NetworkContracts
       graphConfig: any
       addressBook: AddressBook

--- a/tasks/verify/verify.ts
+++ b/tasks/verify/verify.ts
@@ -44,7 +44,7 @@ task('sourcifyAll', 'Verifies all contracts on sourcify')
       throw new Error('Cannot verify contracts without a network')
     }
     console.log(`> Verifying all contracts on chain ${chainName}[${chainId}]...`)
-    const { addressBook } = hre.graph
+    const { addressBook } = hre.graph({ addressBook: _args.addressBook })
 
     for (const contractName of addressBook.listEntries()) {
       console.log(`\n> Verifying contract ${contractName}...`)
@@ -84,7 +84,10 @@ task('verifyAll', 'Verifies all contracts on etherscan')
     }
 
     console.log(`> Verifying all contracts on chain ${chainName}[${chainId}]...`)
-    const { addressBook, graphConfig } = hre.graph
+    const { addressBook, graphConfig } = hre.graph({
+      addressBook: args.addressBook,
+      graphConfig: args.graphConfig,
+    })
 
     const accounts = await hre.ethers.getSigners()
     const env = await loadEnv(args, accounts[0] as unknown as Wallet)

--- a/tasks/verify/verify.ts
+++ b/tasks/verify/verify.ts
@@ -5,13 +5,11 @@ import { isFullyQualifiedName, parseFullyQualifiedName } from 'hardhat/utils/con
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names'
 import { loadEnv } from '../../cli/env'
 import { cliOpts } from '../../cli/defaults'
-import { getAddressBook } from '../../cli/address-book'
-import { getContractConfig, readConfig } from '../../cli/config'
+import { getContractConfig } from '../../cli/config'
 import { Wallet } from 'ethers'
-import { NomicLabsHardhatPluginError } from 'hardhat/plugins'
 import fs from 'fs'
 import path from 'path'
-import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { HardhatRuntimeEnvironment } from 'hardhat/types/runtime'
 
 task('sourcify', 'Verifies contract on sourcify')
   .addPositionalParam('address', 'Address of the smart contract to verify', undefined, types.string)
@@ -46,7 +44,7 @@ task('sourcifyAll', 'Verifies all contracts on sourcify')
       throw new Error('Cannot verify contracts without a network')
     }
     console.log(`> Verifying all contracts on chain ${chainName}[${chainId}]...`)
-    const addressBook = getAddressBook(cliOpts.addressBook.default, chainId.toString())
+    const { addressBook } = hre.graph
 
     for (const contractName of addressBook.listEntries()) {
       console.log(`\n> Verifying contract ${contractName}...`)
@@ -86,8 +84,7 @@ task('verifyAll', 'Verifies all contracts on etherscan')
     }
 
     console.log(`> Verifying all contracts on chain ${chainName}[${chainId}]...`)
-    const addressBook = getAddressBook(args.addressBook, chainId.toString())
-    const graphConfig = readConfig(args.graphConfig)
+    const { addressBook, graphConfig } = hre.graph
 
     const accounts = await hre.ethers.getSigners()
     const env = await loadEnv(args, accounts[0] as unknown as Wallet)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,15 +8,5 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "exclude": ["dist", "node_modules"],
-  "files": [
-    "./hardhat.config.ts",
-    "./scripts/**/*.ts",
-    "./test/**/*.ts",
-    "node_modules/@nomiclabs/hardhat-ethers/internal/type-extensions.d.ts",
-    "node_modules/@nomiclabs/hardhat-etherscan/dist/src/type-extensions.d.ts",
-    "node_modules/@nomiclabs/hardhat-waffle/dist/src/type-extensions.d.ts",
-    "node_modules/@typechain/hardhat/dist/type-extensions.d.ts",
-    "./index.d.ts"
-  ]
+  "include": ["hardhat.config.ts", "index.d.ts", "scripts/**/*.ts", "test/**/*.ts", "tasks/**/*.ts"]
 }


### PR DESCRIPTION
### Motivation
This PR refactors the Graph Runtime Environment extension on hardhat. Currently most functionality is not using GRE and is instead using ` loadEnv` which is a similar concept but inherited from the CLI.

In the future we should think about supporting a single environment for our tooling (CLI vs hardhat), the changes proposed to GRE here assume that future is built using hardhat tooling. New features should use GRE and hardhat environment, and we should aim towards slowly integrating the CLI functionality.

### Changes

GRE now exposes and instanced address book, graph config and contracts:

```js
// Use env vars to determine addressBook (ADDRESS_BOOK) and graphConfig (GRAPH_CONFIG) files 
const { addressBook, contracts, graphConfig } = hre.graph()

const graphTokenEntry = addressBook.getEntry("GraphToken")
console.log(`GraphToken address: ${graphTokenEntry.address}`)

const GraphToken = contracts.GraphToken
const totalSupply = await GraphToken.totalSupply()
console.log(`GRT totalSupply is ${totalSupply}`)
```

You can also specify paths to the graph config and address book files:

```js

// Use custom addressBook and graphConfig files
const { addressBook, graphConfig } = hre.graph({
  addressBook: args.addressBook,
  graphConfig: args.graphConfig,
})
```


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>