### PR TITLE
chore: remove unused ganache and ethereumDIDRegistry references

### DIFF
--- a/cli/commands/migrate.ts
+++ b/cli/commands/migrate.ts
@@ -17,7 +17,7 @@ const { EtherSymbol } = constants
 const { formatEther } = utils
 
 // Contracts are deployed in the order defined in this list
-let allContracts = [
+const allContracts = [
   'GraphProxyAdmin',
   'BancorFormula',
   'Controller',
@@ -48,7 +48,6 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
 
   if (chainId == 1337) {
     await (cli.wallet.provider as providers.JsonRpcProvider).send('evm_setAutomine', [true])
-    allContracts = ['EthereumDIDRegistry', ...allContracts]
   }
 
   logger.info(`>>> Migrating contracts <<<\n`)

--- a/cli/contracts.ts
+++ b/cli/contracts.ts
@@ -16,7 +16,6 @@ import { GraphToken } from '../build/types/GraphToken'
 import { Controller } from '../build/types/Controller'
 import { BancorFormula } from '../build/types/BancorFormula'
 import { IENS } from '../build/types/IENS'
-import { IEthereumDIDRegistry } from '../build/types/IEthereumDIDRegistry'
 import { GraphGovernance } from '../build/types/GraphGovernance'
 import { AllocationExchange } from '../build/types/AllocationExchange'
 
@@ -33,7 +32,6 @@ export interface NetworkContracts {
   Controller: Controller
   BancorFormula: BancorFormula
   IENS: IENS
-  IEthereumDIDRegistry: IEthereumDIDRegistry
   GraphGovernance: GraphGovernance
   AllocationExchange: AllocationExchange
 }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "clean": "rm -rf build/ cache/ dist/",
     "compile": "hardhat compile",
     "deploy": "scripts/predeploy && hardhat migrate",
-    "deploy-ganache": "yarn deploy -- --force",
-    "deploy-ganache-manual": "yarn deploy -- --force --network ganache",
     "deploy-hardhat": "yarn deploy -- --force --network hardhat",
     "deploy-rinkeby": "yarn deploy -- --force --network rinkeby --graph-config config/graph.rinkeby.yml",
     "deploy-goerli": "yarn deploy -- --force --network goerli --graph-config config/graph.goerli.yml",

--- a/scripts/predeploy
+++ b/scripts/predeploy
@@ -2,7 +2,5 @@
 
 cat addresses.json |
     jq '."1"."IENS".address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"' |
-    jq '."4"."IENS".address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"' |
-    jq '."1"."IEthereumDIDRegistry".address = "0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B"' |
-    jq '."4"."IEthereumDIDRegistry".address = "0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B"' > addresses.json.tmp
+    jq '."4"."IENS".address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"' > addresses.json.tmp
 mv addresses.json.tmp addresses.json

--- a/test/lib/deployment.ts
+++ b/test/lib/deployment.ts
@@ -16,7 +16,6 @@ import { GraphToken } from '../../build/types/GraphToken'
 import { ServiceRegistry } from '../../build/types/ServiceRegistry'
 import { Staking } from '../../build/types/Staking'
 import { RewardsManager } from '../../build/types/RewardsManager'
-import { EthereumDIDRegistry } from '../../build/types/EthereumDIDRegistry'
 import { GraphGovernance } from '../../build/types/GraphGovernance'
 import { SubgraphNFT } from '../../build/types/SubgraphNFT'
 
@@ -178,10 +177,6 @@ export async function deployGNS(
   await subgraphNFT.connect(deployer).setTokenDescriptor(subgraphDescriptor.address)
 
   return proxy
-}
-
-export async function deployEthereumDIDRegistry(deployer: Signer): Promise<EthereumDIDRegistry> {
-  return deployContract('EthereumDIDRegistry', deployer) as unknown as Promise<EthereumDIDRegistry>
 }
 
 export async function deployServiceRegistry(


### PR DESCRIPTION
Remove unused code:
- Ganache no longer being used
- EthereumDIDRegistry is the old method to manage subgraph ownership

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>