### PR TITLE
fix: prevent underflow when subgraphs go under the minimum signal threshold

### DIFF
--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -281,9 +281,12 @@ contract RewardsManager is RewardsManagerV3Storage, GraphUpgradeable, IRewardsMa
         Subgraph storage subgraph = subgraphs[_subgraphDeploymentID];
 
         uint256 accRewardsForSubgraph = getAccRewardsForSubgraph(_subgraphDeploymentID);
-        uint256 newRewardsForSubgraph = accRewardsForSubgraph.sub(
-            subgraph.accRewardsForSubgraphSnapshot
-        );
+        uint256 newRewardsForSubgraph;
+        if (accRewardsForSubgraph > subgraph.accRewardsForSubgraphSnapshot) {
+            newRewardsForSubgraph = accRewardsForSubgraph.sub(
+                subgraph.accRewardsForSubgraphSnapshot
+            );
+        }
 
         uint256 subgraphAllocatedTokens = staking().getSubgraphAllocatedTokens(
             _subgraphDeploymentID

--- a/contracts/rewards/RewardsManager.sol
+++ b/contracts/rewards/RewardsManager.sol
@@ -6,6 +6,7 @@ pragma abicoder v2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "../upgrades/GraphUpgradeable.sol";
+import "../staking/libs/MathUtils.sol";
 
 import "./RewardsManagerStorage.sol";
 import "./IRewardsManager.sol";
@@ -281,12 +282,10 @@ contract RewardsManager is RewardsManagerV3Storage, GraphUpgradeable, IRewardsMa
         Subgraph storage subgraph = subgraphs[_subgraphDeploymentID];
 
         uint256 accRewardsForSubgraph = getAccRewardsForSubgraph(_subgraphDeploymentID);
-        uint256 newRewardsForSubgraph;
-        if (accRewardsForSubgraph > subgraph.accRewardsForSubgraphSnapshot) {
-            newRewardsForSubgraph = accRewardsForSubgraph.sub(
-                subgraph.accRewardsForSubgraphSnapshot
-            );
-        }
+        uint256 newRewardsForSubgraph = MathUtils.diffOrZero(
+            accRewardsForSubgraph,
+            subgraph.accRewardsForSubgraphSnapshot
+        );
 
         uint256 subgraphAllocatedTokens = staking().getSubgraphAllocatedTokens(
             _subgraphDeploymentID


### PR DESCRIPTION
Depends on #569 