### PR TITLE
fix: use localhost config for localhost yarn deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "clean": "rm -rf build/ cache/ dist/",
     "compile": "hardhat compile",
     "deploy": "yarn build && scripts/predeploy && hardhat migrate",
-    "deploy-localhost": "yarn deploy --force --network localhost",
+    "deploy-localhost": "yarn deploy --force --network localhost --graph-config config/graph.localhost.yml",
     "deploy-rinkeby": "yarn deploy --force --network rinkeby --graph-config config/graph.rinkeby.yml",
     "deploy-goerli": "yarn deploy --force --network goerli --graph-config config/graph.goerli.yml",
     "predeploy": "scripts/predeploy",


### PR DESCRIPTION
Yarn script `yarn deploy-localhost` was using the default graph config which is `graph.mainnet.yml`. Added the `--graph-config` flag so it uses `graph.localhost.yml`.

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>