### PR TITLE
fix: rewards manager e2e config test

### DIFF
--- a/config/graph.goerli.yml
+++ b/config/graph.goerli.yml
@@ -119,8 +119,9 @@ contracts:
     proxy: true
     init:
       controller: "${{Controller.address}}"
-      issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
     calls:
+      - fn: "setIssuanceRate"
+        issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
       - fn: "setSubgraphAvailabilityOracle"
         subgraphAvailabilityOracle: *availabilityOracle
   AllocationExchange:

--- a/config/graph.localhost.yml
+++ b/config/graph.localhost.yml
@@ -119,8 +119,9 @@ contracts:
     proxy: true
     init:
       controller: "${{Controller.address}}"
-      issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
     calls:
+      - fn: "setIssuanceRate"
+        issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
       - fn: "setSubgraphAvailabilityOracle"
         subgraphAvailabilityOracle: *availabilityOracle
   AllocationExchange:

--- a/config/graph.mainnet.yml
+++ b/config/graph.mainnet.yml
@@ -108,7 +108,7 @@ contracts:
       controller: "${{Controller.address}}"
     calls:
       - fn: "setIssuanceRate"
-        _issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
+        issuanceRate: "1000000012184945188" # per block increase of total supply, blocks in a year = 365*60*60*24/13
   AllocationExchange:
     init:
       graphToken: "${{GraphToken.address}}"

--- a/e2e/deployment/config/rewardsManager.test.ts
+++ b/e2e/deployment/config/rewardsManager.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { getItemValue } from '../../../cli/config'
 import { NamedAccounts } from '../../../tasks/type-extensions'
 
 describe('RewardsManager configuration', () => {
   const {
-    graphConfig,
     getNamedAccounts,
     contracts: { RewardsManager, Controller },
   } = hre.graph()
@@ -23,8 +21,7 @@ describe('RewardsManager configuration', () => {
 
   it('issuanceRate should match "issuanceRate" in the config file', async function () {
     const value = await RewardsManager.issuanceRate()
-    const expected = getItemValue(graphConfig, 'contracts/RewardsManager/init/issuanceRate')
-    expect(value).eq(expected)
+    expect(value).eq('1000000012184945188') // hardcoded as it's set with a function call rather than init parameter
   })
 
   it('should allow subgraph availability oracle to deny rewards', async function () {


### PR DESCRIPTION
PR #569 broke one of the rewards manager e2e config tests as it removed an initialization value from the initializer and instead is setting it with a function call. 

Connected to: #654
Signed-off-by: Tomás Migone <tomas@edgeandnode.com>