### PR TITLE
Simplify GRE account logic

### DIFF
--- a/tasks/deployment/accounts.ts
+++ b/tasks/deployment/accounts.ts
@@ -10,22 +10,22 @@ task('migrate:accounts', '[localhost] Creates protocol accounts and saves them i
       throw new Error('This task can only be run on localhost network')
     }
 
-    const { graphConfig, getNamedAccounts, getDeployer } = hre.graph({
+    const { graphConfig, getDeployer } = hre.graph({
       graphConfig: taskArgs.graphConfig,
     })
 
     console.log('> Generating addresses')
 
     const deployer = await getDeployer()
-    const {
+    const [
+      ,
       arbitrator,
       governor,
       authority,
       availabilityOracle,
       pauseGuardian,
       allocationExchangeOwner,
-    } = await getNamedAccounts()
-    console.log(await getNamedAccounts())
+    ] = await hre.ethers.getSigners()
 
     console.log(`- Deployer: ${deployer.address}`)
     console.log(`- Arbitrator: ${arbitrator.address}`)

--- a/tasks/deployment/ownership.ts
+++ b/tasks/deployment/ownership.ts
@@ -23,10 +23,10 @@ task(
     console.log(`- Governor: ${governor.address}`)
 
     const txs: ContractTransaction[] = []
-    txs.push(await contracts.GraphToken.connect(governor.signer).acceptOwnership())
-    txs.push(await contracts.Controller.connect(governor.signer).acceptOwnership())
-    txs.push(await contracts.GraphProxyAdmin.connect(governor.signer).acceptOwnership())
-    txs.push(await contracts.SubgraphNFT.connect(governor.signer).acceptOwnership())
+    txs.push(await contracts.GraphToken.connect(governor).acceptOwnership())
+    txs.push(await contracts.Controller.connect(governor).acceptOwnership())
+    txs.push(await contracts.GraphProxyAdmin.connect(governor).acceptOwnership())
+    txs.push(await contracts.SubgraphNFT.connect(governor).acceptOwnership())
 
     await Promise.all(txs.map((tx) => tx.wait()))
     console.log('Done!')

--- a/tasks/deployment/unpause.ts
+++ b/tasks/deployment/unpause.ts
@@ -12,7 +12,7 @@ task('migrate:unpause', 'Unpause protocol')
     const { governor } = await getNamedAccounts()
 
     console.log('> Unpausing protocol')
-    const tx = await contracts.Controller.connect(governor.signer).setPaused(false)
+    const tx = await contracts.Controller.connect(governor).setPaused(false)
     await tx.wait()
     console.log('Done!')
   })

--- a/tasks/gre.ts
+++ b/tasks/gre.ts
@@ -44,7 +44,7 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
 
       // Get signers and filter out blacklisted accounts
       let signers: SignerWithAddress[] = await hre.ethers.getSigners()
-      signers = signers.filter(async (s) => {
+      signers = signers.filter((s) => {
         return !blacklist.includes(s.address)
       })
 

--- a/tasks/gre.ts
+++ b/tasks/gre.ts
@@ -52,11 +52,11 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
     }
 
     const getNamedAccounts = async (): Promise<NamedAccounts> => {
-      const namedAccounts = namedAccountList.reduce(async (accP, name) => {
-        const acc = await accP
+      const namedAccounts = namedAccountList.reduce(async (accountsPromise, name) => {
+        const accounts = await accountsPromise
         const address = getItemValue(readConfig(graphConfigPath, true), `general/${name}`)
-        acc[name] = await hre.ethers.getSigner(address)
-        return acc
+        accounts[name] = await hre.ethers.getSigner(address)
+        return accounts
       }, Promise.resolve({} as NamedAccounts))
 
       return namedAccounts

--- a/tasks/type-extensions.d.ts
+++ b/tasks/type-extensions.d.ts
@@ -1,4 +1,4 @@
-import { Signer } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { AddressBook } from '../cli/address-book'
 import { NetworkContracts } from '../cli/contracts'
 
@@ -7,18 +7,13 @@ export interface GREOptions {
   graphConfig?: string
 }
 
-export interface Account {
-  readonly signer: Signer
-  readonly address: string
-}
-
 export interface NamedAccounts {
-  arbitrator: Account
-  governor: Account
-  authority: Account
-  availabilityOracle: Account
-  pauseGuardian: Account
-  allocationExchangeOwner: Account
+  arbitrator: SignerWithAddress
+  governor: SignerWithAddress
+  authority: SignerWithAddress
+  availabilityOracle: SignerWithAddress
+  pauseGuardian: SignerWithAddress
+  allocationExchangeOwner: SignerWithAddress
 }
 
 declare module 'hardhat/types/runtime' {
@@ -28,8 +23,8 @@ declare module 'hardhat/types/runtime' {
       graphConfig: any
       addressBook: AddressBook
       getNamedAccounts: () => Promise<NamedAccounts>
-      getTestAccounts: () => Promise<Account[]>
-      getDeployer: () => Promise<Account>
+      getTestAccounts: () => Promise<SignerWithAddress[]>
+      getDeployer: () => Promise<SignerWithAddress>
     }
   }
 }


### PR DESCRIPTION
Couple of changes to simplify GRE code:

- Use hardhat's `SignerWithAddress` instead of our own `Account`. This is the same account abstraction but widely used by hardhat so there is no point in redefining it.

- `getNamedAccounts` will now always read the named account addresses from the graph config file and initialize a `SignerWithAddress`. This will succeed regardless of wether we hold the private key/mnemonic for the account or not, so we can remove the `VoidSigner` logic to further simplify. If we don't have the private key the signer simply won't be able to sign any transactions.
