### PR TITLE
feat: add support for local nitro networks

### DIFF
--- a/cli/commands/migrate.ts
+++ b/cli/commands/migrate.ts
@@ -72,7 +72,7 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
 
   if (chainId == 1337) {
     allContracts = ['EthereumDIDRegistry', ...allContracts]
-    await (cli.wallet.provider as providers.JsonRpcProvider).send('evm_setAutomine', [true])
+    await setAutoMine(cli.wallet.provider as providers.JsonRpcProvider, true)
   } else if (chainIdIsL2(chainId)) {
     allContracts = l2Contracts
   }
@@ -167,7 +167,15 @@ export const migrate = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<vo
   logger.info(`Sent ${nTx} transaction${nTx === 1 ? '' : 's'} & spent ${EtherSymbol} ${spent}`)
 
   if (chainId == 1337) {
-    await (cli.wallet.provider as providers.JsonRpcProvider).send('evm_setAutomine', [false])
+    await setAutoMine(cli.wallet.provider as providers.JsonRpcProvider, false)
+  }
+}
+
+const setAutoMine = async (provider: providers.JsonRpcProvider, automine: boolean) => {
+  try {
+    await provider.send('evm_setAutomine', [automine])
+  } catch (error) {
+    logger.warn('The method evm_setAutomine does not exist/is not available!')
   }
 }
 

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -1,4 +1,3 @@
-import { addCustomNetwork } from '@arbitrum/sdk'
 import { Contract, Wallet, providers } from 'ethers'
 
 import { loadArtifact } from './artifacts'
@@ -7,6 +6,7 @@ export const l1ToL2ChainIdMap = {
   '1': '42161',
   '4': '421611',
   '5': '421613',
+  '1337': '412346',
 }
 
 export const l2ChainIds = Object.values(l1ToL2ChainIdMap).map(Number)

--- a/config/graph.arbitrum-localhost.yml
+++ b/config/graph.arbitrum-localhost.yml
@@ -125,7 +125,7 @@ contracts:
         subgraphAvailabilityOracle: *availabilityOracle
   AllocationExchange:
     init:
-      graphToken: "${{GraphToken.address}}"
+      graphToken: "${{L2GraphToken.address}}"
       staking: "${{Staking.address}}"
       governor: *allocationExchangeOwner
       authority: *authority

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -146,6 +146,14 @@ const config: HardhatUserConfig = {
       accounts:
         process.env.FORK === 'true' ? getAccountsKeys() : { mnemonic: DEFAULT_TEST_MNEMONIC },
     },
+    localnitrol1: {
+      url: 'http://localhost:8545',
+      accounts: { mnemonic: DEFAULT_TEST_MNEMONIC },
+    },
+    localnitrol2: {
+      url: 'http://localhost:8547',
+      accounts: { mnemonic: DEFAULT_TEST_MNEMONIC },
+    },
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,


### PR DESCRIPTION
### Motivation

This PR adds the local nitro networks L1 and L2 to hardhat and fixes a few bugs to allow deploying the protocol to those networks.

### Changes
- Add local nitro networks (L1 and L2) to hardhat
- Fail gracefully if the network doesn't support `evm_setAutomine` on local networks. Nitro uses geth in dev mode which already has automine behaviour and doesn't support the RPC call.