### PR TITLE
fix: remove minDripInterval from the drip keeper reward calculation [L-01]

### DIFF
--- a/contracts/reservoir/L1Reservoir.sol
+++ b/contracts/reservoir/L1Reservoir.sol
@@ -307,9 +307,7 @@ contract L1Reservoir is L1ReservoirV2Storage, Reservoir {
         uint256 mintedRewardsActual = getNewGlobalRewards(block.number);
         // eps = (signed int) mintedRewardsTotal - mintedRewardsActual
 
-        uint256 keeperReward = dripRewardPerBlock.mul(
-            block.number.sub(lastRewardsUpdateBlock).sub(minDripInterval)
-        );
+        uint256 keeperReward = dripRewardPerBlock.mul(block.number.sub(lastRewardsUpdateBlock));
         if (nextIssuanceRate != issuanceRate) {
             rewardsManager().updateAccRewardsPerSignal();
             snapshotAccumulatedRewards(mintedRewardsActual); // This updates lastRewardsUpdateBlock

--- a/test/reservoir/l1Reservoir.test.ts
+++ b/test/reservoir/l1Reservoir.test.ts
@@ -592,7 +592,6 @@ describe('L1Reservoir', () => {
       const dripBlock = (await latestBlock()).add(1) // We're gonna drip in the next transaction
       const expectedKeeperReward = dripBlock
         .sub(await l1Reservoir.lastRewardsUpdateBlock())
-        .sub(toBN('2'))
         .mul(toGRT('3'))
       const tracker = await RewardsTracker.create(
         issuanceBase,


### PR DESCRIPTION
Simplifies the keeper reward calculation and increases the odds that calling drip immediately after the minDripInterval will be profitable.