### PR TITLE
test: optimize advanceBlocks by using regular mining up to 10 blocks

### DIFF
--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -76,7 +76,15 @@ export const advanceBlockTo = async (blockNumber: string | number | BigNumber): 
 }
 
 export const advanceBlocks = async (blocks: string | number | BigNumber): Promise<void> => {
-  await provider().send('hardhat_mine', [hexValue(BigNumber.from(blocks))])
+  const blocksBN = BigNumber.from(blocks)
+  const maxIterativeBlocks = BigNumber.from(10)
+  if (blocksBN.lte(maxIterativeBlocks)) {
+    for (let n = 0; blocksBN.gt(n); n++) {
+      await advanceBlock()
+    }
+  } else {
+    await provider().send('hardhat_mine', [hexValue(blocksBN)])
+  }
 }
 
 export const advanceToNextEpoch = async (epochManager: EpochManager): Promise<void> => {


### PR DESCRIPTION
This is (hopefully) a slight improvement over what was introduced in #688 - where we switched to using hardhat_mine whenever we want to advance a number of blocks. It seems this is a bit slower than just mining blocks iteratively when the number of blocks is low, so here we use regular mining for up to 10 blocks, and hardhat_mine if it's more than that.

(the optimal number might be more or less than 10, and probably depends on the machine... but we can tune it to find something that's reasonable)