### PR TITLE
fix: ensure GRE handles multiple chains with same chainId gracefully

### DIFF
--- a/gre/config.ts
+++ b/gre/config.ts
@@ -12,7 +12,8 @@ import GraphNetwork from './helpers/network'
 import { createProvider } from 'hardhat/internal/core/providers/construction'
 import { EthersProviderWrapper } from '@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper'
 
-import { logDebug } from './logger'
+import { logDebug, logWarn } from './logger'
+import { HARDHAT_NETWORK_NAME } from 'hardhat/plugins'
 
 interface GREChains {
   l1ChainId: number
@@ -99,18 +100,23 @@ export function getProviders(
   const getProvider = (
     networks: NetworksConfig,
     chainId: number,
+    mainNetworkName: string,
     isMainProvider: boolean,
     chainLabel: string,
   ): EthersProviderWrapper | undefined => {
-    const network = getNetworkConfig(networks, chainId) as HttpNetworkConfig
-    const networkName = getNetworkName(networks, chainId)
+    const network = getNetworkConfig(networks, chainId, mainNetworkName) as HttpNetworkConfig
+    const networkName = getNetworkName(networks, chainId, mainNetworkName)
+
+    logDebug(`Provider url for ${chainLabel}(${networkName}): ${network?.url}`)
 
     // Ensure at least main provider is configured
-    if (isMainProvider && network === undefined) {
+    if (
+      isMainProvider &&
+      (network === undefined || network.url === undefined) &&
+      networkName !== HARDHAT_NETWORK_NAME
+    ) {
       throw new GREPluginError(`Must set a provider url for chain: ${chainId}!`)
     }
-
-    logDebug(`Provider url for ${chainLabel}: ${network?.url}`)
 
     if (network === undefined || networkName === undefined) {
       return undefined
@@ -123,8 +129,8 @@ export function getProviders(
     return ethersProviderWrapper
   }
 
-  const l1Provider = getProvider(hre.config.networks, l1ChainId, isHHL1, 'L1')
-  const l2Provider = getProvider(hre.config.networks, l2ChainId, !isHHL1, 'L2')
+  const l1Provider = getProvider(hre.config.networks, l1ChainId, hre.network.name, isHHL1, 'L1')
+  const l2Provider = getProvider(hre.config.networks, l2ChainId, hre.network.name, !isHHL1, 'L2')
 
   return {
     l1Provider,
@@ -142,8 +148,8 @@ export function getGraphConfigPaths(
   logDebug('== Getting graph config paths')
   logDebug(`Graph base dir: ${hre.config.paths.graph}`)
 
-  const l1Network = getNetworkConfig(hre.config.networks, l1ChainId)
-  const l2Network = getNetworkConfig(hre.config.networks, l2ChainId)
+  const l1Network = getNetworkConfig(hre.config.networks, l1ChainId, hre.network.name)
+  const l2Network = getNetworkConfig(hre.config.networks, l2ChainId, hre.network.name)
 
   // Priority is as follows:
   // - hre.graph() init parameter l1GraphConfigPath/l2GraphConfigPath
@@ -205,14 +211,43 @@ export function getGraphConfigPaths(
   }
 }
 
-function getNetworkConfig(networks: NetworksConfig, chainId: number): NetworkConfig | undefined {
-  return Object.keys(networks)
-    .map((n) => networks[n])
-    .find((n) => n.chainId === chainId)
+function getNetworkConfig(
+  networks: NetworksConfig,
+  chainId: number,
+  mainNetworkName: string,
+): (NetworkConfig & { name: string }) | undefined {
+  let candidateNetworks = Object.keys(networks)
+    .map((n) => ({ ...networks[n], name: n }))
+    .filter((n) => n.chainId === chainId)
+
+  if (candidateNetworks.length > 1) {
+    logWarn(
+      `Found multiple networks with chainId ${chainId}, trying to use main network name to desambiguate`,
+    )
+
+    candidateNetworks = candidateNetworks.filter((n) => n.name === mainNetworkName)
+
+    if (candidateNetworks.length === 1) {
+      return candidateNetworks[0]
+    } else {
+      throw new GREPluginError(
+        `Found multiple networks with chainID ${chainId}. This is not supported!`,
+      )
+    }
+  } else if (candidateNetworks.length === 1) {
+    return candidateNetworks[0]
+  } else {
+    return undefined
+  }
 }
 
-function getNetworkName(networks: NetworksConfig, chainId: number): string | undefined {
-  return Object.keys(networks).find((n) => networks[n].chainId === chainId)
+function getNetworkName(
+  networks: NetworksConfig,
+  chainId: number,
+  mainNetworkName: string,
+): string | undefined {
+  const network = getNetworkConfig(networks, chainId, mainNetworkName)
+  return network?.name
 }
 
 function normalizePath(_path: string, graphPath: string) {

--- a/gre/config.ts
+++ b/gre/config.ts
@@ -110,6 +110,7 @@ export function getProviders(
     logDebug(`Provider url for ${chainLabel}(${networkName}): ${network?.url}`)
 
     // Ensure at least main provider is configured
+    // For Hardhat network we don't need url to create a provider
     if (
       isMainProvider &&
       (network === undefined || network.url === undefined) &&

--- a/gre/gre.ts
+++ b/gre/gre.ts
@@ -39,6 +39,9 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
 
 extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   hre.graph = (opts: GraphRuntimeEnvironmentOptions = {}) => {
+    logDebug('*** Initializing Graph Runtime Environment (GRE) ***')
+    logDebug(`Main network: ${hre.network.name}`)
+
     const { l1ChainId, l2ChainId, isHHL1 } = getChains(hre.network.config.chainId)
     const { l1Provider, l2Provider } = getProviders(hre, l1ChainId, l2ChainId, isHHL1)
     const addressBookPath = getAddressBookPath(hre, opts)

--- a/gre/test/gre.test.ts
+++ b/gre/test/gre.test.ts
@@ -32,6 +32,20 @@ describe('GRE usage', function () {
     })
   })
 
+  describe('graph-config project setting --network to hardhat network', function () {
+    useEnvironment('graph-config', 'hardhat')
+
+    it('should return L1 and L2 configured objects ', function () {
+      const g = this.hre.graph()
+
+      expect(g).to.be.an('object')
+      expect(g.l1).to.be.an('object')
+      expect(g.l2).to.be.null
+      expect(g.l1.chainId).to.equal(1337)
+      expect(g.chainId).to.equal(1337)
+    })
+  })
+
   describe('graph-config project setting --network to an L1 with no configured counterpart', function () {
     useEnvironment('graph-config', 'localhost')
 

--- a/gre/test/gre.test.ts
+++ b/gre/test/gre.test.ts
@@ -20,7 +20,7 @@ describe('GRE usage', function () {
   describe('graph-config project setting --network to an L2', function () {
     useEnvironment('graph-config', 'arbitrum-goerli')
 
-    it('should return L1 and L2 configured objects ', function () {
+    it('should return L1 and L2 configured objects', function () {
       const g = this.hre.graph()
 
       expect(g).to.be.an('object')
@@ -35,7 +35,7 @@ describe('GRE usage', function () {
   describe('graph-config project setting --network to hardhat network', function () {
     useEnvironment('graph-config', 'hardhat')
 
-    it('should return L1 and L2 configured objects ', function () {
+    it('should return L1 configured object and L2 unconfigured', function () {
       const g = this.hre.graph()
 
       expect(g).to.be.an('object')


### PR DESCRIPTION
### Motivation
This PR fixes a bug in GRE where it would always connect to the first network in the case where multiple chains are listed in `hardhat.config.ts` with the same chainId. This is most likely to happen with local networks colliding with hardhat's own network (`chainId=1337`).

### Changes
Now GRE will try to use the main network name (as specified by `--network`) to disambiguate and if that is not enough it will throw an error saying this behavior is not supported.

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>