### PR TITLE
chore: add GRE test to GitHub actions

### DIFF
--- a/.github/workflows/gre.yml
+++ b/.github/workflows/gre.yml
@@ -1,0 +1,25 @@
+name: Run GRE tests
+
+on:
+  push:
+    branches: [dev]
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install packages
+        run: yarn install --non-interactive --frozen-lockfile
+      - name: Run GRE tests
+        run: yarn test:gre

--- a/.github/workflows/gre.yml
+++ b/.github/workflows/gre.yml
@@ -21,5 +21,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install packages
         run: yarn install --non-interactive --frozen-lockfile
+      - name: Build project
+        run: yarn build
       - name: Run GRE tests
         run: yarn test:gre

--- a/gre/test/fixture-projects/default-config/hardhat.config.js
+++ b/gre/test/fixture-projects/default-config/hardhat.config.js
@@ -1,1 +1,0 @@
-module.exports = {}

--- a/gre/test/fixture-projects/default-config/hardhat.config.ts
+++ b/gre/test/fixture-projects/default-config/hardhat.config.ts
@@ -1,0 +1,8 @@
+module.exports = {
+  networks: {
+    mainnet: {
+      chainId: 1,
+      url: `https://mainnet.infura.io/v3/123456`,
+    },
+  },
+}


### PR DESCRIPTION
### Changes
- Run `yarn test:gre` when merging to `dev`.
- Fix a bug in GRE tests where test env was picking up project's main `hardhat.config.ts` file instead of a test one due to incorrect file extension (`.js --> .ts`)



Signed-off-by: Tomás Migone <tomas@edgeandnode.com>