### PR TITLE
L2 bridge: safer callhook interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run tests
         run: yarn test:coverage
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.json

--- a/contracts/gateway/ICallhookReceiver.sol
+++ b/contracts/gateway/ICallhookReceiver.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/**
+ * @title Interface for contracts that can receive callhooks through the Arbitrum GRT bridge
+ * @dev Any contract that can receive a callhook on L2, send through the bridge from L1, must
+ * be whitelisted by the governor, but also implement this interface that contains
+ * the function that will actually be called by the L2GraphTokenGateway.
+ */
+pragma solidity ^0.7.6;
+
+interface ICallhookReceiver {
+    /**
+     * @dev Receive tokens with a callhook from the bridge
+     * @param _from Token sender in L1
+     * @param _amount Amount of tokens that were transferred
+     * @param _data ABI-encoded callhook data
+     */
+    function onTokenTransfer(
+        address _from,
+        uint256 _amount,
+        bytes calldata _data
+    ) external;
+}

--- a/contracts/gateway/ICallhookReceiver.sol
+++ b/contracts/gateway/ICallhookReceiver.sol
@@ -2,7 +2,7 @@
 
 /**
  * @title Interface for contracts that can receive callhooks through the Arbitrum GRT bridge
- * @dev Any contract that can receive a callhook on L2, send through the bridge from L1, must
+ * @dev Any contract that can receive a callhook on L2, sent through the bridge from L1, must
  * be whitelisted by the governor, but also implement this interface that contains
  * the function that will actually be called by the L2GraphTokenGateway.
  */

--- a/contracts/l2/gateway/L2GraphTokenGateway.sol
+++ b/contracts/l2/gateway/L2GraphTokenGateway.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.7.6;
 pragma abicoder v2;
 
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "../../arbitrum/L2ArbitrumMessenger.sol";
@@ -18,7 +19,7 @@ import "../token/L2GraphToken.sol";
  * (See: https://github.com/OffchainLabs/arbitrum/tree/master/packages/arb-bridge-peripherals/contracts/tokenbridge
  * and https://github.com/livepeer/arbitrum-lpt-bridge)
  */
-contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger {
+contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger, ReentrancyGuardUpgradeable {
     using SafeMath for uint256;
 
     // Address of the Graph Token contract on L1
@@ -85,6 +86,7 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger {
     function initialize(address _controller) external onlyImpl {
         Managed._initialize(_controller);
         _paused = true;
+        __ReentrancyGuard_init();
     }
 
     /**
@@ -138,7 +140,7 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger {
         uint256, // unused on L2
         uint256, // unused on L2
         bytes calldata _data
-    ) public payable override notPaused returns (bytes memory) {
+    ) public payable override notPaused nonReentrant returns (bytes memory) {
         require(_l1Token == l1GRT, "TOKEN_NOT_GRT");
         require(_amount > 0, "INVALID_ZERO_AMOUNT");
         require(msg.value == 0, "INVALID_NONZERO_VALUE");
@@ -226,7 +228,7 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger {
         address _to,
         uint256 _amount,
         bytes calldata _data
-    ) external payable override notPaused onlyL1Counterpart {
+    ) external payable override notPaused onlyL1Counterpart nonReentrant {
         require(_l1Token == l1GRT, "TOKEN_NOT_GRT");
         require(msg.value == 0, "INVALID_NONZERO_VALUE");
 

--- a/contracts/l2/gateway/L2GraphTokenGateway.sol
+++ b/contracts/l2/gateway/L2GraphTokenGateway.sol
@@ -241,8 +241,6 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger, Reentran
                 bytes memory gatewayData;
                 (gatewayData, callhookData) = abi.decode(_data, (bytes, bytes));
             }
-            // Callhooks shouldn't revert, but if they do:
-            // we revert, so that the retryable ticket can be re-attempted
             ICallhookReceiver(_to).onTokenTransfer(_from, _amount, callhookData);
         }
 

--- a/contracts/tests/CallhookReceiverMock.sol
+++ b/contracts/tests/CallhookReceiverMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.7.6;
+
+import "../gateway/ICallhookReceiver.sol";
+
+/**
+ * @title GovernedMock contract
+ */
+contract CallhookReceiverMock is ICallhookReceiver {
+    event TransferReceived(address from, uint256 amount, uint256 foo, uint256 bar);
+
+    /**
+     * @dev Receive tokens with a callhook from the bridge
+     * Expects two uint256 values encoded in _data.
+     * Reverts if the first of these values is zero.
+     * @param _from Token sender in L1
+     * @param _amount Amount of tokens that were transferred
+     * @param _data ABI-encoded callhook data
+     */
+    function onTokenTransfer(
+        address _from,
+        uint256 _amount,
+        bytes calldata _data
+    ) external override {
+        uint256 foo;
+        uint256 bar;
+        (foo, bar) = abi.decode(_data, (uint256, uint256));
+        require(foo != 0, "FOO_IS_ZERO");
+        emit TransferReceived(_from, _amount, foo, bar);
+    }
+}


### PR DESCRIPTION
- Make the L2 gateway functions non-reentrant for additional safety
- Change the callhooks to only call an `onTokenTransfer` function, to limit the potential impact of a compromised whitelisted L1 sender