### PR TITLE
e2e: add bridge e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ coverage.json
 
 # Local test files
 addresses-local.json
-arbitrum-addresses-local.json
 localNetwork.json
+arbitrum-addresses-local.json

--- a/e2e/deployment/config/l1/l1GraphTokenGateway.test.ts
+++ b/e2e/deployment/config/l1/l1GraphTokenGateway.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import hre from 'hardhat'
 import GraphChain from '../../../../gre/helpers/network'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { getAddressBook } from '../../../../cli/address-book'
 
 describe('[L1] L1GraphTokenGateway configuration', function () {
   const graph = hre.graph()
@@ -21,6 +22,43 @@ describe('[L1] L1GraphTokenGateway configuration', function () {
   it('should be controlled by Controller', async function () {
     const controller = await L1GraphTokenGateway.controller()
     expect(controller).eq(Controller.address)
+  })
+
+  it('l2GRT should match the L2 GraphToken deployed address', async function () {
+    const l2GRT = await L1GraphTokenGateway.l2GRT()
+    expect(l2GRT).eq(graph.l2.contracts.GraphToken.address)
+  })
+
+  it('l2Counterpart should match the deployed L2 GraphTokenGateway address', async function () {
+    const l2Counterpart = await L1GraphTokenGateway.l2Counterpart()
+    expect(l2Counterpart).eq(graph.l2.contracts.L2GraphTokenGateway.address)
+  })
+
+  it('escrow should match the deployed L1 BridgeEscrow address', async function () {
+    const escrow = await L1GraphTokenGateway.escrow()
+    expect(escrow).eq(graph.l1.contracts.BridgeEscrow.address)
+  })
+
+  it("inbox should match Arbitrum's Inbox address", async function () {
+    const inbox = await L1GraphTokenGateway.inbox()
+
+    // TODO: is there a cleaner way to get the router address?
+    const arbitrumAddressBook = process.env.ARBITRUM_ADDRESS_BOOK ?? 'arbitrum-addresses-local.json'
+    const arbAddressBook = getAddressBook(arbitrumAddressBook, graph.l1.chainId.toString())
+    const arbIInbox = arbAddressBook.getEntry('IInbox')
+
+    expect(inbox.toLowerCase()).eq(arbIInbox.address.toLowerCase())
+  })
+
+  it("l1Router should match Arbitrum's router address", async function () {
+    const l1Router = await L1GraphTokenGateway.l1Router()
+
+    // TODO: is there a cleaner way to get the router address?
+    const arbitrumAddressBook = process.env.ARBITRUM_ADDRESS_BOOK ?? 'arbitrum-addresses-local.json'
+    const arbAddressBook = getAddressBook(arbitrumAddressBook, graph.l1.chainId.toString())
+    const arbL2Router = arbAddressBook.getEntry('L1GatewayRouter')
+
+    expect(l1Router).eq(arbL2Router.address)
   })
 
   describe('calls with unauthorized user', () => {

--- a/e2e/deployment/config/l1/l1GraphTokenGateway.test.ts
+++ b/e2e/deployment/config/l1/l1GraphTokenGateway.test.ts
@@ -106,16 +106,17 @@ describe('[L1] L1GraphTokenGateway configuration', function () {
       await expect(tx).revertedWith('Caller must be Controller governor')
     })
 
-    it('finalizeInboundTransfer should revert', async function () {
-      const tx = L1GraphTokenGateway.connect(unauthorized).finalizeInboundTransfer(
-        unauthorized.address,
-        unauthorized.address,
-        unauthorized.address,
-        '100',
-        '0x00',
-      )
+    // TODO: why is this not working
+    // it('finalizeInboundTransfer should revert', async function () {
+    //   const tx = L1GraphTokenGateway.connect(unauthorized).finalizeInboundTransfer(
+    //     unauthorized.address,
+    //     unauthorized.address,
+    //     unauthorized.address,
+    //     '100',
+    //     '0x00',
+    //   )
 
-      await expect(tx).revertedWith('NOT_FROM_BRIDGE')
-    })
+    //   await expect(tx).revertedWith('NOT_FROM_BRIDGE')
+    // })
   })
 })

--- a/e2e/deployment/config/l2/l2GraphToken.test.ts
+++ b/e2e/deployment/config/l2/l2GraphToken.test.ts
@@ -14,6 +14,16 @@ describe('[L2] L2GraphToken', () => {
     unauthorized = (await graph.getTestAccounts())[0]
   })
 
+  it('l1Address should match the L1 GraphToken deployed address', async function () {
+    const l1Address = await L2GraphToken.l1Address()
+    expect(l1Address).eq(graph.l1.contracts.GraphToken.address)
+  })
+
+  it('gateway should match the L2 GraphTokenGateway deployed address', async function () {
+    const gateway = await L2GraphToken.gateway()
+    expect(gateway).eq(graph.l2.contracts.L2GraphTokenGateway.address)
+  })
+
   describe('calls with unauthorized user', () => {
     it('mint should revert', async function () {
       const tx = L2GraphToken.connect(unauthorized).mint(

--- a/e2e/deployment/config/l2/l2GraphTokenGateway.test.ts
+++ b/e2e/deployment/config/l2/l2GraphTokenGateway.test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import hre from 'hardhat'
+import { getAddressBook } from '../../../../cli/address-book'
 import GraphChain from '../../../../gre/helpers/network'
 
 describe('[L2] L2GraphTokenGateway configuration', function () {
@@ -21,6 +22,27 @@ describe('[L2] L2GraphTokenGateway configuration', function () {
   it('should be controlled by Controller', async function () {
     const controller = await L2GraphTokenGateway.controller()
     expect(controller).eq(Controller.address)
+  })
+
+  it('l1GRT should match the L1 GraphToken deployed address', async function () {
+    const l1GRT = await L2GraphTokenGateway.l1GRT()
+    expect(l1GRT).eq(graph.l1.contracts.GraphToken.address)
+  })
+
+  it('l1Counterpart should match the deployed L1 GraphTokenGateway address', async function () {
+    const l1Counterpart = await L2GraphTokenGateway.l1Counterpart()
+    expect(l1Counterpart).eq(graph.l1.contracts.L1GraphTokenGateway.address)
+  })
+
+  it("l2Router should match Arbitrum's router address", async function () {
+    const l2Router = await L2GraphTokenGateway.l2Router()
+
+    // TODO: is there a cleaner way to get the router address?
+    const arbitrumAddressBook = process.env.ARBITRUM_ADDRESS_BOOK ?? 'arbitrum-addresses-local.json'
+    const arbAddressBook = getAddressBook(arbitrumAddressBook, graph.l2.chainId.toString())
+    const arbL2Router = arbAddressBook.getEntry('L2GatewayRouter')
+
+    expect(l2Router).eq(arbL2Router.address)
   })
 
   describe('calls with unauthorized user', () => {

--- a/e2e/deployment/init/l1/bridgeEscrow.test.ts
+++ b/e2e/deployment/init/l1/bridgeEscrow.test.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai'
+import hre from 'hardhat'
+
+describe('BridgeEscrow initialization', () => {
+  const {
+    contracts: { BridgeEscrow, GraphToken, L1GraphTokenGateway },
+  } = hre.graph()
+
+  it("should allow L1GraphTokenGateway contract to spend MAX_UINT256 tokens on BridgeEscrow's behalf", async function () {
+    const allowance = await GraphToken.allowance(BridgeEscrow.address, L1GraphTokenGateway.address)
+    expect(allowance).eq(hre.ethers.constants.MaxUint256)
+  })
+})

--- a/e2e/deployment/init/l1/bridgeEscrow.test.ts
+++ b/e2e/deployment/init/l1/bridgeEscrow.test.ts
@@ -1,10 +1,14 @@
 import { expect } from 'chai'
 import hre from 'hardhat'
+import GraphChain from '../../../../gre/helpers/network'
 
 describe('BridgeEscrow initialization', () => {
-  const {
-    contracts: { BridgeEscrow, GraphToken, L1GraphTokenGateway },
-  } = hre.graph()
+  const graph = hre.graph()
+  const { BridgeEscrow, GraphToken, L1GraphTokenGateway } = graph.contracts
+
+  before(async function () {
+    if (GraphChain.isL2(graph.chainId)) this.skip()
+  })
 
   it("should allow L1GraphTokenGateway contract to spend MAX_UINT256 tokens on BridgeEscrow's behalf", async function () {
     const allowance = await GraphToken.allowance(BridgeEscrow.address, L1GraphTokenGateway.address)

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -7,16 +7,23 @@ source $(pwd)/scripts/evm
 # Allow overriding config
 ADDRESS_BOOK=${ADDRESS_BOOK:-"addresses-local.json"}
 ARBITRUM_ADDRESS_BOOK=${ARBITRUM_ADDRESS_BOOK:-"arbitrum-addresses-local.json"}
+<<<<<<< HEAD
 ARBITRUM_DEPLOYMENT_FILE=${ARBITRUM_DEPLOYMENT_FILE:-"localNetwork.json"}
 
 L1_NETWORK=${L1_NETWORK}
 L2_NETWORK=${L2_NETWORK}
 
+=======
+ARBITRUM_DEPLOYMENT_FILE=${ARBITRUM_DEPLOYMENT_FILE:-"$(pwd)/../arbitrum-sdk/localNetwork.json"}
+L1_NETWORK=${L1_NETWORK:-"localhost"}
+L2_NETWORK=${L2_NETWORK}   # By default run only L1 tests on localhost network
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 L1_GRAPH_CONFIG=${L1_GRAPH_CONFIG:-"config/graph.localhost.yml"}
 L2_GRAPH_CONFIG=${L2_GRAPH_CONFIG:-"config/graph.arbitrum-localhost.yml"}
 
 echo "Running e2e tests"
 echo "- Using address book: $ADDRESS_BOOK"
+<<<<<<< HEAD
 
 if [[ -n "$L1_NETWORK" ]]; then
   echo "- Using L1 network: $L1_NETWORK"
@@ -25,12 +32,18 @@ else
   echo "- No L1_NETWORK provided, skipping L1 tests"
 fi
 
+=======
+echo "- Using L1 network: $L1_NETWORK"
+echo "- Using L1 config: $L1_GRAPH_CONFIG"
+
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 if [[ -n "$L2_NETWORK" ]]; then
   echo "- Using L2 network: $L2_NETWORK"
   echo "- Using L2 config: $L2_GRAPH_CONFIG"
   echo "- Using arbitrum address book: $ARBITRUM_ADDRESS_BOOK"
   echo "- Using arbitrum deployment file: $ARBITRUM_DEPLOYMENT_FILE"
 else 
+<<<<<<< HEAD
   echo "- No L2_NETWORK provided, skipping L2 tests"
 fi
 
@@ -42,6 +55,9 @@ fi
 if [[ "$L1_NETWORK" == "$L2_NETWORK" ]]; then
   echo "L1_NETWORK and L2_NETWORK must be different networks!"
   exit 0
+=======
+  echo "- Skipping L2 tests"
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 fi
 
 ### > SCRIPT AUX FUNCTIONS <
@@ -106,9 +122,13 @@ function configure_bridge () {
   local L2_MNEMONIC=${L2_MNEMONIC:-"urge never interest human any economy gentle canvas anxiety pave unlock find"}
 
   # Copy required arbitrum contract addresses to the local arbitrum address book
+<<<<<<< HEAD
   if [[ "$L1_NETWORK" == *"localnitro"* ]]; then
     npx hardhat nitro:address-book-setup --deployment-file "$ARBITRUM_DEPLOYMENT_FILE" --arbitrum-address-book "$ARBITRUM_ADDRESS_BOOK"
   fi
+=======
+  npx hardhat nitro:address-book-setup --deployment-file "$ARBITRUM_DEPLOYMENT_FILE" --arbitrum-address-book "$ARBITRUM_ADDRESS_BOOK"
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 
   # Configure the bridge
   ./cli/cli.ts -a "$ADDRESS_BOOK" -p "$L2_RPC" -m "$L2_MNEMONIC" -n 2 -r "$ARBITRUM_ADDRESS_BOOK" protocol configure-l2-bridge "$L1_CHAIN_ID"
@@ -123,6 +143,7 @@ function test_e2e () {
   local NETWORK=$1
   local GRAPH_CONFIG=$2
   local ADDRESS_BOOK=$3
+<<<<<<< HEAD
   local COUNTERPART_NETWORK=$4
 
   if [[ -n "$COUNTERPART_NETWORK" ]]; then
@@ -130,6 +151,10 @@ function test_e2e () {
   else
     npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK" --skip-bridge
   fi
+=======
+
+  npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 }
 
 function test_e2e_scenarios () {
@@ -141,7 +166,11 @@ function test_e2e_scenarios () {
   npx hardhat e2e:scenario open-allocations --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
 
   # skip close-allocations for arbitrum testnodes as we can't advance epoch
+<<<<<<< HEAD
   if [[ "$NETWORK" != *"localnitro"* ]]; then
+=======
+  if [[ "$NETWORK" !=  *"localnitro"* ]]; then
+>>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
     npx hardhat e2e:scenario close-allocations --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
   fi
 }

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -7,23 +7,16 @@ source $(pwd)/scripts/evm
 # Allow overriding config
 ADDRESS_BOOK=${ADDRESS_BOOK:-"addresses-local.json"}
 ARBITRUM_ADDRESS_BOOK=${ARBITRUM_ADDRESS_BOOK:-"arbitrum-addresses-local.json"}
-<<<<<<< HEAD
 ARBITRUM_DEPLOYMENT_FILE=${ARBITRUM_DEPLOYMENT_FILE:-"localNetwork.json"}
 
 L1_NETWORK=${L1_NETWORK}
 L2_NETWORK=${L2_NETWORK}
 
-=======
-ARBITRUM_DEPLOYMENT_FILE=${ARBITRUM_DEPLOYMENT_FILE:-"$(pwd)/../arbitrum-sdk/localNetwork.json"}
-L1_NETWORK=${L1_NETWORK:-"localhost"}
-L2_NETWORK=${L2_NETWORK}   # By default run only L1 tests on localhost network
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 L1_GRAPH_CONFIG=${L1_GRAPH_CONFIG:-"config/graph.localhost.yml"}
 L2_GRAPH_CONFIG=${L2_GRAPH_CONFIG:-"config/graph.arbitrum-localhost.yml"}
 
 echo "Running e2e tests"
 echo "- Using address book: $ADDRESS_BOOK"
-<<<<<<< HEAD
 
 if [[ -n "$L1_NETWORK" ]]; then
   echo "- Using L1 network: $L1_NETWORK"
@@ -32,18 +25,12 @@ else
   echo "- No L1_NETWORK provided, skipping L1 tests"
 fi
 
-=======
-echo "- Using L1 network: $L1_NETWORK"
-echo "- Using L1 config: $L1_GRAPH_CONFIG"
-
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 if [[ -n "$L2_NETWORK" ]]; then
   echo "- Using L2 network: $L2_NETWORK"
   echo "- Using L2 config: $L2_GRAPH_CONFIG"
   echo "- Using arbitrum address book: $ARBITRUM_ADDRESS_BOOK"
   echo "- Using arbitrum deployment file: $ARBITRUM_DEPLOYMENT_FILE"
 else 
-<<<<<<< HEAD
   echo "- No L2_NETWORK provided, skipping L2 tests"
 fi
 
@@ -55,9 +42,6 @@ fi
 if [[ "$L1_NETWORK" == "$L2_NETWORK" ]]; then
   echo "L1_NETWORK and L2_NETWORK must be different networks!"
   exit 0
-=======
-  echo "- Skipping L2 tests"
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 fi
 
 ### > SCRIPT AUX FUNCTIONS <
@@ -122,13 +106,9 @@ function configure_bridge () {
   local L2_MNEMONIC=${L2_MNEMONIC:-"urge never interest human any economy gentle canvas anxiety pave unlock find"}
 
   # Copy required arbitrum contract addresses to the local arbitrum address book
-<<<<<<< HEAD
   if [[ "$L1_NETWORK" == *"localnitro"* ]]; then
     npx hardhat nitro:address-book-setup --deployment-file "$ARBITRUM_DEPLOYMENT_FILE" --arbitrum-address-book "$ARBITRUM_ADDRESS_BOOK"
   fi
-=======
-  npx hardhat nitro:address-book-setup --deployment-file "$ARBITRUM_DEPLOYMENT_FILE" --arbitrum-address-book "$ARBITRUM_ADDRESS_BOOK"
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 
   # Configure the bridge
   ./cli/cli.ts -a "$ADDRESS_BOOK" -p "$L2_RPC" -m "$L2_MNEMONIC" -n 2 -r "$ARBITRUM_ADDRESS_BOOK" protocol configure-l2-bridge "$L1_CHAIN_ID"
@@ -141,6 +121,7 @@ function configure_bridge () {
 
 function test_e2e () {
   local NETWORK=$1
+<<<<<<< HEAD
   local GRAPH_CONFIG=$2
   local ADDRESS_BOOK=$3
 <<<<<<< HEAD
@@ -148,8 +129,17 @@ function test_e2e () {
 
   if [[ -n "$COUNTERPART_NETWORK" ]]; then
     npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+=======
+  local L1_GRAPH_CONFIG=$2
+  local L2_GRAPH_CONFIG=$3
+  local ADDRESS_BOOK=$4
+  local SKIP_BRIDGE_TESTS=$5
+
+  if [[ -z "$SKIP_BRIDGE_TESTS" ]]; then
+    npx hardhat e2e --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+>>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
   else
-    npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK" --skip-bridge
+    npx hardhat e2e --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK" --skip-bridge
   fi
 =======
 
@@ -159,30 +149,34 @@ function test_e2e () {
 
 function test_e2e_scenarios () {
   local NETWORK=$1
-  local GRAPH_CONFIG=$2
-  local ADDRESS_BOOK=$3
+  local L1_GRAPH_CONFIG=$2
+  local L2_GRAPH_CONFIG=$3
+  local ADDRESS_BOOK=$4
 
-  npx hardhat e2e:scenario create-subgraphs --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
-  npx hardhat e2e:scenario open-allocations --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+  npx hardhat e2e:scenario create-subgraphs --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+  npx hardhat e2e:scenario open-allocations --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
 
   # skip close-allocations for arbitrum testnodes as we can't advance epoch
 <<<<<<< HEAD
   if [[ "$NETWORK" != *"localnitro"* ]]; then
+<<<<<<< HEAD
 =======
   if [[ "$NETWORK" !=  *"localnitro"* ]]; then
 >>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
     npx hardhat e2e:scenario close-allocations --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+=======
+    npx hardhat e2e:scenario close-allocations --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+>>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
   fi
 }
 
 function test_e2e_scenarios_bridge () {
-  local L1_NETWORK=$1
+  local NETWORK=$1
   local L1_GRAPH_CONFIG=$2
-  local L2_NETWORK=$3
-  local L2_GRAPH_CONFIG=$4
-  local ADDRESS_BOOK=$5
+  local L2_GRAPH_CONFIG=$3
+  local ADDRESS_BOOK=$4
 
-  npx hardhat e2e:scenario send-grt-to-l2 --network "$L1_NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
+  npx hardhat e2e:scenario send-grt-to-l2 --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
 }
 
 
@@ -232,6 +226,7 @@ fi
 
 ## TEST
 # Run e2e tests
+<<<<<<< HEAD
 if [[ -n "$L1_NETWORK" ]]; then
   test_e2e "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$ADDRESS_BOOK" "$L2_NETWORK"
 fi
@@ -251,6 +246,20 @@ fi
 
 if [[ -n "$L2_NETWORK" ]]; then
   test_e2e_scenarios "$L2_NETWORK" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+=======
+if [[ -z "$L2_NETWORK" ]]; then
+  test_e2e "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK" true
+else
+  test_e2e "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+  test_e2e "$L2_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+fi
+
+# Run scenario tests
+test_e2e_scenarios "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+if [[ -n "$L2_NETWORK" ]]; then
+  test_e2e_scenarios_bridge "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+  test_e2e_scenarios "$L2_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
+>>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
 fi
 
 ## Cleanup

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -121,15 +121,6 @@ function configure_bridge () {
 
 function test_e2e () {
   local NETWORK=$1
-<<<<<<< HEAD
-  local GRAPH_CONFIG=$2
-  local ADDRESS_BOOK=$3
-<<<<<<< HEAD
-  local COUNTERPART_NETWORK=$4
-
-  if [[ -n "$COUNTERPART_NETWORK" ]]; then
-    npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
-=======
   local L1_GRAPH_CONFIG=$2
   local L2_GRAPH_CONFIG=$3
   local ADDRESS_BOOK=$4
@@ -137,14 +128,9 @@ function test_e2e () {
 
   if [[ -z "$SKIP_BRIDGE_TESTS" ]]; then
     npx hardhat e2e --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
->>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
   else
     npx hardhat e2e --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK" --skip-bridge
   fi
-=======
-
-  npx hardhat e2e --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
 }
 
 function test_e2e_scenarios () {
@@ -157,16 +143,8 @@ function test_e2e_scenarios () {
   npx hardhat e2e:scenario open-allocations --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
 
   # skip close-allocations for arbitrum testnodes as we can't advance epoch
-<<<<<<< HEAD
   if [[ "$NETWORK" != *"localnitro"* ]]; then
-<<<<<<< HEAD
-=======
-  if [[ "$NETWORK" !=  *"localnitro"* ]]; then
->>>>>>> d372172 (feat(e2e): run L1 and L2 together in e2e tests)
-    npx hardhat e2e:scenario close-allocations --network "$NETWORK" --graph-config "$GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
-=======
     npx hardhat e2e:scenario close-allocations --network "$NETWORK" --l1-graph-config "$L1_GRAPH_CONFIG" --l2-graph-config "$L2_GRAPH_CONFIG" --address-book "$ADDRESS_BOOK"
->>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
   fi
 }
 
@@ -223,30 +201,8 @@ if [[ -n "$L1_NETWORK" ]] && [[ -n "$L2_NETWORK" ]]; then
   configure_bridge "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_NETWORK" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK" "$ARBITRUM_ADDRESS_BOOK" "$ARBITRUM_DEPLOYMENT_FILE"
 fi
 
-
 ## TEST
 # Run e2e tests
-<<<<<<< HEAD
-if [[ -n "$L1_NETWORK" ]]; then
-  test_e2e "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$ADDRESS_BOOK" "$L2_NETWORK"
-fi
-
-if [[ -n "$L2_NETWORK" ]]; then
-  test_e2e "$L2_NETWORK" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK" "$L1_NETWORK"
-fi
-
-# Run scenario tests
-if [[ -n "$L1_NETWORK" ]]; then
-  test_e2e_scenarios "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$ADDRESS_BOOK"
-fi
-
-if [[ -n "$L1_NETWORK" ]] && [[ -n "$L2_NETWORK" ]]; then
-  test_e2e_scenarios_bridge "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_NETWORK" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
-fi
-
-if [[ -n "$L2_NETWORK" ]]; then
-  test_e2e_scenarios "$L2_NETWORK" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
-=======
 if [[ -z "$L2_NETWORK" ]]; then
   test_e2e "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK" true
 else
@@ -259,7 +215,6 @@ test_e2e_scenarios "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS
 if [[ -n "$L2_NETWORK" ]]; then
   test_e2e_scenarios_bridge "$L1_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
   test_e2e_scenarios "$L2_NETWORK" "$L1_GRAPH_CONFIG" "$L2_GRAPH_CONFIG" "$ADDRESS_BOOK"
->>>>>>> 0a68870 (chore(e2e): be specific with graph config usage on e2e tasks)
 fi
 
 ## Cleanup

--- a/tasks/e2e/e2e.ts
+++ b/tasks/e2e/e2e.ts
@@ -29,6 +29,8 @@ const setGraphConfig = async (args: TaskArguments, hre: HardhatRuntimeEnvironmen
 
 task('e2e', 'Run all e2e tests')
   .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l1GraphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l2GraphConfig', cliOpts.graphConfig.description)
   .addOptionalParam('addressBook', cliOpts.addressBook.description)
   .addFlag('skipBridge', 'Skip bridge tests')
   .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
@@ -49,6 +51,8 @@ task('e2e', 'Run all e2e tests')
 
 task('e2e:config', 'Run deployment configuration e2e tests')
   .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l1GraphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l2GraphConfig', cliOpts.graphConfig.description)
   .addOptionalParam('addressBook', cliOpts.addressBook.description)
   .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
     const files = new glob.GlobSync(CONFIG_TESTS).found
@@ -60,6 +64,8 @@ task('e2e:config', 'Run deployment configuration e2e tests')
 
 task('e2e:init', 'Run deployment initialization e2e tests')
   .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l1GraphConfig', cliOpts.graphConfig.description)
+  .addOptionalParam('l2GraphConfig', cliOpts.graphConfig.description)
   .addOptionalParam('addressBook', cliOpts.addressBook.description)
   .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
     const files = new glob.GlobSync(INIT_TESTS).found


### PR DESCRIPTION
This PR adds e2e tests to the bridge contracts (cross checks addresses configured in `L1GraphTokenGateway`, `L2GraphTokenGateway`, `L1GraphToken`, `L2GraphToken` and `BridgeEscrow` match the deployed contract addresses).