### PR TITLE
feat(gre): add convenience gre task creation method

### DIFF
--- a/gre/README.md
+++ b/gre/README.md
@@ -8,6 +8,7 @@ GRE is a hardhat plugin that extends hardhat's runtime environment to inject add
 - Exposes protocol configuration via graph config file and address book
 - Provides account management methods for convenience
 - Multichain! Supports both L1 and L2 layers of the protocol simultaneously
+- Convenience method to create tasks that use GRE
 
 ### Usage
 
@@ -121,6 +122,42 @@ The path to the graph config and the address book can be set in multiple ways. T
 The priority for the address book is:
 1) `hre.graph({ ... })` init parameter `addressBook`
 2) `graph.addressBook` graph config parameter `addressBook` in hardhat config file
+
+### Graph task convenience method
+
+GRE accepts a few parameters when being initialized. When using GRE in the context of a hardhat task these parameters would typically be configured as task options. 
+
+In order to simplify the creation of hardhat tasks that will make use of GRE and would require several options to be defined we provide a convenience method: `graphTask`. By using this instead of hardhat's `task` you avoid having to define GRE's options on all of your tasks.
+
+Here is an example of a task using this convenience method:
+
+```ts
+import { graphTask } from '../../gre/gre'
+
+graphTask('hello-world', 'Say hi!', async (args, hre) => {
+  console.log('hello world')
+  const graph = hre.graph(args)
+})
+```
+
+```bash
+✗ npx hardhat hello-world --help
+Hardhat version 2.10.1
+
+Usage: hardhat [GLOBAL OPTIONS] test-graph [--address-book <STRING>] [--disable-secure-accounts] [--graph-config <STRING>] [--l1-graph-config <STRING>] [--l2-graph-config <STRING>]
+
+OPTIONS:
+
+  --address-book                Path to the address book file.
+  --disable-secure-accounts     Disable secure accounts.
+  --graph-config                Path to the graph config file for the network specified using --network.
+  --l1-graph-config             Path to the graph config file for the L1 network.
+  --l2-graph-config             Path to the graph config file for the L2 network.
+
+hello-world: Say hi!
+
+For global options help run: hardhat help
+```
 
 ### API
 

--- a/gre/README.md
+++ b/gre/README.md
@@ -127,7 +127,9 @@ The priority for the address book is:
 
 GRE accepts a few parameters when being initialized. When using GRE in the context of a hardhat task these parameters would typically be configured as task options. 
 
-In order to simplify the creation of hardhat tasks that will make use of GRE and would require several options to be defined we provide a convenience method: `graphTask`. By using this instead of hardhat's `task` you avoid having to define GRE's options on all of your tasks.
+In order to simplify the creation of hardhat tasks that will make use of GRE and would require several options to be defined we provide a convenience method: `graphTask`. This is a drop in replacement for hardhat's `task` that includes GRE related boilerplate, you can still customize the task as you would do with `task`.
+
+ you avoid having to define GRE's options on all of your tasks.
 
 Here is an example of a task using this convenience method:
 

--- a/gre/gre.ts
+++ b/gre/gre.ts
@@ -17,6 +17,10 @@ import path from 'path'
 import { EthersProviderWrapper } from '@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper'
 import { Wallet } from 'ethers'
 
+// Export GRE convenience task creator
+import { graphTask } from './tasks'
+export { graphTask }
+
 // Graph Runtime Environment (GRE) extensions for the HRE
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {

--- a/gre/tasks.ts
+++ b/gre/tasks.ts
@@ -1,0 +1,18 @@
+import { task } from 'hardhat/config'
+import { ActionType, ConfigurableTaskDefinition } from 'hardhat/types/runtime'
+
+export function graphTask(
+  name: string,
+  description?: string,
+  action?: ActionType<unknown>,
+): ConfigurableTaskDefinition {
+  return task(name, description, action)
+    .addOptionalParam('addressBook', 'Path to the address book file.')
+    .addOptionalParam(
+      'graphConfig',
+      'Path to the graph config file for the network specified using --network.',
+    )
+    .addOptionalParam('l1GraphConfig', 'Path to the graph config file for the L1 network.')
+    .addOptionalParam('l2GraphConfig', 'Path to the graph config file for the L2 network.')
+    .addFlag('disableSecureAccounts', 'Disable secure accounts.')
+}

--- a/tasks/deployment/accounts.ts
+++ b/tasks/deployment/accounts.ts
@@ -1,11 +1,8 @@
-import { task } from 'hardhat/config'
-
-import { cliOpts } from '../../cli/defaults'
+import { graphTask } from '../../gre/gre'
 import { updateItemValue, writeConfig } from '../../cli/config'
 
-task('migrate:accounts', 'Creates protocol accounts and saves them in graph config')
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .setAction(async (taskArgs, hre) => {
+graphTask('migrate:accounts', 'Creates protocol accounts and saves them in graph config').setAction(
+  async (taskArgs, hre) => {
     const { graphConfig, getDeployer } = hre.graph(taskArgs)
 
     console.log('> Generating addresses')
@@ -37,4 +34,5 @@ task('migrate:accounts', 'Creates protocol accounts and saves them in graph conf
     updateItemValue(graphConfig, 'general/allocationExchangeOwner', allocationExchangeOwner.address)
 
     writeConfig(taskArgs.graphConfig, graphConfig.toString())
-  })
+  },
+)

--- a/tasks/deployment/config.ts
+++ b/tasks/deployment/config.ts
@@ -1,4 +1,4 @@
-import { task } from 'hardhat/config'
+import { graphTask } from '../../gre/gre'
 import { cliOpts } from '../../cli/defaults'
 import { updateItemValue, writeConfig } from '../../cli/config'
 import YAML from 'yaml'
@@ -87,8 +87,7 @@ const generalParams: GeneralParam[] = [
   },
 ]
 
-task('update-config', 'Update graph config parameters with onchain data')
-  .addParam('graphConfig', cliOpts.graphConfig.description, cliOpts.graphConfig.default)
+graphTask('update-config', 'Update graph config parameters with onchain data')
   .addFlag('dryRun', "Only print the changes, don't write them to the config file")
   .addFlag('skipConfirmation', cliOpts.skipConfirmation.description)
   .setAction(async (taskArgs, hre) => {

--- a/tasks/deployment/deploy.ts
+++ b/tasks/deployment/deploy.ts
@@ -1,13 +1,11 @@
 import { Wallet } from 'ethers'
-import { task } from 'hardhat/config'
+import { graphTask } from '../../gre/gre'
 
 import { loadEnv } from '../../cli/env'
 import { cliOpts } from '../../cli/defaults'
 import { migrate } from '../../cli/commands/migrate'
 
-task('migrate', 'Migrate contracts')
-  .addParam('addressBook', cliOpts.addressBook.description, cliOpts.addressBook.default)
-  .addParam('graphConfig', cliOpts.graphConfig.description, cliOpts.graphConfig.default)
+graphTask('migrate', 'Migrate contracts')
   .addFlag('skipConfirmation', cliOpts.skipConfirmation.description)
   .addFlag('force', cliOpts.force.description)
   .addFlag('autoMine', 'Enable auto mining after deployment on local networks')

--- a/tasks/deployment/ownership.ts
+++ b/tasks/deployment/ownership.ts
@@ -1,23 +1,22 @@
 import { ContractTransaction } from 'ethers'
-import { task } from 'hardhat/config'
-import { cliOpts } from '../../cli/defaults'
+import { graphTask } from '../../gre/gre'
 
-task('migrate:ownership', 'Accepts ownership of protocol contracts on behalf of governor')
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .setAction(async (taskArgs, hre) => {
-    const { contracts, getNamedAccounts } = hre.graph(taskArgs)
-    const { governor } = await getNamedAccounts()
+graphTask(
+  'migrate:ownership',
+  'Accepts ownership of protocol contracts on behalf of governor',
+).setAction(async (taskArgs, hre) => {
+  const { contracts, getNamedAccounts } = hre.graph(taskArgs)
+  const { governor } = await getNamedAccounts()
 
-    console.log('> Accepting ownership of contracts')
-    console.log(`- Governor: ${governor.address}`)
+  console.log('> Accepting ownership of contracts')
+  console.log(`- Governor: ${governor.address}`)
 
-    const txs: ContractTransaction[] = []
-    txs.push(await contracts.GraphToken.connect(governor).acceptOwnership())
-    txs.push(await contracts.Controller.connect(governor).acceptOwnership())
-    txs.push(await contracts.GraphProxyAdmin.connect(governor).acceptOwnership())
-    txs.push(await contracts.SubgraphNFT.connect(governor).acceptOwnership())
+  const txs: ContractTransaction[] = []
+  txs.push(await contracts.GraphToken.connect(governor).acceptOwnership())
+  txs.push(await contracts.Controller.connect(governor).acceptOwnership())
+  txs.push(await contracts.GraphProxyAdmin.connect(governor).acceptOwnership())
+  txs.push(await contracts.SubgraphNFT.connect(governor).acceptOwnership())
 
-    await Promise.all(txs.map((tx) => tx.wait()))
-    console.log('Done!')
-  })
+  await Promise.all(txs.map((tx) => tx.wait()))
+  console.log('Done!')
+})

--- a/tasks/deployment/unpause.ts
+++ b/tasks/deployment/unpause.ts
@@ -1,15 +1,11 @@
-import { task } from 'hardhat/config'
-import { cliOpts } from '../../cli/defaults'
+import { graphTask } from '../../gre/gre'
 
-task('migrate:unpause', 'Unpause protocol')
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .setAction(async (taskArgs, hre) => {
-    const { contracts, getNamedAccounts } = hre.graph(taskArgs)
-    const { governor } = await getNamedAccounts()
+graphTask('migrate:unpause', 'Unpause protocol').setAction(async (taskArgs, hre) => {
+  const { contracts, getNamedAccounts } = hre.graph(taskArgs)
+  const { governor } = await getNamedAccounts()
 
-    console.log('> Unpausing protocol')
-    const tx = await contracts.Controller.connect(governor).setPaused(false)
-    await tx.wait()
-    console.log('Done!')
-  })
+  console.log('> Unpausing protocol')
+  const tx = await contracts.Controller.connect(governor).setPaused(false)
+  await tx.wait()
+  console.log('Done!')
+})

--- a/tasks/e2e/e2e.ts
+++ b/tasks/e2e/e2e.ts
@@ -1,8 +1,7 @@
-import { task } from 'hardhat/config'
+import { graphTask } from '../../gre/gre'
 import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
 import { TASK_TEST } from 'hardhat/builtin-tasks/task-names'
 import glob from 'glob'
-import { cliOpts } from '../../cli/defaults'
 import fs from 'fs'
 import { isL1 } from '../../gre/helpers/network'
 import { runScriptWithHardhat } from 'hardhat/internal/util/scripts-runner'
@@ -27,47 +26,40 @@ const setGraphConfig = async (args: TaskArguments, hre: HardhatRuntimeEnvironmen
   }
 }
 
-task('e2e', 'Run all e2e tests')
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
-  .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
-    const testFiles = [
-      ...new glob.GlobSync(CONFIG_TESTS).found,
-      ...new glob.GlobSync(INIT_TESTS).found,
-    ]
+graphTask('e2e', 'Run all e2e tests').setAction(async (args, hre: HardhatRuntimeEnvironment) => {
+  const testFiles = [
+    ...new glob.GlobSync(CONFIG_TESTS).found,
+    ...new glob.GlobSync(INIT_TESTS).found,
+  ]
 
-    setGraphConfig(args, hre)
-    await hre.run(TASK_TEST, {
-      testFiles: testFiles,
-    })
+  setGraphConfig(args, hre)
+  await hre.run(TASK_TEST, {
+    testFiles: testFiles,
   })
+})
 
-task('e2e:config', 'Run deployment configuration e2e tests')
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
-  .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
+graphTask('e2e:config', 'Run deployment configuration e2e tests').setAction(
+  async (args, hre: HardhatRuntimeEnvironment) => {
     const files = new glob.GlobSync(CONFIG_TESTS).found
     setGraphConfig(args, hre)
     await hre.run(TASK_TEST, {
       testFiles: files,
     })
-  })
+  },
+)
 
-task('e2e:init', 'Run deployment initialization e2e tests')
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
-  .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
+graphTask('e2e:init', 'Run deployment initialization e2e tests').setAction(
+  async (args, hre: HardhatRuntimeEnvironment) => {
     const files = new glob.GlobSync(INIT_TESTS).found
     setGraphConfig(args, hre)
     await hre.run(TASK_TEST, {
       testFiles: files,
     })
-  })
+  },
+)
 
-task('e2e:scenario', 'Run scenario scripts and e2e tests')
+graphTask('e2e:scenario', 'Run scenario scripts and e2e tests')
   .addPositionalParam('scenario', 'Name of the scenario to run')
-  .addOptionalParam('graphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('addressBook', cliOpts.addressBook.description)
   .addFlag('skipScript', "Don't run scenario script")
   .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
     setGraphConfig(args, hre)


### PR DESCRIPTION
### Motivation

Each hardhat task that we add that uses GRE requires setting up the same parameters. This PR introduces a convenience method `graphTask` which is a drop in replacement for `task` but includes GRE related boilerplate.

```ts
// Before
import { task } from 'hardhat/config'

task('hello-world', 'Say hi!')
  .addOptionalParam('addressBook', 'Path to the address book file.')
  .addOptionalParam('graphConfig', 'Path to the graph config file for the network specified using --network.')
  .addOptionalParam('l1GraphConfig', 'Path to the graph config file for the L1 network.')
  .addOptionalParam('l2GraphConfig', 'Path to the graph config file for the L2 network.')
  .setAction(async (args, hre) => {
    console.log('hello world')
    const graph = hre.graph(args)
})

// After
import { graphTask } from '../../gre/gre'

graphTask('hello-world', 'Say hi!')
  .setAction((args, hre) => {
    console.log('hello world')
    const graph = hre.graph(args)
})
```


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>