### PR TITLE
feat: add optional expression logging to GRE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bin/
 # Coverage and other reports
 /reports
 coverage.json
+
+tx-*.log

--- a/gre/gre.ts
+++ b/gre/gre.ts
@@ -43,6 +43,9 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
     logDebug('*** Initializing Graph Runtime Environment (GRE) ***')
     logDebug(`Main network: ${hre.network.name}`)
 
+    const enableTXLogging = opts.enableTXLogging ?? false
+    logDebug(`Tx logging: ${enableTXLogging ? 'enabled' : 'disabled'}`)
+
     const { l1ChainId, l2ChainId, isHHL1 } = getChains(hre.network.config.chainId)
     const { l1Provider, l2Provider } = getProviders(hre, l1ChainId, l2ChainId, isHHL1)
     const addressBookPath = getAddressBookPath(hre, opts)
@@ -69,6 +72,7 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
       l1GraphConfigPath,
       addressBookPath,
       isHHL1,
+      enableTXLogging,
       l1GetWallets,
       l1GetWallet,
     )
@@ -79,6 +83,7 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
       l2GraphConfigPath,
       addressBookPath,
       isHHL1,
+      enableTXLogging,
       l2GetWallets,
       l2GetWallet,
     )
@@ -102,6 +107,7 @@ function buildGraphNetworkEnvironment(
   graphConfigPath: string | undefined,
   addressBookPath: string,
   isHHL1: boolean,
+  enableTXLogging: boolean,
   getWallets: () => Promise<Wallet[]>,
   getWallet: (address: string) => Promise<Wallet>,
 ): GraphNetworkEnvironment | null {
@@ -127,7 +133,7 @@ function buildGraphNetworkEnvironment(
     addressBook: lazyObject(() => getAddressBook(addressBookPath, chainId.toString())),
     graphConfig: lazyObject(() => readConfig(graphConfigPath, true)),
     contracts: lazyObject(() =>
-      loadContracts(getAddressBook(addressBookPath, chainId.toString()), provider),
+      loadContracts(getAddressBook(addressBookPath, chainId.toString()), provider, enableTXLogging),
     ),
     getDeployer: lazyFunction(() => () => getDeployer(provider)),
     getNamedAccounts: lazyFunction(() => () => getNamedAccounts(provider, graphConfigPath)),

--- a/gre/gre.ts
+++ b/gre/gre.ts
@@ -43,8 +43,8 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
     logDebug('*** Initializing Graph Runtime Environment (GRE) ***')
     logDebug(`Main network: ${hre.network.name}`)
 
-    const enableTXLogging = opts.enableTXLogging ?? false
-    logDebug(`Tx logging: ${enableTXLogging ? 'enabled' : 'disabled'}`)
+    const enableTxLogging = opts.enableTxLogging ?? false
+    logDebug(`Tx logging: ${enableTxLogging ? 'enabled' : 'disabled'}`)
 
     const { l1ChainId, l2ChainId, isHHL1 } = getChains(hre.network.config.chainId)
     const { l1Provider, l2Provider } = getProviders(hre, l1ChainId, l2ChainId, isHHL1)
@@ -72,7 +72,7 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
       l1GraphConfigPath,
       addressBookPath,
       isHHL1,
-      enableTXLogging,
+      enableTxLogging,
       l1GetWallets,
       l1GetWallet,
     )
@@ -83,7 +83,7 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
       l2GraphConfigPath,
       addressBookPath,
       isHHL1,
-      enableTXLogging,
+      enableTxLogging,
       l2GetWallets,
       l2GetWallet,
     )
@@ -107,7 +107,7 @@ function buildGraphNetworkEnvironment(
   graphConfigPath: string | undefined,
   addressBookPath: string,
   isHHL1: boolean,
-  enableTXLogging: boolean,
+  enableTxLogging: boolean,
   getWallets: () => Promise<Wallet[]>,
   getWallet: (address: string) => Promise<Wallet>,
 ): GraphNetworkEnvironment | null {
@@ -133,7 +133,7 @@ function buildGraphNetworkEnvironment(
     addressBook: lazyObject(() => getAddressBook(addressBookPath, chainId.toString())),
     graphConfig: lazyObject(() => readConfig(graphConfigPath, true)),
     contracts: lazyObject(() =>
-      loadContracts(getAddressBook(addressBookPath, chainId.toString()), provider, enableTXLogging),
+      loadContracts(getAddressBook(addressBookPath, chainId.toString()), provider, enableTxLogging),
     ),
     getDeployer: lazyFunction(() => () => getDeployer(provider)),
     getNamedAccounts: lazyFunction(() => () => getNamedAccounts(provider, graphConfigPath)),

--- a/gre/type-extensions.d.ts
+++ b/gre/type-extensions.d.ts
@@ -10,7 +10,7 @@ export interface GraphRuntimeEnvironmentOptions {
   l1GraphConfig?: string
   l2GraphConfig?: string
   graphConfig?: string
-  enableTXLogging?: boolean
+  enableTxLogging?: boolean
 }
 
 export type AccountNames =

--- a/gre/type-extensions.d.ts
+++ b/gre/type-extensions.d.ts
@@ -10,6 +10,7 @@ export interface GraphRuntimeEnvironmentOptions {
   l1GraphConfig?: string
   l2GraphConfig?: string
   graphConfig?: string
+  enableTXLogging?: boolean
 }
 
 export type AccountNames =


### PR DESCRIPTION
Adds an optional wrapper for GRE contract calls, the wrapper will:
- make the contract call and wait for confirmation using `provider.waitForTransaction`
- log transaction details to the console in a "pretty" human readable form
- log transaction details to a file in the projects root directory (`tx-<DATE>.log`)

This will be disabled for now (unless explicitly enabled) because CLI based scripts already have this type of logging using the `sendTransaction` utility. Until we consolidate those (or solve any potential double logging) we shouldn't enable this feature by default.

### Example usage

To try it out simply initialize GRE with `enableTxLogging = true`. Note that running the same script with `enableTXLogging = false` will print nothing to the console.

```ts
  const graph = hre.graph({ enableTxLogging: true })
  const deployer = await graph.getDeployer()
  await graph.l1.contracts.GraphToken.connect(deployer).addMinter(deployer.address)
```

Console output:
```bash
> Sent transaction GraphToken.addMinter
   sender: 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
   contract: 0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7
   params: [ 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1 ]
   txHash: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
✔ Transaction succeeded: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
```
Log file contents:
```
[2022-10-03T21:14:34.957Z] > Sent transaction GraphToken.addMinter
[2022-10-03T21:14:34.957Z]    sender: 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
[2022-10-03T21:14:34.957Z]    contract: 0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7
[2022-10-03T21:14:34.957Z]    params: [ 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1 ]
[2022-10-03T21:14:34.957Z]    txHash: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
[2022-10-03T21:14:50.972Z] ✔ Transaction succeeded: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
[2022-10-03T21:15:24.780Z] > Sent transaction GraphToken.addMinter
[2022-10-03T21:15:24.780Z]    sender: 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
[2022-10-03T21:15:24.780Z]    contract: 0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7
[2022-10-03T21:15:24.780Z]    params: [ 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1 ]
[2022-10-03T21:15:24.780Z]    txHash: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
[2022-10-03T21:15:40.813Z] ✔ Transaction succeeded: 0xbcdef6ebd4e743a3a11b20ba738c45ec95bd9875e2fa903258f5349b565ade8e
```

Closes: #702
Signed-off-by: Tomás Migone <tomas@edgeandnode.com>