### PR TITLE
test: print gas report, and ensure evm is killed

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -9,6 +9,14 @@ source $(pwd)/scripts/evm
 
 yarn build
 
+### Cleanup
+function cleanup() {
+  if [ "$RUN_EVM" = true ]; then
+    evm_kill
+  fi
+}
+trap cleanup EXIT
+
 # Gas reporter needs to run in its own evm instance
 if [ "$RUN_EVM" = true  ]; then
   evm_kill
@@ -23,14 +31,7 @@ mkdir -p reports
 # Run using the standalone evm instance
 npx hardhat test --network hardhat $@
 
-### Cleanup
-
-# Exit error mode so the evm instance always gets killed
-set +e
-result=0
-
-if [ "$RUN_EVM" = true ]; then
-  evm_kill
+if [ "$REPORT_GAS" = true ]; then
+  cat reports/gas-report.log
+  echo "" # Gas report doesn't have a newline at the end
 fi
-
-exit $result


### PR DESCRIPTION
- Gas report is saved to reports/ folder, but usually we want to see it in the console, so here we add a cat command to print it
- The EVM wasn't being killed properly if the tests failed, so here we add a trap to ensure the cleanup happens