### PR TITLE
feat: avoid zero grt qfee collected being added to rebate pool

### DIFF
--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -577,146 +577,80 @@ describe('Staking:Allocation', () => {
     beforeEach(async function () {
       // Stake and allocate
       await staking.connect(indexer.signer).stake(tokensToStake)
+
+      // Fund asset holder wallet
+      const tokensToFund = toGRT('100000')
+      await grt.connect(governor.signer).mint(assetHolder.address, tokensToFund)
+      await grt.connect(assetHolder.signer).approve(staking.address, tokensToFund)
     })
 
-    for (const tokensToAllocate of [toBN(100), toBN(0)]) {
-      context(`> with ${tokensToAllocate} allocated tokens`, async function () {
-        beforeEach(async function () {
-          await allocate(tokensToAllocate)
-        })
+    for (const toAllocate of [100, 0]) {
+      const tokensToAllocate = toBN(toAllocate)
+      const tokensToCollect = toBN(100 - toAllocate)
+      context(
+        `> with ${tokensToAllocate} allocated tokens and ${tokensToCollect} query fees collected`,
+        async function () {
+          beforeEach(async function () {
+            await allocate(tokensToAllocate)
+            await staking.connect(assetHolder.signer).collect(tokensToCollect, allocationID)
+          })
 
-        it('reject close a non-existing allocation', async function () {
-          const invalidAllocationID = randomHexBytes(20)
-          const tx = staking.connect(indexer.signer).closeAllocation(invalidAllocationID, poi)
-          await expect(tx).revertedWith('!active')
-        })
+          it('reject close a non-existing allocation', async function () {
+            const invalidAllocationID = randomHexBytes(20)
+            const tx = staking.connect(indexer.signer).closeAllocation(invalidAllocationID, poi)
+            await expect(tx).revertedWith('!active')
+          })
 
-        it('reject close before at least one epoch has passed', async function () {
-          const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
-          await expect(tx).revertedWith('<epochs')
-        })
+          it('reject close before at least one epoch has passed', async function () {
+            const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
+            await expect(tx).revertedWith('<epochs')
+          })
 
-        it('reject close if not the owner of allocation', async function () {
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
+          it('reject close if not the owner of allocation', async function () {
+            // Move at least one epoch to be able to close
+            await advanceToNextEpoch(epochManager)
 
-          // Close allocation
-          const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
-          await expect(tx).revertedWith('!auth')
-        })
+            // Close allocation
+            const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
+            await expect(tx).revertedWith('!auth')
+          })
 
-        it('reject close if allocation is already closed', async function () {
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
+          it('reject close if allocation is already closed', async function () {
+            // Move at least one epoch to be able to close
+            await advanceToNextEpoch(epochManager)
 
-          // First closing
-          await staking.connect(indexer.signer).closeAllocation(allocationID, poi)
+            // First closing
+            await staking.connect(indexer.signer).closeAllocation(allocationID, poi)
 
-          // Second closing
-          const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
-          await expect(tx).revertedWith('!active')
-        })
+            // Second closing
+            const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
+            await expect(tx).revertedWith('!active')
+          })
 
-        it('should close an allocation', async function () {
-          // Before state
-          const beforeStake = await staking.stakes(indexer.address)
-          const beforeAlloc = await staking.getAllocation(allocationID)
-          const beforeRebatePool = await staking.rebates(
-            (await epochManager.currentEpoch()).add(toBN('2')),
-          )
-
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
-          await advanceToNextEpoch(epochManager)
-
-          // Calculations
-          const currentEpoch = await epochManager.currentEpoch()
-          const epochs = currentEpoch.sub(beforeAlloc.createdAtEpoch)
-          const maxAllocationEpochs = toBN(await staking.maxAllocationEpochs())
-          const effectiveAllocation = calculateEffectiveAllocation(
-            beforeAlloc.tokens,
-            epochs,
-            maxAllocationEpochs,
-          )
-
-          // Close allocation
-          const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
-          await expect(tx)
-            .emit(staking, 'AllocationClosed')
-            .withArgs(
-              indexer.address,
-              subgraphDeploymentID,
-              currentEpoch,
-              beforeAlloc.tokens,
-              allocationID,
-              effectiveAllocation,
-              indexer.address,
-              poi,
-              false,
+          it('should close an allocation', async function () {
+            // Before state
+            const beforeStake = await staking.stakes(indexer.address)
+            const beforeAlloc = await staking.getAllocation(allocationID)
+            const beforeRebatePool = await staking.rebates(
+              (await epochManager.currentEpoch()).add(toBN('2')),
             )
 
-          // After state
-          const afterStake = await staking.stakes(indexer.address)
-          const afterAlloc = await staking.getAllocation(allocationID)
-          const afterRebatePool = await staking.rebates(currentEpoch)
+            // Move at least one epoch to be able to close
+            await advanceToNextEpoch(epochManager)
+            await advanceToNextEpoch(epochManager)
 
-          // Stake updated
-          expect(afterStake.tokensAllocated).eq(beforeStake.tokensAllocated.sub(beforeAlloc.tokens))
-          // Allocation updated
-          expect(afterAlloc.closedAtEpoch).eq(currentEpoch)
-          expect(afterAlloc.effectiveAllocation).eq(effectiveAllocation)
-          // Rebate updated
-          expect(afterRebatePool.fees).eq(beforeRebatePool.fees.add(beforeAlloc.collectedFees))
-          expect(afterRebatePool.effectiveAllocatedStake).eq(
-            beforeRebatePool.effectiveAllocatedStake.add(effectiveAllocation),
-          )
-          expect(afterRebatePool.unclaimedAllocationsCount).eq(
-            beforeRebatePool.unclaimedAllocationsCount + 1,
-          )
-        })
-
-        it('should close an allocation (by operator)', async function () {
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
-          await advanceToNextEpoch(epochManager)
-
-          // Reject to close if the address is not operator
-          const tx1 = staking.connect(me.signer).closeAllocation(allocationID, poi)
-          await expect(tx1).revertedWith('!auth')
-
-          // Should close if given operator auth
-          await staking.connect(indexer.signer).setOperator(me.address, true)
-          await staking.connect(me.signer).closeAllocation(allocationID, poi)
-        })
-
-        it('should close an allocation (by public) only if allocation is non-zero', async function () {
-          // Reject to close if public address and under max allocation epochs
-          const tx1 = staking.connect(me.signer).closeAllocation(allocationID, poi)
-          await expect(tx1).revertedWith('<epochs')
-
-          // Move max allocation epochs to close by delegator
-          const maxAllocationEpochs = await staking.maxAllocationEpochs()
-          await advanceEpochs(epochManager, maxAllocationEpochs + 1)
-
-          // Closing should only be possible if allocated tokens > 0
-          const alloc = await staking.getAllocation(allocationID)
-          if (alloc.tokens.gt(0)) {
             // Calculations
-            const beforeAlloc = await staking.getAllocation(allocationID)
             const currentEpoch = await epochManager.currentEpoch()
             const epochs = currentEpoch.sub(beforeAlloc.createdAtEpoch)
+            const maxAllocationEpochs = toBN(await staking.maxAllocationEpochs())
             const effectiveAllocation = calculateEffectiveAllocation(
               beforeAlloc.tokens,
               epochs,
-              toBN(maxAllocationEpochs),
+              maxAllocationEpochs,
             )
 
-            // Setup
-            await grt.connect(governor.signer).mint(me.address, toGRT('1'))
-            await grt.connect(me.signer).approve(staking.address, toGRT('1'))
-
-            // Should close by public
-            const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
+            // Close allocation
+            const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
             await expect(tx)
               .emit(staking, 'AllocationClosed')
               .withArgs(
@@ -726,56 +660,144 @@ describe('Staking:Allocation', () => {
                 beforeAlloc.tokens,
                 allocationID,
                 effectiveAllocation,
-                me.address,
+                indexer.address,
                 poi,
-                true,
+                false,
               )
-          } else {
-            // closing by the public on a zero allocation is not authorized
-            const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
-            await expect(tx).revertedWith('!auth')
-          }
-        })
 
-        it('should close many allocations in batch', async function () {
-          // Setup a second allocation
-          await staking.connect(indexer.signer).stake(tokensToStake)
-          const channelKey2 = deriveChannelKey()
-          const allocationID2 = channelKey2.address
-          await staking
-            .connect(indexer.signer)
-            .allocate(
-              subgraphDeploymentID,
-              tokensToAllocate,
-              allocationID2,
-              metadata,
-              await channelKey2.generateProof(indexer.address),
+            // After state
+            const afterStake = await staking.stakes(indexer.address)
+            const afterAlloc = await staking.getAllocation(allocationID)
+            const afterRebatePool = await staking.rebates(currentEpoch)
+
+            // Stake updated
+            expect(afterStake.tokensAllocated).eq(
+              beforeStake.tokensAllocated.sub(beforeAlloc.tokens),
             )
+            // Allocation updated
+            expect(afterAlloc.closedAtEpoch).eq(currentEpoch)
+            expect(afterAlloc.effectiveAllocation).eq(effectiveAllocation)
+            // Rebate updated accordingly depending if zero or non-zero queryFees
+            expect(afterRebatePool.fees).eq(beforeRebatePool.fees.add(beforeAlloc.collectedFees))
+            if (beforeAlloc.collectedFees > toBN(0)) {
+              expect(afterRebatePool.effectiveAllocatedStake).eq(
+                beforeRebatePool.effectiveAllocatedStake.add(effectiveAllocation),
+              )
+              expect(afterRebatePool.unclaimedAllocationsCount).eq(
+                beforeRebatePool.unclaimedAllocationsCount + 1,
+              )
+            } else {
+              expect(afterRebatePool.effectiveAllocatedStake).eq(
+                beforeRebatePool.effectiveAllocatedStake,
+              )
+              expect(afterRebatePool.unclaimedAllocationsCount).eq(
+                beforeRebatePool.unclaimedAllocationsCount,
+              )
+            }
+          })
 
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
-          await advanceToNextEpoch(epochManager)
+          it('should close an allocation (by operator)', async function () {
+            // Move at least one epoch to be able to close
+            await advanceToNextEpoch(epochManager)
+            await advanceToNextEpoch(epochManager)
 
-          // Close multiple allocations in one tx
-          const requests = await Promise.all(
-            [
-              {
-                allocationID: allocationID,
-                poi: poi,
-              },
-              {
-                allocationID: allocationID2,
-                poi: poi,
-              },
-            ].map(({ allocationID, poi }) =>
-              staking
-                .connect(indexer.signer)
-                .populateTransaction.closeAllocation(allocationID, poi),
-            ),
-          ).then((e) => e.map((e: PopulatedTransaction) => e.data))
-          await staking.connect(indexer.signer).multicall(requests)
-        })
-      })
+            // Reject to close if the address is not operator
+            const tx1 = staking.connect(me.signer).closeAllocation(allocationID, poi)
+            await expect(tx1).revertedWith('!auth')
+
+            // Should close if given operator auth
+            await staking.connect(indexer.signer).setOperator(me.address, true)
+            await staking.connect(me.signer).closeAllocation(allocationID, poi)
+          })
+
+          it('should close an allocation (by public) only if allocation is non-zero', async function () {
+            // Reject to close if public address and under max allocation epochs
+            const tx1 = staking.connect(me.signer).closeAllocation(allocationID, poi)
+            await expect(tx1).revertedWith('<epochs')
+
+            // Move max allocation epochs to close by delegator
+            const maxAllocationEpochs = await staking.maxAllocationEpochs()
+            await advanceEpochs(epochManager, maxAllocationEpochs + 1)
+
+            // Closing should only be possible if allocated tokens > 0
+            const alloc = await staking.getAllocation(allocationID)
+            if (alloc.tokens.gt(0)) {
+              // Calculations
+              const beforeAlloc = await staking.getAllocation(allocationID)
+              const currentEpoch = await epochManager.currentEpoch()
+              const epochs = currentEpoch.sub(beforeAlloc.createdAtEpoch)
+              const effectiveAllocation = calculateEffectiveAllocation(
+                beforeAlloc.tokens,
+                epochs,
+                toBN(maxAllocationEpochs),
+              )
+
+              // Setup
+              await grt.connect(governor.signer).mint(me.address, toGRT('1'))
+              await grt.connect(me.signer).approve(staking.address, toGRT('1'))
+
+              // Should close by public
+              const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
+              await expect(tx)
+                .emit(staking, 'AllocationClosed')
+                .withArgs(
+                  indexer.address,
+                  subgraphDeploymentID,
+                  currentEpoch,
+                  beforeAlloc.tokens,
+                  allocationID,
+                  effectiveAllocation,
+                  me.address,
+                  poi,
+                  true,
+                )
+            } else {
+              // closing by the public on a zero allocation is not authorized
+              const tx = staking.connect(me.signer).closeAllocation(allocationID, poi)
+              await expect(tx).revertedWith('!auth')
+            }
+          })
+
+          it('should close many allocations in batch', async function () {
+            // Setup a second allocation
+            await staking.connect(indexer.signer).stake(tokensToStake)
+            const channelKey2 = deriveChannelKey()
+            const allocationID2 = channelKey2.address
+            await staking
+              .connect(indexer.signer)
+              .allocate(
+                subgraphDeploymentID,
+                tokensToAllocate,
+                allocationID2,
+                metadata,
+                await channelKey2.generateProof(indexer.address),
+              )
+
+            // Move at least one epoch to be able to close
+            await advanceToNextEpoch(epochManager)
+            await advanceToNextEpoch(epochManager)
+
+            // Close multiple allocations in one tx
+            const requests = await Promise.all(
+              [
+                {
+                  allocationID: allocationID,
+                  poi: poi,
+                },
+                {
+                  allocationID: allocationID2,
+                  poi: poi,
+                },
+              ].map(({ allocationID, poi }) =>
+                staking
+                  .connect(indexer.signer)
+                  .populateTransaction.closeAllocation(allocationID, poi),
+              ),
+            ).then((e) => e.map((e: PopulatedTransaction) => e.data))
+            await staking.connect(indexer.signer).multicall(requests)
+          })
+        },
+      )
     }
   })
 


### PR DESCRIPTION
Adds some checks to avoid adding zero qfee collected allocations to the rebate pools, to avoid diluting the effective allocation stake of actual participants that provided qfees to the rebate pool.

Should improve burn rates on the rebate pools significantly