### PR TITLE
fix: remove unneeded empty bytes from callhook data

### DIFF
--- a/contracts/gateway/L1GraphTokenGateway.sol
+++ b/contracts/gateway/L1GraphTokenGateway.sol
@@ -316,8 +316,6 @@ contract L1GraphTokenGateway is Initializable, GraphTokenGateway, L1ArbitrumMess
         uint256 _amount,
         bytes memory _data
     ) public pure returns (bytes memory) {
-        bytes memory emptyBytes;
-
         return
             abi.encodeWithSelector(
                 ITokenGateway.finalizeInboundTransfer.selector,
@@ -325,7 +323,7 @@ contract L1GraphTokenGateway is Initializable, GraphTokenGateway, L1ArbitrumMess
                 _from,
                 _to,
                 _amount,
-                abi.encode(emptyBytes, _data)
+                _data
             );
     }
 

--- a/contracts/l2/gateway/L2GraphTokenGateway.sol
+++ b/contracts/l2/gateway/L2GraphTokenGateway.sol
@@ -171,11 +171,7 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger, Reentran
         L2GraphToken(calculateL2TokenAddress(l1GRT)).bridgeMint(_to, _amount);
 
         if (_data.length > 0) {
-            bytes memory callhookData;
-            {
-                (, callhookData) = abi.decode(_data, (bytes, bytes));
-            }
-            ICallhookReceiver(_to).onTokenTransfer(_from, _amount, callhookData);
+            ICallhookReceiver(_to).onTokenTransfer(_from, _amount, _data);
         }
 
         emit DepositFinalized(_l1Token, _from, _to, _amount);

--- a/test/gateway/l1GraphTokenGateway.test.ts
+++ b/test/gateway/l1GraphTokenGateway.test.ts
@@ -339,13 +339,7 @@ describe('L1GraphTokenGateway', () => {
       const selector = l1GraphTokenGateway.interface.getSighash('finalizeInboundTransfer')
       const params = utils.defaultAbiCoder.encode(
         ['address', 'address', 'address', 'uint256', 'bytes'],
-        [
-          grt.address,
-          tokenSender.address,
-          l2Receiver.address,
-          toGRT('10'),
-          utils.defaultAbiCoder.encode(['bytes', 'bytes'], [emptyCallHookData, callHookData]),
-        ],
+        [grt.address, tokenSender.address, l2Receiver.address, toGRT('10'), callHookData],
       )
       const outboundData = utils.hexlify(utils.concat([selector, params]))
 

--- a/test/l2/l2GraphTokenGateway.test.ts
+++ b/test/l2/l2GraphTokenGateway.test.ts
@@ -39,13 +39,9 @@ describe('L2GraphTokenGateway', () => {
 
   const senderTokens = toGRT('1000')
   const defaultData = '0x'
-  const notEmptyCallHookData = utils.defaultAbiCoder.encode(
+  const defaultDataWithNotEmptyCallHookData = utils.defaultAbiCoder.encode(
     ['uint256', 'uint256'],
     [toBN('1337'), toBN('42')],
-  )
-  const defaultDataWithNotEmptyCallHookData = utils.defaultAbiCoder.encode(
-    ['bytes', 'bytes'],
-    ['0x', notEmptyCallHookData],
   )
 
   before(async function () {
@@ -419,7 +415,6 @@ describe('L2GraphTokenGateway', () => {
           ['uint256', 'uint256'],
           [toBN('0'), toBN('42')],
         )
-        const data = utils.defaultAbiCoder.encode(['bytes', 'bytes'], ['0x', callHookData])
         const mockL1GatewayL2Alias = await getL2SignerFromL1(mockL1Gateway.address)
         await me.signer.sendTransaction({
           to: await mockL1GatewayL2Alias.getAddress(),
@@ -432,13 +427,12 @@ describe('L2GraphTokenGateway', () => {
             tokenSender.address,
             callhookReceiverMock.address,
             toGRT('10'),
-            data,
+            callHookData,
           )
         await expect(tx).revertedWith('FOO_IS_ZERO')
       })
       it('reverts if trying to call a callhook in a contract that does not implement onTokenTransfer', async function () {
         const callHookData = utils.defaultAbiCoder.encode(['uint256'], [toBN('0')])
-        const data = utils.defaultAbiCoder.encode(['bytes', 'bytes'], ['0x', callHookData])
         const mockL1GatewayL2Alias = await getL2SignerFromL1(mockL1Gateway.address)
         await me.signer.sendTransaction({
           to: await mockL1GatewayL2Alias.getAddress(),
@@ -452,7 +446,7 @@ describe('L2GraphTokenGateway', () => {
             tokenSender.address,
             rewardsManager.address,
             toGRT('10'),
-            data,
+            callHookData,
           )
         await expect(tx).revertedWith(
           "function selector was not recognized and there's no fallback function",


### PR DESCRIPTION
With the way it worked up to now, `_data.length` would _always_ be nonzero, so we were calling the callhooks always, even when transferring to an EOA! This removes those unnecessary emptyBytes (which were there just to keep the gateway similar to Arbitrum's gateway implementation), and now `_data` on the L2 side will be the callhook data sent from L1, and therefore zero length if there is no callhook to call.