### PR TITLE
fix(L2GraphTokenGateway): burn without allowance for Router / Arbitrum UI compatibility

### DIFF
--- a/cli/commands/bridge/to-l1.ts
+++ b/cli/commands/bridge/to-l1.ts
@@ -90,8 +90,6 @@ export const startSendToL1 = async (cli: CLIEnvironment, cliArgs: CLIArgs): Prom
   }
 
   const params = [l1GRTAddress, recipient, amount, '0x']
-  logger.info('Approving token transfer')
-  await sendTransaction(l2Wallet, l2GRT, 'approve', [gateway.address, amount])
   logger.info('Sending outbound transfer transaction')
   const receipt = await sendTransaction(
     l2Wallet,

--- a/contracts/l2/gateway/L2GraphTokenGateway.sol
+++ b/contracts/l2/gateway/L2GraphTokenGateway.sol
@@ -126,7 +126,8 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger, Reentran
      * @notice Burns L2 tokens and initiates a transfer to L1.
      * The tokens will be received on L1 only after the wait period (7 days) is over,
      * and will require an Outbox.executeTransaction to finalize.
-     * @dev no additional callhook data is allowed
+     * @dev No additional callhook data is allowed. Note this function does not require
+     * giving the gateway allowance for the tokens that will be transferred.
      * @param _l1Token L1 Address of GRT (needed for compatibility with Arbitrum Gateway Router)
      * @param _to Recipient address on L1
      * @param _amount Amount of tokens to burn
@@ -181,8 +182,8 @@ contract L2GraphTokenGateway is GraphTokenGateway, L2ArbitrumMessenger, Reentran
      * @notice Burns L2 tokens and initiates a transfer to L1.
      * The tokens will be available on L1 only after the wait period (7 days) is over,
      * and will require an Outbox.executeTransaction to finalize.
-     * Note that the caller must previously allow the gateway to spend the specified amount of GRT.
-     * @dev no additional callhook data is allowed. The two unused params are needed
+     * @dev No additional callhook data is allowed. Note this function does not require
+     * giving the gateway allowance for the tokens that will be transferred. The two unused params are needed
      * for compatibility with Arbitrum's gateway router.
      * The function is payable for ITokenGateway compatibility, but msg.value must be zero.
      * @param _l1Token L1 Address of GRT (needed for compatibility with Arbitrum Gateway Router)

--- a/contracts/l2/token/L2GraphToken.sol
+++ b/contracts/l2/token/L2GraphToken.sol
@@ -84,7 +84,7 @@ contract L2GraphToken is GraphTokenUpgradeable, IArbToken {
      * @param _amount Number of tokens to burn
      */
     function bridgeBurn(address _account, uint256 _amount) external override onlyGateway {
-        burnFrom(_account, _amount);
+        _burn(_account, _amount);
         emit BridgeBurned(_account, _amount);
     }
 }

--- a/test/l2/l2GraphTokenGateway.test.ts
+++ b/test/l2/l2GraphTokenGateway.test.ts
@@ -307,11 +307,9 @@ describe('L2GraphTokenGateway', () => {
         await expect(tx).revertedWith('TOKEN_NOT_GRT')
       })
       it('burns tokens and triggers an L1 call', async function () {
-        await grt.connect(tokenSender.signer).approve(l2GraphTokenGateway.address, toGRT('10'))
         await testValidOutboundTransfer(tokenSender.signer, defaultData)
       })
       it('decodes the sender address from messages sent by the router', async function () {
-        await grt.connect(tokenSender.signer).approve(l2GraphTokenGateway.address, toGRT('10'))
         const routerEncodedData = utils.defaultAbiCoder.encode(
           ['address', 'bytes'],
           [tokenSender.address, defaultData],
@@ -319,7 +317,6 @@ describe('L2GraphTokenGateway', () => {
         await testValidOutboundTransfer(mockRouter.signer, routerEncodedData)
       })
       it('reverts when called with nonempty calldata', async function () {
-        await grt.connect(tokenSender.signer).approve(l2GraphTokenGateway.address, toGRT('10'))
         const tx = l2GraphTokenGateway
           .connect(tokenSender.signer)
           ['outboundTransfer(address,address,uint256,bytes)'](
@@ -331,7 +328,6 @@ describe('L2GraphTokenGateway', () => {
         await expect(tx).revertedWith('CALL_HOOK_DATA_NOT_ALLOWED')
       })
       it('reverts when the sender does not have enough GRT', async function () {
-        await grt.connect(tokenSender.signer).approve(l2GraphTokenGateway.address, toGRT('1001'))
         const tx = l2GraphTokenGateway
           .connect(tokenSender.signer)
           ['outboundTransfer(address,address,uint256,bytes)'](


### PR DESCRIPTION
Looks like the Arbitrum router and bridge UI expects the L2 gateway to be able to burn tokens without requiring allowance.