### PR TITLE
feat: integrate bridge tasks with arbitrum sdk

### DIFF
--- a/cli/arbitrum.ts
+++ b/cli/arbitrum.ts
@@ -1,0 +1,108 @@
+import {
+  L1ToL2MessageReader,
+  L1ToL2MessageStatus,
+  L1ToL2MessageWriter,
+  L1TransactionReceipt,
+  L2ToL1MessageReader,
+  L2ToL1MessageStatus,
+  L2ToL1MessageWriter,
+  L2TransactionReceipt,
+} from '@arbitrum/sdk'
+import { providers, Signer } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+
+// L1 -> L2
+export async function getL1ToL2MessageWriter(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+  signer: Signer,
+): Promise<L1ToL2MessageWriter> {
+  return (await getL1ToL2Message(
+    txHashOrReceipt,
+    l1Provider,
+    l2Provider,
+    signer,
+  )) as L1ToL2MessageWriter
+}
+
+export async function getL1ToL2MessageReader(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+): Promise<L1ToL2MessageReader> {
+  return await getL1ToL2Message(txHashOrReceipt, l1Provider, l2Provider)
+}
+
+export async function getL1ToL2MessageStatus(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+): Promise<L1ToL2MessageStatus> {
+  const message = await getL1ToL2Message(txHashOrReceipt, l1Provider, l2Provider)
+  return await message.status()
+}
+
+async function getL1ToL2Message(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+  signer?: Signer,
+): Promise<L1ToL2MessageWriter | L1ToL2MessageReader> {
+  const txReceipt =
+    typeof txHashOrReceipt === 'string'
+      ? await l1Provider.getTransactionReceipt(txHashOrReceipt)
+      : txHashOrReceipt
+  const l2SignerOrProvider = signer ? signer.connect(l2Provider) : l2Provider
+  const l1Receipt = new L1TransactionReceipt(txReceipt)
+  const l1ToL2Messages = await l1Receipt.getL1ToL2Messages(l2SignerOrProvider)
+  return l1ToL2Messages[0]
+}
+
+// L2 -> L1
+export async function getL2ToL1MessageWriter(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+  signer: Signer,
+): Promise<L2ToL1MessageWriter> {
+  return (await getL2ToL1Message(
+    txHashOrReceipt,
+    l1Provider,
+    l2Provider,
+    signer,
+  )) as L2ToL1MessageWriter
+}
+
+export async function getL2ToL1MessageReader(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+): Promise<L2ToL1MessageReader> {
+  return await getL2ToL1Message(txHashOrReceipt, l1Provider, l2Provider)
+}
+
+export async function getL2ToL1MessageStatus(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+): Promise<L2ToL1MessageStatus> {
+  const message = await getL2ToL1Message(txHashOrReceipt, l1Provider, l2Provider)
+  return await message.status(l2Provider)
+}
+
+async function getL2ToL1Message(
+  txHashOrReceipt: string | providers.TransactionReceipt,
+  l1Provider: Provider,
+  l2Provider: Provider,
+  signer?: Signer,
+) {
+  const txReceipt =
+    typeof txHashOrReceipt === 'string'
+      ? await l2Provider.getTransactionReceipt(txHashOrReceipt)
+      : txHashOrReceipt
+  const l1SignerOrProvider = signer ? signer.connect(l1Provider) : l1Provider
+  const l2Receipt = new L2TransactionReceipt(txReceipt)
+  const l2ToL1Messages = await l2Receipt.getL2ToL1Messages(l1SignerOrProvider)
+  return l2ToL1Messages[0]
+}

--- a/cli/commands/bridge/to-l2.ts
+++ b/cli/commands/bridge/to-l2.ts
@@ -6,6 +6,7 @@ import { loadEnv, CLIArgs, CLIEnvironment } from '../../env'
 import { logger } from '../../logging'
 import { getProvider, sendTransaction, toGRT, ensureAllowance, toBN } from '../../network'
 import { chainIdIsL2, estimateRetryableTxGas } from '../../cross-chain'
+import { getL1ToL2MessageWriter } from '../../arbitrum'
 
 const logAutoRedeemReason = (autoRedeemRec) => {
   if (autoRedeemRec == null) {
@@ -105,9 +106,12 @@ export const sendToL2 = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<v
   // get l2 ticket status
   if (txReceipt.status == 1) {
     logger.info('Waiting for message to propagate to L2...')
-    const l1Receipt = new L1TransactionReceipt(txReceipt)
-    const l1ToL2Messages = await l1Receipt.getL1ToL2Messages(cli.wallet.connect(l2Provider))
-    const l1ToL2Message = l1ToL2Messages[0]
+    const l1ToL2Message = await getL1ToL2MessageWriter(
+      txReceipt,
+      cli.wallet.provider,
+      l2Provider,
+      cli.wallet,
+    )
     try {
       await checkAndRedeemMessage(l1ToL2Message)
     } catch (e) {

--- a/tasks/bridge/withdrawals.ts
+++ b/tasks/bridge/withdrawals.ts
@@ -2,6 +2,8 @@ import { task } from 'hardhat/config'
 import { cliOpts } from '../../cli/defaults'
 import { ethers } from 'ethers'
 import { Table } from 'console-table-printer'
+import { L2ToL1MessageStatus } from '@arbitrum/sdk'
+import { getL2ToL1MessageStatus } from '../../cli/arbitrum'
 
 export const TASK_BRIDGE_WITHDRAWALS = 'bridge:withdrawals'
 
@@ -27,15 +29,20 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
     const endBlock = taskArgs.endBlock ? parseInt(taskArgs.endBlock) : 'latest'
     console.log(`Searching blocks from block ${startBlock} to block ${endBlock}`)
 
-    const events = (
-      await gateway.queryFilter(gateway.filters.WithdrawalInitiated(), startBlock, endBlock)
-    ).map((e) => ({
-      blockNumber: e.blockNumber,
-      transactionHash: e.transactionHash,
-      from: e.args.from,
-      to: e.args.to,
-      amount: ethers.utils.formatEther(e.args.amount),
-    }))
+    const events = await Promise.all(
+      (
+        await gateway.queryFilter(gateway.filters.WithdrawalInitiated(), startBlock, endBlock)
+      ).map(async (e) => ({
+        blockNumber: `${e.blockNumber} (${new Date(
+          (await graph.l2.provider.getBlock(e.blockNumber)).timestamp * 1000,
+        ).toLocaleString()})`,
+        tx: `${e.transactionHash} ${e.args.from} -> ${e.args.to}`,
+        amount: ethers.utils.formatEther(e.args.amount),
+        status: emojifyL2ToL1Status(
+          await getL2ToL1MessageStatus(e.transactionHash, graph.l1.provider, graph.l2.provider),
+        ),
+      })),
+    )
 
     const total = events.reduce(
       (acc, e) => acc.add(ethers.utils.parseEther(e.amount)),
@@ -45,23 +52,42 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
       `Found ${events.length} withdrawals for a total of ${ethers.utils.formatEther(total)} GRT`,
     )
 
+    console.log(
+      'L2 to L1 message status reference: 🚧 = unconfirmed, ⚠️  = confirmed, ✅ = executed',
+    )
+
     printEvents(events)
   })
 
 function printEvents(events: any[]) {
   const tablePrinter = new Table({
+    charLength: { '🚧': 2, '✅': 2, '⚠️': 1, '❌': 2 },
     columns: [
+      { name: 'status', color: 'green', alignment: 'center' },
       { name: 'blockNumber', color: 'green' },
       {
-        name: 'transactionHash',
+        name: 'tx',
         color: 'green',
+        alignment: 'center',
+        maxLen: 88,
       },
-      { name: 'from', color: 'green' },
-      { name: 'to', color: 'green' },
       { name: 'amount', color: 'green' },
     ],
   })
 
   events.map((e) => tablePrinter.addRow(e))
   tablePrinter.printTable()
+}
+
+function emojifyL2ToL1Status(status: L2ToL1MessageStatus): string {
+  switch (status) {
+    case L2ToL1MessageStatus.UNCONFIRMED:
+      return '🚧'
+    case L2ToL1MessageStatus.CONFIRMED:
+      return '⚠️ '
+    case L2ToL1MessageStatus.EXECUTED:
+      return '✅'
+    default:
+      return '❌'
+  }
 }


### PR DESCRIPTION
### Changes
- Integrate Arbitrum SDK on `bridge:deposits` and `bridge:withdrawals` tasks to show message status
- Rework how tables are shown a bit.


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>