### PR TITLE
fix: allow anyone to deprecate a subgraph if migration is not finished after a week (OZ H-01)

### DIFF
--- a/contracts/discovery/IGNS.sol
+++ b/contracts/discovery/IGNS.sol
@@ -34,6 +34,7 @@ interface IGNS {
         bool l1Done; // Migration finished on L1 side
         mapping(address => bool) curatorBalanceClaimed; // True for curators whose balance has been claimed in L2
         bool l2Done; // Migration finished on L2 side
+        uint256 subgraphReceivedOnL2BlockNumber; // Block number when the subgraph was received on L2
     }
 
     /**

--- a/contracts/l2/discovery/IL2GNS.sol
+++ b/contracts/l2/discovery/IL2GNS.sol
@@ -25,6 +25,15 @@ interface IL2GNS is ICallhookReceiver {
     ) external;
 
     /**
+     * @notice Deprecate a subgraph that was migrated from L1, but for which
+     * the migration was never finished. Anyone can call this function after 50400 blocks
+     * (one day) have passed since the subgraph was migrated, if the subgraph owner didn't
+     * call finishSubgraphMigrationFromL1.
+     * @param _subgraphID Subgraph ID
+     */
+    function deprecateSubgraphMigratedFromL1(uint256 _subgraphID) external;
+
+    /**
      * @notice Claim curator balance belonging to a curator from L1.
      * This will be credited to the a beneficiary on L2, and can only be called
      * from the GNS on L1 through a retryable ticket.

--- a/contracts/l2/discovery/IL2GNS.sol
+++ b/contracts/l2/discovery/IL2GNS.sol
@@ -26,9 +26,9 @@ interface IL2GNS is ICallhookReceiver {
 
     /**
      * @notice Deprecate a subgraph that was migrated from L1, but for which
-     * the migration was never finished. Anyone can call this function after 50400 blocks
-     * (one day) have passed since the subgraph was migrated, if the subgraph owner didn't
-     * call finishSubgraphMigrationFromL1.
+     * the migration was never finished. Anyone can call this function after a certain amount of
+     * blocks have passed since the subgraph was migrated, if the subgraph owner didn't
+     * call finishSubgraphMigrationFromL1. In L2GNS this timeout is the FINISH_MIGRATION_TIMEOUT constant.
      * @param _subgraphID Subgraph ID
      */
     function deprecateSubgraphMigratedFromL1(uint256 _subgraphID) external;

--- a/contracts/l2/discovery/L2GNS.sol
+++ b/contracts/l2/discovery/L2GNS.sol
@@ -134,9 +134,9 @@ contract L2GNS is GNS, L2GNSV1Storage, IL2GNS {
 
     /**
      * @notice Deprecate a subgraph that was migrated from L1, but for which
-     * the migration was never finished. Anyone can call this function after 50400 blocks
-     * (one day) have passed since the subgraph was migrated, if the subgraph owner didn't
-     * call finishSubgraphMigrationFromL1.
+     * the migration was never finished. Anyone can call this function after a certain amount of
+     * blocks have passed since the subgraph was migrated, if the subgraph owner didn't
+     * call finishSubgraphMigrationFromL1. In L2GNS this timeout is the FINISH_MIGRATION_TIMEOUT constant.
      * @param _subgraphID Subgraph ID
      */
     function deprecateSubgraphMigratedFromL1(uint256 _subgraphID)


### PR DESCRIPTION
Prevents a griefing attack in which the subgraph owner leaves all the curators' GRT locked because the subgraph migration is never finished.
Note for gas efficiency we switch from using `migrationData.l1Done == true` to `migrationData.subgraphReceivedOnL2BlockNumber != 0` as an indicator that a subgraph was received from L1.