### PR TITLE
feat: subgraph migration to L2 sending only the owner's tokens (OZ M-01)

### DIFF
--- a/contracts/discovery/L1GNS.sol
+++ b/contracts/discovery/L1GNS.sol
@@ -27,7 +27,12 @@ contract L1GNS is GNS, L1GNSV1Storage {
     using SafeMathUpgradeable for uint256;
 
     /// @dev Emitted when a subgraph was sent to L2 through the bridge
-    event SubgraphSentToL2(uint256 indexed _subgraphID, address indexed _l1Owner, address indexed _l2Owner, uint256 _tokens);
+    event SubgraphSentToL2(
+        uint256 indexed _subgraphID,
+        address indexed _l1Owner,
+        address indexed _l2Owner,
+        uint256 _tokens
+    );
 
     /// @dev Emitted when a curator's balance for a subgraph was sent to L2
     event CuratorBalanceSentToL2(
@@ -99,7 +104,7 @@ contract L1GNS is GNS, L1GNSV1Storage {
 
         subgraphData.reserveRatioDeprecated = 0;
         _burnNFT(_subgraphID);
-        emit SubgraphSentToL2(_subgraphID, _l2Owner);
+        emit SubgraphSentToL2(_subgraphID, msg.sender, _l2Owner, tokensForL2);
     }
 
     /**
@@ -156,6 +161,7 @@ contract L1GNS is GNS, L1GNSV1Storage {
             _maxSubmissionCost,
             extraData
         );
+        emit CuratorBalanceSentToL2(_subgraphID, msg.sender, _beneficiary, tokensForL2);
     }
 
     /**

--- a/contracts/discovery/L1GNS.sol
+++ b/contracts/discovery/L1GNS.sol
@@ -27,12 +27,13 @@ contract L1GNS is GNS, L1GNSV1Storage {
     using SafeMathUpgradeable for uint256;
 
     /// @dev Emitted when a subgraph was sent to L2 through the bridge
-    event SubgraphSentToL2(uint256 indexed _subgraphID, address indexed _l2Owner);
+    event SubgraphSentToL2(uint256 indexed _subgraphID, address indexed _l1Owner, address indexed _l2Owner, uint256 _tokens);
 
     /// @dev Emitted when a curator's balance for a subgraph was sent to L2
     event CuratorBalanceSentToL2(
         uint256 indexed _subgraphID,
-        address indexed _curator,
+        address indexed _l1Curator,
+        address indexed _l2Beneficiary,
         uint256 _tokens
     );
 

--- a/contracts/discovery/L1GNS.sol
+++ b/contracts/discovery/L1GNS.sol
@@ -8,7 +8,6 @@ import { SafeMathUpgradeable } from "@openzeppelin/contracts-upgradeable/math/Sa
 import { GNS } from "./GNS.sol";
 
 import { ITokenGateway } from "../arbitrum/ITokenGateway.sol";
-import { L1ArbitrumMessenger } from "../arbitrum/L1ArbitrumMessenger.sol";
 import { IL2GNS } from "../l2/discovery/IL2GNS.sol";
 import { IGraphToken } from "../token/IGraphToken.sol";
 import { L1GNSV1Storage } from "./L1GNSStorage.sol";

--- a/contracts/discovery/L1GNS.sol
+++ b/contracts/discovery/L1GNS.sol
@@ -140,7 +140,8 @@ contract L1GNS is GNS, L1GNSV1Storage {
         uint256 subgraphNSignal = subgraphData.nSignal;
         require(subgraphNSignal != 0, "NO_SUBGRAPH_SIGNAL");
 
-        uint256 tokensForL2 = curatorNSignal.mul(subgraphData.withdrawableGRT).div(subgraphNSignal);
+        uint256 withdrawableGRT = subgraphData.withdrawableGRT;
+        uint256 tokensForL2 = curatorNSignal.mul(withdrawableGRT).div(subgraphNSignal);
         bytes memory extraData = abi.encode(
             uint8(IL2GNS.L1MessageCodes.RECEIVE_CURATOR_BALANCE_CODE),
             _subgraphID,
@@ -150,7 +151,7 @@ contract L1GNS is GNS, L1GNSV1Storage {
         // Set the subgraph as if the curator had withdrawn their tokens
         subgraphData.curatorNSignal[msg.sender] = 0;
         subgraphData.nSignal = subgraphNSignal.sub(curatorNSignal);
-        subgraphData.withdrawableGRT = subgraphData.withdrawableGRT.sub(tokensForL2);
+        subgraphData.withdrawableGRT = withdrawableGRT.sub(tokensForL2);
 
         // Send the tokens and data to L2 using the L1GraphTokenGateway
         _sendTokensAndMessageToL2GNS(

--- a/contracts/discovery/L1GNSStorage.sol
+++ b/contracts/discovery/L1GNSStorage.sol
@@ -10,8 +10,6 @@ pragma abicoder v2;
  * reduce the size of the gap accordingly.
  */
 abstract contract L1GNSV1Storage {
-    /// Address of the Arbitrum DelayedInbox
-    address public arbitrumInboxAddress;
     /// True for subgraph IDs that have been migrated to L2
     mapping(uint256 => bool) public subgraphMigratedToL2;
     /// @dev Storage gap to keep storage slots fixed in future versions

--- a/contracts/l2/curation/IL2Curation.sol
+++ b/contracts/l2/curation/IL2Curation.sol
@@ -12,14 +12,11 @@ interface IL2Curation {
      * only during an L1-L2 migration).
      * @param _subgraphDeploymentID Subgraph deployment pool from where to mint signal
      * @param _tokensIn Amount of Graph Tokens to deposit
-     * @param _signalOutMin Expected minimum amount of signal to receive
      * @return Signal minted
      */
-    function mintTaxFree(
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokensIn,
-        uint256 _signalOutMin
-    ) external returns (uint256);
+    function mintTaxFree(bytes32 _subgraphDeploymentID, uint256 _tokensIn)
+        external
+        returns (uint256);
 
     /**
      * @notice Calculate amount of signal that can be bought with tokens in a curation pool,

--- a/contracts/l2/curation/L2Curation.sol
+++ b/contracts/l2/curation/L2Curation.sol
@@ -13,7 +13,6 @@ import { IRewardsManager } from "../../rewards/IRewardsManager.sol";
 import { Managed } from "../../governance/Managed.sol";
 import { IGraphToken } from "../../token/IGraphToken.sol";
 import { CurationV2Storage } from "../../curation/CurationStorage.sol";
-import { ICuration } from "../../curation/ICuration.sol";
 import { IGraphCurationToken } from "../../curation/IGraphCurationToken.sol";
 import { IL2Curation } from "./IL2Curation.sol";
 

--- a/contracts/l2/curation/L2Curation.sol
+++ b/contracts/l2/curation/L2Curation.sol
@@ -231,22 +231,20 @@ contract L2Curation is CurationV2Storage, GraphUpgradeable, IL2Curation {
      * only during an L1-L2 migration).
      * @param _subgraphDeploymentID Subgraph deployment pool from where to mint signal
      * @param _tokensIn Amount of Graph Tokens to deposit
-     * @param _signalOutMin Expected minimum amount of signal to receive
      * @return Signal minted
      */
-    function mintTaxFree(
-        bytes32 _subgraphDeploymentID,
-        uint256 _tokensIn,
-        uint256 _signalOutMin
-    ) external override notPartialPaused onlyGNS returns (uint256) {
+    function mintTaxFree(bytes32 _subgraphDeploymentID, uint256 _tokensIn)
+        external
+        override
+        notPartialPaused
+        onlyGNS
+        returns (uint256)
+    {
         // Need to deposit some funds
         require(_tokensIn != 0, "Cannot deposit zero tokens");
 
         // Exchange GRT tokens for GCS of the subgraph pool (no tax)
         uint256 signalOut = _tokensToSignal(_subgraphDeploymentID, _tokensIn);
-
-        // Slippage protection
-        require(signalOut >= _signalOutMin, "Slippage protection");
 
         address curator = msg.sender;
         CurationPool storage curationPool = pools[_subgraphDeploymentID];

--- a/contracts/l2/discovery/IL2GNS.sol
+++ b/contracts/l2/discovery/IL2GNS.sol
@@ -8,6 +8,11 @@ import { ICallhookReceiver } from "../../gateway/ICallhookReceiver.sol";
  * @title Interface for the L2GNS contract.
  */
 interface IL2GNS is ICallhookReceiver {
+    enum L1MessageCodes {
+        RECEIVE_SUBGRAPH_CODE,
+        RECEIVE_CURATOR_BALANCE_CODE
+    }
+
     /**
      * @dev The SubgraphL2MigrationData struct holds information
      * about a subgraph related to its migration from L1 to L2.
@@ -33,30 +38,5 @@ interface IL2GNS is ICallhookReceiver {
         bytes32 _subgraphDeploymentID,
         bytes32 _subgraphMetadata,
         bytes32 _versionMetadata
-    ) external;
-
-    /**
-     * @notice Deprecate a subgraph that was migrated from L1, but for which
-     * the migration was never finished. Anyone can call this function after a certain amount of
-     * blocks have passed since the subgraph was migrated, if the subgraph owner didn't
-     * call finishSubgraphMigrationFromL1. In L2GNS this timeout is the FINISH_MIGRATION_TIMEOUT constant.
-     * @param _subgraphID Subgraph ID
-     */
-    function deprecateSubgraphMigratedFromL1(uint256 _subgraphID) external;
-
-    /**
-     * @notice Claim curator balance belonging to a curator from L1.
-     * This will be credited to the a beneficiary on L2, and can only be called
-     * from the GNS on L1 through a retryable ticket.
-     * @param _subgraphID Subgraph on which to claim the balance
-     * @param _curator Curator who owns the balance on L1
-     * @param _balance Balance of the curator from L1
-     * @param _beneficiary Address of an L2 beneficiary for the balance
-     */
-    function claimL1CuratorBalanceToBeneficiary(
-        uint256 _subgraphID,
-        address _curator,
-        uint256 _balance,
-        address _beneficiary
     ) external;
 }

--- a/contracts/l2/discovery/L2GNS.sol
+++ b/contracts/l2/discovery/L2GNS.sol
@@ -250,13 +250,13 @@ contract L2GNS is GNS, L2GNSV1Storage, IL2GNS {
         uint256 _tokensIn
     ) internal {
         IL2GNS.SubgraphL2MigrationData storage migratedData = subgraphL2MigrationData[_subgraphID];
+        SubgraphData storage subgraphData = _getSubgraphData(_subgraphID);
 
         // If subgraph migration wasn't finished, we should send the tokens to the curator
-        if (!migratedData.l2Done) {
+        if (!migratedData.l2Done || subgraphData.disabled) {
             graphToken().transfer(_curator, _tokensIn);
             emit CuratorBalanceReturnedToBeneficiary(_subgraphID, _curator, _tokensIn);
         } else {
-            SubgraphData storage subgraphData = _getSubgraphData(_subgraphID);
             // Get name signal to mint for tokens deposited
             IL2Curation curation = IL2Curation(address(curation()));
             uint256 vSignal = curation.mintTaxFree(subgraphData.subgraphDeploymentID, _tokensIn);

--- a/test/l2/l2Curation.test.ts
+++ b/test/l2/l2Curation.test.ts
@@ -256,9 +256,7 @@ describe('L2Curation', () => {
     const beforeTotalTokens = await grt.balanceOf(curation.address)
 
     // Curate
-    const tx = curation
-      .connect(gnsImpersonator)
-      .mintTaxFree(subgraphDeploymentID, tokensToDeposit, 0)
+    const tx = curation.connect(gnsImpersonator).mintTaxFree(subgraphDeploymentID, tokensToDeposit)
     await expect(tx)
       .emit(curation, 'Signalled')
       .withArgs(gns.address, subgraphDeploymentID, tokensToDeposit, expectedSignal, 0)
@@ -472,9 +470,7 @@ describe('L2Curation', () => {
   describe('curate tax free (from GNS)', async function () {
     it('can not be called by anyone other than GNS', async function () {
       const tokensToDeposit = await curation.minimumCurationDeposit()
-      const tx = curation
-        .connect(curator.signer)
-        .mintTaxFree(subgraphDeploymentID, tokensToDeposit, 0)
+      const tx = curation.connect(curator.signer).mintTaxFree(subgraphDeploymentID, tokensToDeposit)
       await expect(tx).revertedWith('Only the GNS can call this')
     })
 
@@ -482,7 +478,7 @@ describe('L2Curation', () => {
       const tokensToDeposit = (await curation.minimumCurationDeposit()).sub(toBN(1))
       const tx = curation
         .connect(gnsImpersonator)
-        .mintTaxFree(subgraphDeploymentID, tokensToDeposit, 0)
+        .mintTaxFree(subgraphDeploymentID, tokensToDeposit)
       await expect(tx).revertedWith('Curation deposit is below minimum required')
     })
 
@@ -509,15 +505,6 @@ describe('L2Curation', () => {
         tokensToDeposit,
       )
       await shouldMintTaxFree(tokensToDeposit, expectedSignal)
-    })
-
-    it('should revert curate if over slippage', async function () {
-      const tokensToDeposit = toGRT('1000')
-      const expectedSignal = signalAmountFor1000Tokens
-      const tx = curation
-        .connect(gnsImpersonator)
-        .mintTaxFree(subgraphDeploymentID, tokensToDeposit, expectedSignal.add(1))
-      await expect(tx).revertedWith('Slippage protection')
     })
   })
 

--- a/test/l2/l2GNS.test.ts
+++ b/test/l2/l2GNS.test.ts
@@ -274,7 +274,9 @@ describe('L2GNS', () => {
       await expect(tx)
         .emit(l2GraphTokenGateway, 'DepositFinalized')
         .withArgs(mockL1GRT.address, mockL1GNS.address, gns.address, curatedTokens)
-      await expect(tx).emit(gns, 'SubgraphReceivedFromL1').withArgs(l1SubgraphId)
+      await expect(tx)
+        .emit(gns, 'SubgraphReceivedFromL1')
+        .withArgs(l1SubgraphId, me.address, curatedTokens)
 
       const migrationData = await gns.subgraphL2MigrationData(l1SubgraphId)
       const subgraphData = await gns.subgraphs(l1SubgraphId)
@@ -310,7 +312,9 @@ describe('L2GNS', () => {
       await expect(tx)
         .emit(l2GraphTokenGateway, 'DepositFinalized')
         .withArgs(mockL1GRT.address, mockL1GNS.address, gns.address, curatedTokens)
-      await expect(tx).emit(gns, 'SubgraphReceivedFromL1').withArgs(l1SubgraphId)
+      await expect(tx)
+        .emit(gns, 'SubgraphReceivedFromL1')
+        .withArgs(l1SubgraphId, me.address, curatedTokens)
 
       const migrationData = await gns.subgraphL2MigrationData(l1SubgraphId)
       const subgraphData = await gns.subgraphs(l1SubgraphId)

--- a/test/l2/l2GNS.test.ts
+++ b/test/l2/l2GNS.test.ts
@@ -500,6 +500,34 @@ describe('L2GNS', () => {
         .finishSubgraphMigrationFromL1(l1SubgraphId, HashZero, metadata, metadata)
       await expect(tx).revertedWith('GNS: deploymentID != 0')
     })
+    it('rejects calls if the subgraph migration was already finished', async function () {
+      const metadata = randomHexBytes()
+      const { l1SubgraphId, curatedTokens } = await defaultL1SubgraphParams()
+      const callhookData = defaultAbiCoder.encode(
+        ['uint8', 'uint256', 'address'],
+        [toBN(0), l1SubgraphId, me.address],
+      )
+      await gatewayFinalizeTransfer(mockL1GNS.address, gns.address, curatedTokens, callhookData)
+
+      await gns
+        .connect(me.signer)
+        .finishSubgraphMigrationFromL1(
+          l1SubgraphId,
+          newSubgraph0.subgraphDeploymentID,
+          metadata,
+          metadata,
+        )
+
+      const tx = gns
+        .connect(me.signer)
+        .finishSubgraphMigrationFromL1(
+          l1SubgraphId,
+          newSubgraph0.subgraphDeploymentID,
+          metadata,
+          metadata,
+        )
+      await expect(tx).revertedWith('ALREADY_DONE')
+    })
   })
   describe('claiming a curator balance with a message from L1 (onTokenTransfer)', function () {
     it('assigns a curator balance to a beneficiary', async function () {


### PR DESCRIPTION
Building on #585 but only sending the owner's signal and allowing curators to send to L2 or withdraw.

Still studying both options, and pending GIP.