### PR TITLE
test: additional tests for L2GNS (OZ M-03)

### DIFF
--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -507,7 +507,40 @@ describe('L1GNS', () => {
         await expect(tx).revertedWith('ERC721: owner query for nonexistent token')
       })
     })
-
+    describe('subgraphTokens', function () {
+      it('should return the correct number of tokens for a subgraph', async function () {
+        const subgraph = await publishNewSubgraph(me, newSubgraph0, gns)
+        const taxForMe = (
+          await curation.tokensToSignal(subgraph.subgraphDeploymentID, tokens10000)
+        )[1]
+        await mintSignal(me, subgraph.id, tokens10000, gns, curation)
+        const taxForOther = (
+          await curation.tokensToSignal(subgraph.subgraphDeploymentID, tokens1000)
+        )[1]
+        await mintSignal(other, subgraph.id, tokens1000, gns, curation)
+        expect(await gns.subgraphTokens(subgraph.id)).eq(
+          tokens10000.add(tokens1000).sub(taxForMe).sub(taxForOther),
+        )
+      })
+    })
+    describe('subgraphSignal', function () {
+      it('should return the correct amount of signal for a subgraph', async function () {
+        const subgraph = await publishNewSubgraph(me, newSubgraph0, gns)
+        const vSignalForMe = (
+          await curation.tokensToSignal(subgraph.subgraphDeploymentID, tokens10000)
+        )[0]
+        await mintSignal(me, subgraph.id, tokens10000, gns, curation)
+        const vSignalForOther = (
+          await curation.tokensToSignal(subgraph.subgraphDeploymentID, tokens1000)
+        )[0]
+        await mintSignal(other, subgraph.id, tokens1000, gns, curation)
+        const expectedSignal = await gns.vSignalToNSignal(
+          subgraph.id,
+          vSignalForMe.add(vSignalForOther),
+        )
+        expect(await gns.subgraphSignal(subgraph.id)).eq(expectedSignal)
+      })
+    })
     describe('deprecateSubgraph', async function () {
       let subgraph: Subgraph
 

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -1286,6 +1286,54 @@ describe('L1GNS', () => {
 
         await expect(tx).revertedWith('GNS: Must be active')
       })
+      it('does not allow curators to burn signal after sending', async function () {
+        const subgraph0 = await publishAndCurateOnSubgraph()
+
+        const maxSubmissionCost = toBN('100')
+        const maxGas = toBN('10')
+        const gasPriceBid = toBN('20')
+        const tx = gns
+          .connect(me.signer)
+          .sendSubgraphToL2(subgraph0.id, me.address, maxGas, gasPriceBid, maxSubmissionCost, {
+            value: maxSubmissionCost.add(maxGas.mul(gasPriceBid)),
+          })
+        await expect(tx).emit(gns, 'SubgraphSentToL2').withArgs(subgraph0.id, me.address)
+
+        const tx2 = gns.connect(me.signer).burnSignal(subgraph0.id, toBN(1), toGRT('0'))
+        await expect(tx2).revertedWith('GNS: Must be active')
+      })
+      it('does not allow curators to transfer signal after sending', async function () {
+        const subgraph0 = await publishAndCurateOnSubgraph()
+
+        const maxSubmissionCost = toBN('100')
+        const maxGas = toBN('10')
+        const gasPriceBid = toBN('20')
+        const tx = gns
+          .connect(me.signer)
+          .sendSubgraphToL2(subgraph0.id, me.address, maxGas, gasPriceBid, maxSubmissionCost, {
+            value: maxSubmissionCost.add(maxGas.mul(gasPriceBid)),
+          })
+        await expect(tx).emit(gns, 'SubgraphSentToL2').withArgs(subgraph0.id, me.address)
+
+        const tx2 = gns.connect(me.signer).transferSignal(subgraph0.id, other.address, toBN(1))
+        await expect(tx2).revertedWith('GNS: Must be active')
+      })
+      it('does not allow curators to withdraw GRT after sending', async function () {
+        const subgraph0 = await publishAndCurateOnSubgraph()
+
+        const maxSubmissionCost = toBN('100')
+        const maxGas = toBN('10')
+        const gasPriceBid = toBN('20')
+        const tx = gns
+          .connect(me.signer)
+          .sendSubgraphToL2(subgraph0.id, me.address, maxGas, gasPriceBid, maxSubmissionCost, {
+            value: maxSubmissionCost.add(maxGas.mul(gasPriceBid)),
+          })
+        await expect(tx).emit(gns, 'SubgraphSentToL2').withArgs(subgraph0.id, me.address)
+
+        const tx2 = gns.connect(me.signer).withdraw(subgraph0.id)
+        await expect(tx2).revertedWith('GNS: No more GRT to withdraw')
+      })
     })
     describe('claimCuratorBalanceToBeneficiaryOnL2', function () {
       beforeEach(async function () {

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -879,6 +879,18 @@ describe('L1GNS', () => {
   })
 
   describe('NFT descriptor', function () {
+    it('cannot be minted by an account that is not the minter (i.e. GNS)', async function () {
+      const subgraphNFTAddress = await gns.subgraphNFT()
+      const subgraphNFT = getContractAt('SubgraphNFT', subgraphNFTAddress) as SubgraphNFT
+      const tx = subgraphNFT.connect(me.signer).mint(me.address, 1)
+      await expect(tx).revertedWith('Must be a minter')
+    })
+    it('cannot be burned by an account that is not the minter (i.e. GNS)', async function () {
+      const subgraphNFTAddress = await gns.subgraphNFT()
+      const subgraphNFT = getContractAt('SubgraphNFT', subgraphNFTAddress) as SubgraphNFT
+      const tx = subgraphNFT.connect(me.signer).burn(1)
+      await expect(tx).revertedWith('Must be a minter')
+    })
     it('with token descriptor', async function () {
       const subgraph0 = await publishNewSubgraph(me, newSubgraph0, gns)
 


### PR DESCRIPTION
- [x] A test to ensure that curators can recover GRT from a deprecated subgraph on L2. (Note: this was already implemented in [PR 763](https://github.com/graphprotocol/contracts/pull/763/files#diff-18c2e12a8fdc69d95bb043b3ad76dd4d5f26cf9d67c9ab808d275296dcf6e76aR428-R439))
- [x] Tests to ensure that L1 signal cannot be double spent after a curator claims their balance to an L2 beneficiary. Double spending should be tested both on L1 (burning, transferring, and withdrawing), and on L2 (claiming). (Note: check for double spending on L2 was [already implemented in l2GNS.test.ts](https://github.com/graphprotocol/contracts/pull/585/files#diff-18c2e12a8fdc69d95bb043b3ad76dd4d5f26cf9d67c9ab808d275296dcf6e76aR504-R535))
- [x] A test for publishing a new version of a subgraph on L2 when the new deployment is pre-curated (ahead of the subgraph owner publishing it).
- [x] Views tests for subgraphSignal and subgraphTokens in GNS.
- [x] A test case for mintTaxFree for a pre-curated deployment (in which case curation shares exist). (Note: this was already present [in the original PR](https://github.com/graphprotocol/contracts/pull/585/files#diff-18c2e12a8fdc69d95bb043b3ad76dd4d5f26cf9d67c9ab808d275296dcf6e76aR327-R378))
- [x] NFT minting access control tests.