### PR TITLE
feat: changed dispute manager to not delete bad actors disputes on re…

### DIFF
--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -563,7 +563,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
      * @param _disputeID ID of the dispute to be accepted
      */
     function acceptDispute(bytes32 _disputeID) external override onlyArbitrator {
-        Dispute memory dispute = _resolveDispute(_disputeID);
+        Dispute memory dispute = disputes[_disputeID];
 
         // Slash
         (, uint256 tokensToReward) = _slashIndexer(


### PR DESCRIPTION
…solution

Related to GIP-0041. This shouldn't cause any issues regarding functionality of the dispute manager, but not deleted malicious disputeIDs allows the subgraph bridge to not allow accepted dispute attestations to be used on chain.

FORUM POST: https://forum.thegraph.com/t/gip-0041-store-dispute-status-on-resolution/3759

Any feedback is welcome. 

Thank you!