### PR TITLE
feat: make bridge tasks prettier and display more info for L2 to L1

### DIFF
--- a/tasks/bridge/deposits.ts
+++ b/tasks/bridge/deposits.ts
@@ -37,6 +37,11 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
       `Tracking 'DepositFinalized' events on L2GraphTokenGateway (${l2Gateway.address}) from block ${l2StartBlock} onwards`,
     )
 
+    const amount = await (
+      await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
+    ).length
+    console.log(`Found ${amount} deposits on L1`)
+
     const depositInitiatedEvents = await Promise.all(
       (
         await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
@@ -76,7 +81,6 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
 
     printEvents(depositInitiatedEvents)
     console.timeEnd('runtime')
-    console.timeLog('runtime')
   })
 
 function printEvents(events: any[]) {

--- a/tasks/bridge/deposits.ts
+++ b/tasks/bridge/deposits.ts
@@ -37,7 +37,7 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
           (await graph.l1.provider.getBlock(e.blockNumber)).timestamp * 1000,
         ).toLocaleString()})`,
         tx: `${e.transactionHash} ${e.args.from} -> ${e.args.to}`,
-        amount: ethers.utils.formatEther(e.args.amount),
+        amount: prettyBigNumber(e.args.amount),
         status: emojifyRetryableStatus(
           await getL1ToL2MessageStatus(e.transactionHash, graph.l1.provider, graph.l2.provider),
         ),
@@ -48,12 +48,10 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
       (acc, e) => acc.add(ethers.utils.parseEther(e.amount)),
       ethers.BigNumber.from(0),
     )
-    console.log(
-      `Found ${events.length} deposits with a total of ${ethers.utils.formatEther(total)} GRT`,
-    )
+    console.log(`Found ${events.length} deposits with a total of ${prettyBigNumber(total)} GRT`)
 
     console.log(
-      'L1 to L2 message status reference: 🚧 = not yet created, ❌ = creation failed, ⚠️  = funds deposited on L2, ✅ = redeemed, ⌛ = expired',
+      '\nL1 to L2 message status reference: 🚧 = not yet created, ❌ = creation failed, ⚠️  = funds deposited on L2, ✅ = redeemed, ⌛ = expired',
     )
 
     printEvents(events)
@@ -94,4 +92,9 @@ function emojifyRetryableStatus(status: L1ToL2MessageStatus): string {
     default:
       return '❌'
   }
+}
+
+// Format BigNumber to 2 decimal places
+function prettyBigNumber(amount: ethers.BigNumber): string {
+  return (+ethers.utils.formatEther(amount)).toFixed(2)
 }

--- a/tasks/bridge/deposits.ts
+++ b/tasks/bridge/deposits.ts
@@ -3,7 +3,7 @@ import { cliOpts } from '../../cli/defaults'
 import { ethers } from 'ethers'
 import { Table } from 'console-table-printer'
 import { L1ToL2MessageStatus } from '@arbitrum/sdk'
-import { getL1ToL2MessageStatus } from '../../cli/arbitrum'
+import { getL1ToL2MessageStatus, getL1ToL2MessageReader } from '../../cli/arbitrum'
 
 export const TASK_BRIDGE_DEPOSITS = 'bridge:deposits'
 
@@ -16,45 +16,67 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
   )
   .addOptionalParam('l1GraphConfig', cliOpts.graphConfig.description)
   .addOptionalParam('l2GraphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('startBlock', 'Start block for the search')
-  .addOptionalParam('endBlock', 'End block for the search')
+  .addOptionalParam('l1StartBlock', 'Start block on L1 for the search')
+  .addOptionalParam('l1EndBlock', 'End block on L1 for the search')
+  .addOptionalParam('l2StartBlock', 'Start block on L2 for the search')
   .setAction(async (taskArgs, hre) => {
-    console.log('> L1GraphTokenGateway deposits')
+    console.time('runtime')
+    console.log('> GRT Bridge deposits <\n')
 
     const graph = hre.graph(taskArgs)
-    const gateway = graph.l1.contracts.L1GraphTokenGateway
-    console.log(`Tracking 'DepositInitiated' events on ${gateway.address}`)
+    const l2Gateway = graph.l2.contracts.L2GraphTokenGateway
+    const l1Gateway = graph.l1.contracts.L1GraphTokenGateway
+    const l1StartBlock = taskArgs.l1StartBlock ? parseInt(taskArgs.l1StartBlock) : 0
+    const l1EndBlock = taskArgs.l1EndBlock ? parseInt(taskArgs.l1EndBlock) : 'latest'
+    const l2StartBlock = taskArgs.l2StartBlock ? parseInt(taskArgs.l2StartBlock) : 0
 
-    const startBlock = taskArgs.startBlock ? parseInt(taskArgs.startBlock) : 0
-    const endBlock = taskArgs.endBlock ? parseInt(taskArgs.endBlock) : 'latest'
-    console.log(`Searching blocks from block ${startBlock} to block ${endBlock}`)
-
-    const events = await Promise.all(
-      (
-        await gateway.queryFilter(gateway.filters.DepositInitiated(), startBlock, endBlock)
-      ).map(async (e) => ({
-        blockNumber: `${e.blockNumber} (${new Date(
-          (await graph.l1.provider.getBlock(e.blockNumber)).timestamp * 1000,
-        ).toLocaleString()})`,
-        tx: `${e.transactionHash} ${e.args.from} -> ${e.args.to}`,
-        amount: prettyBigNumber(e.args.amount),
-        status: emojifyRetryableStatus(
-          await getL1ToL2MessageStatus(e.transactionHash, graph.l1.provider, graph.l2.provider),
-        ),
-      })),
+    console.log(
+      `Tracking 'DepositInitiated' events on L1GraphTokenGateway (${l1Gateway.address}) from block ${l1StartBlock} to block ${l1EndBlock}`,
+    )
+    console.log(
+      `Tracking 'DepositFinalized' events on L2GraphTokenGateway (${l2Gateway.address}) from block ${l2StartBlock} onwards`,
     )
 
-    const total = events.reduce(
+    const depositInitiatedEvents = await Promise.all(
+      (
+        await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
+      ).map(async (e) => {
+        const retryableTicket = await getL1ToL2MessageReader(
+          e.transactionHash,
+          graph.l1.provider,
+          graph.l2.provider,
+        )
+
+        return {
+          l1Tx: `Block ${e.blockNumber} (${new Date(
+            (await graph.l1.provider.getBlock(e.blockNumber)).timestamp * 1000,
+          ).toLocaleString()}) ${e.transactionHash}`,
+          l2Tx: `${retryableTicket.retryableCreationId}`, // Can't get block data because of arb node rate limit
+          amount: prettyBigNumber(e.args.amount),
+          status: emojifyRetryableStatus(
+            await getL1ToL2MessageStatus(e.transactionHash, graph.l1.provider, graph.l2.provider),
+          ),
+        }
+      }),
+    )
+
+    const total = depositInitiatedEvents.reduce(
       (acc, e) => acc.add(ethers.utils.parseEther(e.amount)),
       ethers.BigNumber.from(0),
     )
-    console.log(`Found ${events.length} deposits with a total of ${prettyBigNumber(total)} GRT`)
+    console.log(
+      `Found ${depositInitiatedEvents.length} deposits with a total of ${prettyBigNumber(
+        total,
+      )} GRT`,
+    )
 
     console.log(
       '\nL1 to L2 message status reference: 🚧 = not yet created, ❌ = creation failed, ⚠️  = funds deposited on L2, ✅ = redeemed, ⌛ = expired',
     )
 
-    printEvents(events)
+    printEvents(depositInitiatedEvents)
+    console.timeEnd('runtime')
+    console.timeLog('runtime')
   })
 
 function printEvents(events: any[]) {
@@ -62,18 +84,22 @@ function printEvents(events: any[]) {
     charLength: { '🚧': 2, '✅': 2, '⚠️': 1, '⌛': 2, '❌': 2 },
     columns: [
       { name: 'status', color: 'green', alignment: 'center' },
-      { name: 'blockNumber', color: 'green', alignment: 'center' },
+      { name: 'l1Tx', color: 'green', alignment: 'center', maxLen: 72, title: 'L1 transaction' },
       {
-        name: 'tx',
+        name: 'l2Tx',
         color: 'green',
         alignment: 'center',
-        maxLen: 88,
+        maxLen: 72,
+        title: 'L2 retryable ticket creation',
       },
-      { name: 'amount', color: 'green', alignment: 'center' },
+      { name: 'amount', color: 'green' },
     ],
   })
 
-  events.map((e) => tablePrinter.addRow(e))
+  events.map((e) => {
+    tablePrinter.addRow(e)
+    tablePrinter.addRow({}) // For table padding
+  })
   tablePrinter.printTable()
 }
 

--- a/tasks/bridge/deposits.ts
+++ b/tasks/bridge/deposits.ts
@@ -37,15 +37,15 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
       `Tracking 'DepositFinalized' events on L2GraphTokenGateway (${l2Gateway.address}) from block ${l2StartBlock} onwards`,
     )
 
-    const amount = await (
-      await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
-    ).length
-    console.log(`Found ${amount} deposits on L1`)
+    const deposits = await l1Gateway.queryFilter(
+      l1Gateway.filters.DepositInitiated(),
+      l1StartBlock,
+      l1EndBlock,
+    )
+    console.log(`Found ${deposits.length} deposits on L1`)
 
     const depositInitiatedEvents = await Promise.all(
-      (
-        await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
-      ).map(async (e) => {
+      deposits.map(async (e) => {
         const retryableTicket = await getL1ToL2MessageReader(
           e.transactionHash,
           graph.l1.provider,

--- a/tasks/bridge/deposits.ts
+++ b/tasks/bridge/deposits.ts
@@ -37,15 +37,10 @@ task(TASK_BRIDGE_DEPOSITS, 'List deposits initiated on L1GraphTokenGateway')
       `Tracking 'DepositFinalized' events on L2GraphTokenGateway (${l2Gateway.address}) from block ${l2StartBlock} onwards`,
     )
 
-    const deposits = await l1Gateway.queryFilter(
-      l1Gateway.filters.DepositInitiated(),
-      l1StartBlock,
-      l1EndBlock,
-    )
-    console.log(`Found ${deposits.length} deposits on L1`)
-
     const depositInitiatedEvents = await Promise.all(
-      deposits.map(async (e) => {
+      (
+        await l1Gateway.queryFilter(l1Gateway.filters.DepositInitiated(), l1StartBlock, l1EndBlock)
+      ).map(async (e) => {
         const retryableTicket = await getL1ToL2MessageReader(
           e.transactionHash,
           graph.l1.provider,

--- a/tasks/bridge/withdrawals.ts
+++ b/tasks/bridge/withdrawals.ts
@@ -1,9 +1,10 @@
 import { task } from 'hardhat/config'
 import { cliOpts } from '../../cli/defaults'
-import { ethers } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 import { Table } from 'console-table-printer'
 import { L2ToL1MessageStatus } from '@arbitrum/sdk'
 import { getL2ToL1MessageStatus } from '../../cli/arbitrum'
+import { keccak256 } from 'ethers/lib/utils'
 
 export const TASK_BRIDGE_WITHDRAWALS = 'bridge:withdrawals'
 
@@ -16,26 +17,63 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
   )
   .addOptionalParam('l1GraphConfig', cliOpts.graphConfig.description)
   .addOptionalParam('l2GraphConfig', cliOpts.graphConfig.description)
-  .addOptionalParam('startBlock', 'Start block for the search')
-  .addOptionalParam('endBlock', 'End block for the search')
+  .addOptionalParam('l1StartBlock', 'Start block on L1 for the search')
+  .addOptionalParam('l2StartBlock', 'Start block on L2 for the search')
+  .addOptionalParam('l2EndBlock', 'End block on L2 for the search')
   .setAction(async (taskArgs, hre) => {
-    console.log('> L2GraphTokenGateway withdrawals')
+    console.time('runtime')
+    console.log('> GRT Bridge withdrawals <\n')
 
     const graph = hre.graph(taskArgs)
-    const gateway = graph.l2.contracts.L2GraphTokenGateway
-    console.log(`Tracking 'WithdrawalInitiated' events on ${gateway.address}`)
+    const l2Gateway = graph.l2.contracts.L2GraphTokenGateway
+    const l1Gateway = graph.l1.contracts.L1GraphTokenGateway
+    const l1StartBlock = taskArgs.l1StartBlock ? parseInt(taskArgs.l1StartBlock) : 0
+    const l2StartBlock = taskArgs.l2StartBlock ? parseInt(taskArgs.l2StartBlock) : 0
+    const l2EndBlock = taskArgs.l2EndBlock ? parseInt(taskArgs.l2EndBlock) : 'latest'
 
-    const startBlock = taskArgs.startBlock ? parseInt(taskArgs.startBlock) : 0
-    const endBlock = taskArgs.endBlock ? parseInt(taskArgs.endBlock) : 'latest'
-    console.log(`Searching blocks from block ${startBlock} to block ${endBlock}`)
+    console.log(
+      `Tracking 'WithdrawalInitiated' events on L2GraphTokenGateway (${l2Gateway.address}) from block ${l2StartBlock} to block ${l2EndBlock}`,
+    )
+    console.log(
+      `Tracking 'WithdrawalFinalized' events on L1GraphTokenGateway (${l1Gateway.address}) from block ${l1StartBlock} onwards`,
+    )
 
     let totalGRTClaimed = ethers.BigNumber.from(0)
     let totalGRTConfirmed = ethers.BigNumber.from(0)
     let totalGRTUnconfirmed = ethers.BigNumber.from(0)
 
-    const events = await Promise.all(
+    const withdrawalFinalizedEvents = await Promise.all(
       (
-        await gateway.queryFilter(gateway.filters.WithdrawalInitiated(), startBlock, endBlock)
+        await l1Gateway.queryFilter(l1Gateway.filters.WithdrawalFinalized(), l1StartBlock)
+      ).map(async (e) => {
+        const receipt = await e.getTransactionReceipt()
+        const outBoxTransactionExecutedEvent = receipt.logs.find(
+          (log) =>
+            log.topics[0] ===
+            keccak256(
+              ethers.utils.toUtf8Bytes(
+                'OutBoxTransactionExecuted(address,address,uint256,uint256)',
+              ),
+            ),
+        )
+
+        return {
+          blockNumber: e.blockNumber,
+          transactionHash: e.transactionHash,
+          transactionIndex: outBoxTransactionExecutedEvent
+            ? BigNumber.from(outBoxTransactionExecutedEvent.data)
+            : null,
+        }
+      }),
+    )
+
+    const withdrawalInitiatedEvents = await Promise.all(
+      (
+        await l2Gateway.queryFilter(
+          l2Gateway.filters.WithdrawalInitiated(),
+          l2StartBlock,
+          l2EndBlock,
+        )
       ).map(async (e) => {
         const status = await getL2ToL1MessageStatus(
           e.transactionHash,
@@ -49,11 +87,20 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
         if (status === L2ToL1MessageStatus.UNCONFIRMED)
           totalGRTUnconfirmed = totalGRTUnconfirmed.add(e.args.amount)
 
+        // Find L1 event
+        const l1Event = withdrawalFinalizedEvents.find((ev) =>
+          ev.transactionIndex.eq(e.args.l2ToL1Id),
+        )
+
         return {
-          blockNumber: `${e.blockNumber} (${new Date(
+          l2Tx: `Block ${e.blockNumber} (${new Date(
             (await graph.l2.provider.getBlock(e.blockNumber)).timestamp * 1000,
-          ).toLocaleString()})`,
-          tx: `${e.transactionHash} ${e.args.from} -> ${e.args.to}`,
+          ).toLocaleString()}) ${e.transactionHash}`,
+          l1Tx: l1Event
+            ? `Block ${l1Event.blockNumber} (${new Date(
+                (await graph.l1.provider.getBlock(l1Event.blockNumber)).timestamp * 1000,
+              ).toLocaleString()}) ${l1Event.transactionHash}`
+            : '-',
           amount: prettyBigNumber(e.args.amount),
           status: emojifyL2ToL1Status(status),
         }
@@ -61,7 +108,7 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
     )
 
     console.log(
-      `Found ${events.length} withdrawals for a total of ${prettyBigNumber(
+      `\nFound ${withdrawalInitiatedEvents.length} withdrawals for a total of ${prettyBigNumber(
         totalGRTClaimed.add(totalGRTConfirmed).add(totalGRTUnconfirmed),
       )} GRT`,
     )
@@ -75,7 +122,9 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
       '\nL2 to L1 message status reference: 🚧 = unconfirmed, ⚠️  = confirmed, ✅ = executed',
     )
 
-    printEvents(events)
+    printEvents(withdrawalInitiatedEvents)
+    console.timeEnd('runtime')
+    console.timeLog('runtime')
   })
 
 function printEvents(events: any[]) {
@@ -83,18 +132,16 @@ function printEvents(events: any[]) {
     charLength: { '🚧': 2, '✅': 2, '⚠️': 1, '❌': 2 },
     columns: [
       { name: 'status', color: 'green', alignment: 'center' },
-      { name: 'blockNumber', color: 'green' },
-      {
-        name: 'tx',
-        color: 'green',
-        alignment: 'center',
-        maxLen: 88,
-      },
+      { name: 'l2Tx', color: 'green', alignment: 'center', maxLen: 72, title: 'L2 transaction' },
+      { name: 'l1Tx', color: 'green', alignment: 'center', maxLen: 72, title: 'L1 transaction' },
       { name: 'amount', color: 'green' },
     ],
   })
 
-  events.map((e) => tablePrinter.addRow(e))
+  events.map((e) => {
+    tablePrinter.addRow(e)
+    tablePrinter.addRow({}) // For table padding
+  })
   tablePrinter.printTable()
 }
 

--- a/tasks/bridge/withdrawals.ts
+++ b/tasks/bridge/withdrawals.ts
@@ -124,7 +124,6 @@ task(TASK_BRIDGE_WITHDRAWALS, 'List withdrawals initiated on L2GraphTokenGateway
 
     printEvents(withdrawalInitiatedEvents)
     console.timeEnd('runtime')
-    console.timeLog('runtime')
   })
 
 function printEvents(events: any[]) {


### PR DESCRIPTION
### Changes
- bridge tasks
   - Format GRT amounts to 2 decimal places, makes is easier to read/scan task output
   - Show granular information for withdrawal amounts
   - Show L1 and L2 tx's related to a deposit/withdrawal (where possible, in L1 to L2 arb node rate limiting prevents from getting retryable attempts).

<img width="1237" alt="Screen Shot 2023-01-18 at 13 28 05" src="https://user-images.githubusercontent.com/3076185/213249712-75b956e6-c553-43dd-b6bb-097cd5dd728a.png">



Signed-off-by: Tomás Migone <tomas@edgeandnode.com>