### PR TITLE
Add missing `yarn install` to `prepublish` scritpt

### DIFF
--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -6,6 +6,7 @@ set -eo pipefail
 
 # Build contracts
 yarn clean
+yarn install
 yarn build
 
 # Refresh distribution folder


### PR DESCRIPTION
I noticed this script was running into an error without this step: 

```
node_modules/@types/node/globals.d.ts(347,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.
``` 

Adding `yarn install` after `yarn clean` fixed the issue.