### PR TITLE
fix: produce an alias for migrated subgraphIDs

### DIFF
--- a/contracts/l2/discovery/IL2GNS.sol
+++ b/contracts/l2/discovery/IL2GNS.sol
@@ -28,15 +28,22 @@ interface IL2GNS is ICallhookReceiver {
      * @notice Finish a subgraph migration from L1.
      * The subgraph must have been previously sent through the bridge
      * using the sendSubgraphToL2 function on L1GNS.
-     * @param _subgraphID Subgraph ID
+     * @param _l2SubgraphID Subgraph ID in L2 (aliased from the L1 subgraph ID)
      * @param _subgraphDeploymentID Latest subgraph deployment to assign to the subgraph
      * @param _subgraphMetadata IPFS hash of the subgraph metadata
      * @param _versionMetadata IPFS hash of the version metadata
      */
     function finishSubgraphMigrationFromL1(
-        uint256 _subgraphID,
+        uint256 _l2SubgraphID,
         bytes32 _subgraphDeploymentID,
         bytes32 _subgraphMetadata,
         bytes32 _versionMetadata
     ) external;
+
+    /**
+     * @notice Return the aliased L2 subgraph ID from a migrated L1 subgraph ID
+     * @param _l1SubgraphID L1 subgraph ID
+     * @return L2 subgraph ID
+     */
+    function getAliasedL2SubgraphID(uint256 _l1SubgraphID) external pure returns (uint256);
 }

--- a/test/l2/l2GNS.test.ts
+++ b/test/l2/l2GNS.test.ts
@@ -784,4 +784,28 @@ describe('L2GNS', () => {
       await expect(tx).revertedWith('INVALID_CODE')
     })
   })
+  describe('getAliasedL2SubgraphID', function () {
+    it('returns the L2 subgraph ID that is the L1 subgraph ID with an offset', async function () {
+      const l1SubgraphId = ethers.BigNumber.from(
+        '68799548758199140224151701590582019137924969401915573086349306511960790045480',
+      )
+      const l2SubgraphId = await gns.getAliasedL2SubgraphID(l1SubgraphId)
+      const offset = ethers.BigNumber.from(
+        '0x1111000000000000000000000000000000000000000000000000000000001111',
+      )
+      const base = ethers.constants.MaxUint256.add(1)
+      const expectedL2SubgraphId = l1SubgraphId.add(offset).mod(base)
+      expect(l2SubgraphId).eq(expectedL2SubgraphId)
+    })
+    it('wraps around MAX_UINT256 in case of overflow', async function () {
+      const l1SubgraphId = ethers.constants.MaxUint256
+      const l2SubgraphId = await gns.getAliasedL2SubgraphID(l1SubgraphId)
+      const offset = ethers.BigNumber.from(
+        '0x1111000000000000000000000000000000000000000000000000000000001111',
+      )
+      const base = ethers.constants.MaxUint256.add(1)
+      const expectedL2SubgraphId = l1SubgraphId.add(offset).mod(base)
+      expect(l2SubgraphId).eq(expectedL2SubgraphId)
+    })
+  })
 })


### PR DESCRIPTION
The alias works in a similar way to Arbitrum's AddressAliasHelper, but using a uint256 constant added to the subgraphID hash to produce a new L2 subgraphID.