### PR TITLE
fix: enforce minimum stake when restaking (OZ M-08)

### DIFF
--- a/contracts/l2/staking/L2Staking.sol
+++ b/contracts/l2/staking/L2Staking.sol
@@ -93,7 +93,16 @@ contract L2Staking is Staking, IL2StakingBase {
         uint256 _amount,
         IL2Staking.ReceiveIndexerStakeData memory _indexerData
     ) internal {
-        _stake(_indexerData.indexer, _amount);
+        address _indexer = _indexerData.indexer;
+        // Deposit tokens into the indexer stake
+        __stakes[_indexer].deposit(_amount);
+
+        // Initialize the delegation pool the first time
+        if (__delegationPools[_indexer].updatedAtBlock == 0) {
+            _setDelegationParameters(_indexer, MAX_PPM, MAX_PPM, __delegationParametersCooldown);
+        }
+
+        emit StakeDeposited(_indexer, _amount);
     }
 
     /**

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -35,7 +35,7 @@ abstract contract Staking is StakingV3Storage, GraphUpgradeable, IStakingBase, M
     using Rebates for Rebates.Pool;
 
     /// @dev 100% in parts per million
-    uint32 private constant MAX_PPM = 1000000;
+    uint32 internal constant MAX_PPM = 1000000;
 
     // -- Events are declared in IStakingBase -- //
 
@@ -156,9 +156,7 @@ abstract contract Staking is StakingV3Storage, GraphUpgradeable, IStakingBase, M
     }
 
     /**
-     * @notice Set the minimum stake required to be an indexer. Note the
-     * minimum stake in L2 MUST be the same as in L1, or migrated stake might
-     * fail to be redeemed in L2.
+     * @notice Set the minimum stake required to be an indexer.
      * @param _minimumIndexerStake Minimum indexer stake
      */
     function setMinimumIndexerStake(uint256 _minimumIndexerStake) external override onlyGovernor {
@@ -663,7 +661,7 @@ abstract contract Staking is StakingV3Storage, GraphUpgradeable, IStakingBase, M
         uint32 _indexingRewardCut,
         uint32 _queryFeeCut,
         uint32 _cooldownBlocks
-    ) private {
+    ) internal {
         // Incentives must be within bounds
         require(_queryFeeCut <= MAX_PPM, ">queryFeeCut");
         require(_indexingRewardCut <= MAX_PPM, ">indexingRewardCut");


### PR DESCRIPTION
This avoid issues when an indexer migrates to L2, then restakes some rewards/fees, so delegators are stuck without being able to quick-withdraw but with an indexer that's under minimum stake.

However, this also affects redeeming migrated stake in L2, because the onTokenTransfer calls `_stake()` (added in #811). This could cause issues if an indexer migrates stake, then withdraws, then migrates some more, so we now won't call `_stake` and just receive the stake without checking the minimum; note this can break the minimum stake invariant, but the indexer will not be able to allocate that stake.