### PR TITLE
fix: do not double count tokens when checking minimum stake (OZ M-08)

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -703,14 +703,14 @@ abstract contract Staking is StakingV3Storage, GraphUpgradeable, IStakingBase, M
      * @param _tokens Amount of tokens to stake
      */
     function _stake(address _indexer, uint256 _tokens) internal {
-        // Deposit tokens into the indexer stake
-        __stakes[_indexer].deposit(_tokens);
-
         // Ensure minimum stake
         require(
             __stakes[_indexer].tokensSecureStake().add(_tokens) >= __minimumIndexerStake,
             "!minimumIndexerStake"
         );
+
+        // Deposit tokens into the indexer stake
+        __stakes[_indexer].deposit(_tokens);
 
         // Initialize the delegation pool the first time
         if (__delegationPools[_indexer].updatedAtBlock == 0) {

--- a/test/staking/staking.test.ts
+++ b/test/staking/staking.test.ts
@@ -115,8 +115,8 @@ describe('Staking:Stakes', () => {
       })
 
       it('reject stake less than minimum indexer stake', async function () {
-        expect(toGRT('1')).lte(await staking.minimumIndexerStake())
-        const tx = staking.connect(indexer.signer).stake(toGRT('1'))
+        const amount = (await staking.minimumIndexerStake()).sub(toGRT('1'))
+        const tx = staking.connect(indexer.signer).stake(amount)
         await expect(tx).revertedWith('!minimumIndexerStake')
       })
 


### PR DESCRIPTION
Noted by the OZ team as a bug in #813.

We also change the minimum stake test to use a value closer to the minimum stake, which would catch issues like this a bit better.