### PR TITLE
feat: add upgrade testing to the e2e framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ addresses-local.json
 localNetwork.json
 arbitrum-addresses-local.json
 tx-*.log
+addresses-fork.json
 
 # Keys
 .keystore

--- a/cli/network.ts
+++ b/cli/network.ts
@@ -303,6 +303,34 @@ export const deployContractAndSave = async (
   return deployResult.contract
 }
 
+export const deployContractImplementationAndSave = async (
+  name: string,
+  args: Array<ContractParam>,
+  sender: Signer,
+  addressBook: AddressBook,
+): Promise<Contract> => {
+  // Deploy the contract
+  const deployResult = await deployContract(name, args, sender)
+
+  // Save address entry
+  const entry = addressBook.getEntry(name)
+  entry.implementation = {
+    address: deployResult.contract.address,
+    constructorArgs: args.length === 0 ? undefined : args.map((e) => e.toString()),
+    creationCodeHash: deployResult.creationCodeHash,
+    runtimeCodeHash: deployResult.runtimeCodeHash,
+    txHash: deployResult.txHash,
+    libraries:
+      deployResult.libraries && Object.keys(deployResult.libraries).length > 0
+        ? deployResult.libraries
+        : undefined,
+  }
+  addressBook.setEntry(name, entry)
+  logger.info('> Contract saved to address book')
+
+  return deployResult.contract
+}
+
 export const deployContractWithProxyAndSave = async (
   name: string,
   args: Array<ContractParam>,

--- a/e2e/lib/accounts.ts
+++ b/e2e/lib/accounts.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers'
 import { ethers } from 'hardhat'
-import { GraphToken } from '../../../build/types/GraphToken'
+import { GraphToken } from '../../build/types/GraphToken'
 import { TransactionResponse } from '@ethersproject/providers'
 
 const checkBalance = async (

--- a/e2e/lib/curation.ts
+++ b/e2e/lib/curation.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumberish } from 'ethers'
-import { NetworkContracts } from '../../../cli/contracts'
-import { sendTransaction } from '../../../cli/network'
+import { NetworkContracts } from '../../cli/contracts'
+import { sendTransaction } from '../../cli/network'
 import { ensureGRTAllowance } from './accounts'
 
 export const signal = async (

--- a/e2e/lib/helpers.ts
+++ b/e2e/lib/helpers.ts
@@ -4,6 +4,7 @@ export function getGraphOptsFromArgv(): {
   l1GraphConfig: string | undefined
   l2GraphConfig: string | undefined
   disableSecureAccounts?: boolean | undefined
+  fork?: boolean | undefined
 } {
   const argv = process.argv.slice(2)
 
@@ -16,5 +17,6 @@ export function getGraphOptsFromArgv(): {
     l1GraphConfig: getArgv(2),
     l2GraphConfig: getArgv(3),
     disableSecureAccounts: getArgv(4),
+    fork: getArgv(5),
   }
 }

--- a/e2e/lib/staking.ts
+++ b/e2e/lib/staking.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumberish, ethers } from 'ethers'
-import { NetworkContracts } from '../../../cli/contracts'
-import { randomHexBytes, sendTransaction } from '../../../cli/network'
+import { NetworkContracts } from '../../cli/contracts'
+import { randomHexBytes, sendTransaction } from '../../cli/network'
 import { ensureGRTAllowance } from './accounts'
 
 export const stake = async (

--- a/e2e/lib/subgraph.ts
+++ b/e2e/lib/subgraph.ts
@@ -1,8 +1,8 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumber } from 'ethers'
 import { solidityKeccak256 } from 'ethers/lib/utils'
-import { NetworkContracts } from '../../../cli/contracts'
-import { randomHexBytes, sendTransaction } from '../../../cli/network'
+import { NetworkContracts } from '../../cli/contracts'
+import { randomHexBytes, sendTransaction } from '../../cli/network'
 
 export const recreatePreviousSubgraphId = async (
   contracts: NetworkContracts,

--- a/e2e/scenarios/close-allocations.ts
+++ b/e2e/scenarios/close-allocations.ts
@@ -7,11 +7,11 @@
 //    npx hardhat e2e:scenario close-allocations --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { closeAllocation } from './lib/staking'
+import { closeAllocation } from '../lib/staking'
 import { advanceToNextEpoch } from '../../test/lib/testHelpers'
-import { fundAccountsETH } from './lib/accounts'
+import { fundAccountsETH } from '../lib/accounts'
 import { getIndexerFixtures } from './fixtures/indexers'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/create-subgraphs.test.ts
+++ b/e2e/scenarios/create-subgraphs.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { recreatePreviousSubgraphId } from './lib/subgraph'
+import { recreatePreviousSubgraphId } from '../lib/subgraph'
 import { BigNumber } from 'ethers'
 import { CuratorFixture, getCuratorFixtures } from './fixtures/curators'
 import { SubgraphFixture, getSubgraphFixtures, getSubgraphOwner } from './fixtures/subgraphs'

--- a/e2e/scenarios/create-subgraphs.ts
+++ b/e2e/scenarios/create-subgraphs.ts
@@ -5,12 +5,12 @@
 //    npx hardhat e2e:scenario create-subgraphs --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { publishNewSubgraph } from './lib/subgraph'
-import { fundAccountsETH, fundAccountsGRT } from './lib/accounts'
-import { signal } from './lib/curation'
+import { publishNewSubgraph } from '../lib/subgraph'
+import { fundAccountsETH, fundAccountsGRT } from '../lib/accounts'
+import { signal } from '../lib/curation'
 import { getSubgraphFixtures, getSubgraphOwner } from './fixtures/subgraphs'
 import { getCuratorFixtures } from './fixtures/curators'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/open-allocations.ts
+++ b/e2e/scenarios/open-allocations.ts
@@ -5,10 +5,10 @@
 //    npx hardhat e2e:scenario open-allocations --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { allocateFrom, stake } from './lib/staking'
-import { fundAccountsETH, fundAccountsGRT } from './lib/accounts'
+import { allocateFrom, stake } from '../lib/staking'
+import { fundAccountsETH, fundAccountsGRT } from '../lib/accounts'
 import { getIndexerFixtures } from './fixtures/indexers'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/send-grt-to-l2.ts
+++ b/e2e/scenarios/send-grt-to-l2.ts
@@ -6,7 +6,7 @@
 
 import hre from 'hardhat'
 import { TASK_BRIDGE_TO_L2 } from '../../tasks/bridge/to-l2'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 import { getBridgeFixture } from './fixtures/bridge'
 
 async function main() {

--- a/e2e/upgrades/example/Instructions.md
+++ b/e2e/upgrades/example/Instructions.md
@@ -1,0 +1,7 @@
+# Usage
+
+1) Upgrade the GNS contract, add a `uint256 public test;` storage variable
+2) Run the upgrade script:
+    ```
+    CHAIN_ID=1 FORK_URL=<RPC_URL> CONTRACT_NAME=GNS UPGRADE_NAME=example yarn test:upgrade
+    ```

--- a/e2e/upgrades/example/post-upgrade.test.ts
+++ b/e2e/upgrades/example/post-upgrade.test.ts
@@ -1,0 +1,14 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import hre from 'hardhat'
+
+chai.use(chaiAsPromised)
+
+describe('GNS contract', () => {
+  it(`'test' storage variable should exist`, async function () {
+    const graph = hre.graph()
+    const { GNS } = graph.contracts
+
+    await expect(GNS.test()).to.eventually.be.fulfilled
+  })
+})

--- a/e2e/upgrades/example/post-upgrade.ts
+++ b/e2e/upgrades/example/post-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the post-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/e2e/upgrades/example/pre-upgrade.test.ts
+++ b/e2e/upgrades/example/pre-upgrade.test.ts
@@ -1,0 +1,13 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import hre from 'hardhat'
+
+chai.use(chaiAsPromised)
+
+describe('GNS contract', () => {
+  it(`'test' storage variable should not exist`, async function () {
+    const graph = hre.graph()
+    const { GNS } = graph.contracts
+    await expect(GNS.test()).to.eventually.be.rejected
+  })
+})

--- a/e2e/upgrades/example/pre-upgrade.ts
+++ b/e2e/upgrades/example/pre-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the pre-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/gre/accounts.ts
+++ b/gre/accounts.ts
@@ -19,10 +19,17 @@ const namedAccountList: AccountNames[] = [
 export async function getNamedAccounts(
   provider: EthersProviderWrapper,
   graphConfigPath: string,
+  impersonate?: boolean,
 ): Promise<NamedAccounts> {
   const namedAccounts = namedAccountList.reduce(async (accountsPromise, name) => {
     const accounts = await accountsPromise
     const address = getItemValue(readConfig(graphConfigPath, true), `general/${name}`)
+
+    // If we are impersonating, we need to set the balance of the account
+    if (impersonate) {
+      await provider.send('hardhat_impersonateAccount', [address])
+      await provider.send('hardhat_setBalance', [address, '0x56BC75E2D63100000']) // 100 ETH
+    }
     accounts[name] = await SignerWithAddress.create(provider.getSigner(address))
     return accounts
   }, Promise.resolve({} as NamedAccounts))

--- a/gre/providers.ts
+++ b/gre/providers.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment, Network } from 'hardhat/types/runtime'
+import { Network } from 'hardhat/types/runtime'
 import { NetworksConfig, HttpNetworkConfig } from 'hardhat/types/config'
 import { EthersProviderWrapper } from '@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper'
 import { HARDHAT_NETWORK_NAME } from 'hardhat/plugins'
@@ -42,6 +42,7 @@ export const getSecureAccountsProvider = async (
   mainNetworkName: string,
   isMainProvider: boolean,
   chainLabel: string,
+  caller: string,
   accountName?: string,
   accountPassword?: string,
 ): Promise<EthersProviderWrapper | undefined> => {
@@ -57,10 +58,10 @@ export const getSecureAccountsProvider = async (
     return undefined
   }
 
-  logDebug(`Using secure accounts provider for ${chainLabel}(${networkName})`)
+  logDebug(`Using secure accounts provider for ${chainLabel}(${networkName}) - Caller is ${caller}`)
   if (accountName === undefined || accountPassword === undefined) {
     console.log(
-      `== Using secure accounts, please unlock an account for ${chainLabel}(${networkName})`,
+      `== Using secure accounts, please unlock an account for ${chainLabel}(${networkName}) - Caller is ${caller}`,
     )
   }
 

--- a/gre/type-extensions.d.ts
+++ b/gre/type-extensions.d.ts
@@ -12,6 +12,7 @@ export interface GraphRuntimeEnvironmentOptions {
   graphConfig?: string
   enableTxLogging?: boolean
   disableSecureAccounts?: boolean
+  fork?: boolean
 
   // These are mostly for testing purposes
   l1AccountName?: string

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -155,14 +155,12 @@ const config: HardhatUserConfig = {
         interval: 13000,
       },
       hardfork: 'london',
-      graphConfig: 'config/graph.localhost.yml',
     },
     localhost: {
       chainId: 1337,
       url: 'http://localhost:8545',
       accounts:
         process.env.FORK === 'true' ? getAccountsKeys() : { mnemonic: DEFAULT_TEST_MNEMONIC },
-      graphConfig: 'config/graph.localhost.yml',
     },
     localnitrol1: {
       chainId: 1337,
@@ -181,6 +179,7 @@ const config: HardhatUserConfig = {
     addressBook: process.env.ADDRESS_BOOK ?? 'addresses.json',
     l1GraphConfig: process.env.L1_GRAPH_CONFIG ?? 'config/graph.localhost.yml',
     l2GraphConfig: process.env.L2_GRAPH_CONFIG ?? 'config/graph.arbitrum-localhost.yml',
+    fork: process.env.FORK === 'true',
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "test:gas": "RUN_EVM=true REPORT_GAS=true scripts/test",
     "test:coverage": "scripts/coverage",
     "test:gre": "cd gre && mocha --exit --recursive 'test/**/*.test.ts' && cd ..",
+    "test:upgrade": "scripts/upgrade",
     "lint": "yarn lint:ts && yarn lint:sol",
     "lint:fix": "yarn lint:ts:fix && yarn lint:sol:fix",
     "lint:ts": "eslint '**/*.{js,ts}'",

--- a/scripts/evm
+++ b/scripts/evm
@@ -19,9 +19,31 @@ evm_ping() {
     }'
 }
 
+evm_automine() {
+  curl --location --request POST "localhost:$TESTRPC_PORT/" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+      "jsonrpc":"2.0",
+      "method":"evm_setAutomine",
+      "params":[true],
+      "id":1
+    }'
+    echo
+}
+
 evm_start() {
+  local FORK_URL=$1
+  local FORK_BLOCK_NUMBER="$2"
   echo "Starting our own evm instance at port $TESTRPC_PORT"
-  npx hardhat node --port "$TESTRPC_PORT" > /dev/null &
+  if [[ -n "$FORK_URL" ]]; then
+    if [[ "$FORK_BLOCK_NUMBER" == "latest" ]]; then
+      npx hardhat node --port "$TESTRPC_PORT" --fork "$FORK_URL" > /dev/null &
+    else
+      npx hardhat node --port "$TESTRPC_PORT" --fork "$FORK_URL" --fork-block-number "$FORK_BLOCK_NUMBER" > /dev/null &
+    fi
+  else
+    npx hardhat node --port "$TESTRPC_PORT" > /dev/null & 
+  fi
   retries=0
   while ! evm_ping $TESTRPC_PORT; do
     ((retries=retries+1))
@@ -31,6 +53,8 @@ evm_start() {
     fi
     sleep 1
   done
+
+  echo -e "\nEVM instance is ready"
 }
 
 evm_kill() {

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -eo pipefail
+source $(pwd)/scripts/evm
+
+print_separator() {
+  echo -e "\n############################################################################################"
+  echo "# $1"
+  echo "############################################################################################"
+}
+
+### > SCRIPT CONFIG <
+FORK_URL=${FORK_URL}
+FORK_BLOCK_NUMBER=${FORK_BLOCK_NUMBER:-"latest"}
+CHAIN_ID=${CHAIN_ID}
+
+NETWORK=${NETWORK:-"mainnet"}
+ADDRESS_BOOK=${ADDRESS_BOOK:-"addresses.json"}
+GRAPH_CONFIG=${GRAPH_CONFIG:-"config/graph.mainnet.yml"}
+CONTRACT_NAME=${CONTRACT_NAME}
+UPGRADE_NAME=${UPGRADE_NAME}
+
+if [[ -z "$FORK_URL" ]]; then
+  if [[ -n "$INFURA_KEY" ]]; then
+    FORK_URL="https://mainnet.infura.io/v3/$INFURA_KEY"
+  else
+    echo "Must specify FORK_URL or INFURA_KEY!"
+    exit 0
+  fi
+fi
+
+if [[ -z "$CHAIN_ID" ]]; then
+  echo "Must specify CHAIN_ID you are forking from!"
+  exit 0
+fi
+
+if [[ -z "$CONTRACT_NAME" ]]; then
+  echo "Must specify CONTRACT_NAME to upgrade!"
+  exit 0
+fi
+
+if [[ -z "$UPGRADE_NAME" ]]; then
+  echo "Must specify UPGRADE_NAME to upgrade!"
+  exit 0
+fi
+
+print_separator "Running upgrade tests with config"
+echo "- Using forking URL: $FORK_URL"
+echo "- Forking from chain id: $CHAIN_ID"
+echo "- Fork block number: $FORK_BLOCK_NUMBER"
+echo "- Upgrading contract: $CONTRACT_NAME"
+echo "- Upgrade name: $UPGRADE_NAME"
+
+### > SCRIPT START < ###
+## SETUP
+# Compile contracts
+print_separator "Building contracts"
+yarn build
+
+# Build fork address book with actual contract addresses from the forked chain
+jq "{\"$CHAIN_ID\"} + {"\"1337\"": .\"$CHAIN_ID\"} | del(.\"$CHAIN_ID\")" $ADDRESS_BOOK > addresses-fork.json
+
+# Start evm - fork it!
+print_separator "Starting forked chain"
+evm_kill
+evm_start "$FORK_URL" "$FORK_BLOCK_NUMBER"
+evm_automine
+
+# Run pre-upgrade scripts
+print_separator "Running pre-upgrade scripts and tests"
+FORK=true npx hardhat e2e:upgrade "$UPGRADE_NAME" \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --disable-secure-accounts
+
+# Run upgrade
+print_separator "Upgrading contract"
+FORK=true npx hardhat contracts:upgrade \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --contract "${CONTRACT_NAME}" \
+  --disable-secure-accounts
+
+# Run post-upgrade scripts
+print_separator "Running post-upgrade scripts and tests"
+FORK=true npx hardhat e2e:upgrade "$UPGRADE_NAME" \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --disable-secure-accounts \
+  --post
+
+# Kill evm
+print_separator "Clean up"
+read -p "Upgrade test finished! Do you want to stop the evm? (Y/n) " yn
+if [[ $yn != "y" ]]; then
+  evm_kill
+fi
+

--- a/tasks/contracts/upgrade.ts
+++ b/tasks/contracts/upgrade.ts
@@ -1,0 +1,42 @@
+import { task } from 'hardhat/config'
+
+import { cliOpts } from '../../cli/defaults'
+import { deployContractImplementationAndSave } from '../../cli/network'
+import { getAddressBook } from '../../cli/address-book'
+
+task('contracts:upgrade', 'Upgrades a contract')
+  .addParam('contract', 'Name of the contract to upgrade')
+  .addFlag('disableSecureAccounts', 'Disable secure accounts on GRE')
+  .addOptionalParam('graphConfig', cliOpts.graphConfig.description, cliOpts.graphConfig.default)
+  .addOptionalParam('addressBook', cliOpts.addressBook.description, cliOpts.addressBook.default)
+  .addOptionalVariadicPositionalParam(
+    'init',
+    'Initialization arguments for the contract constructor',
+  )
+  .setAction(async (taskArgs, hre) => {
+    const graph = hre.graph(taskArgs)
+
+    const { GraphProxyAdmin } = graph.contracts
+    const { governor } = await graph.getNamedAccounts()
+    const deployer = await graph.getDeployer()
+
+    const contract = graph.contracts[taskArgs.contract]
+    if (!contract) {
+      throw new Error(`Contract ${taskArgs.contract} not found in address book`)
+    }
+    console.log(`Upgrading ${taskArgs.contract}...`)
+
+    // Deploy new implementation
+    const implementation = await deployContractImplementationAndSave(
+      taskArgs.contract,
+      taskArgs.init || [],
+      deployer,
+      getAddressBook(taskArgs.addressBook, graph.chainId.toString()),
+    )
+    console.log(`New implementation deployed at ${implementation.address}`)
+
+    // Upgrade proxy and accept implementation
+    await GraphProxyAdmin.connect(governor).upgrade(contract.address, implementation.address)
+    await GraphProxyAdmin.connect(governor).acceptProxy(implementation.address, contract.address)
+    console.log(`Proxy upgraded to ${implementation.address}`)
+  })


### PR DESCRIPTION
This PR extends the e2e framework to include contract upgrade testing via a new script. Using a local fork from mainnet or other sources it allows writing tests to validate contract upgrades, state transitions, etc.


The script will:
- Run a hardhat node forking from an RPC (mainnet or any network)
- Runs a user defined pre-upgrade script (in case it’s useful)
- Runs a user defined pre-upgrade test script (here you can write tests like usual, using GRE, etc)
- Upgrades the specified contract in the fork using the current directory source code (this includes impersonating governance to accept upgrades)
- Runs a user defined post-upgrade script (here you might do things like contract configuration that requires the new implementation address, add it to callhook whitelist for example)
- Runs a user defined post-upgrade test script (here you can write tests to validate the deployment, maybe if the upgrade was fixing a bug you can verify it)


An example can be found in `e2e/upgrades/example`.


These changes are also included in https://github.com/graphprotocol/contracts/pull/838 which is the branch we'll likely end up merging.