### PR TITLE
fix: Allocations that had a `Claimed` state will now appear with an `Active` state (OZ H-01)

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -1076,7 +1076,7 @@ abstract contract Staking is StakingV4Storage, GraphUpgradeable, IStakingBase, M
             return AllocationState.Null;
         }
 
-        if (alloc.closedAtEpoch == 0) {
+        if (alloc.createdAtEpoch != 0 && alloc.closedAtEpoch == 0) {
             return AllocationState.Active;
         }
 

--- a/test/staking/allocation.test.ts
+++ b/test/staking/allocation.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai'
-import { constants, BigNumber, PopulatedTransaction, ethers } from 'ethers'
+import { constants, BigNumber, PopulatedTransaction } from 'ethers'
 
 import { Curation } from '../../build/types/Curation'
 import { EpochManager } from '../../build/types/EpochManager'
 import { GraphToken } from '../../build/types/GraphToken'
 import { IStaking } from '../../build/types/IStaking'
-import { Staking } from '../../build/types/Staking'
 import { LibExponential } from '../../build/types/LibExponential'
 
 import { NetworkFixture } from '../lib/fixtures'
@@ -101,6 +100,7 @@ describe('Staking:Allocation', () => {
     // After state
     const afterStake = await staking.stakes(indexer.address)
     const afterAlloc = await staking.getAllocation(allocationID)
+    const afterState = await staking.getAllocationState(allocationID)
 
     // Stake updated
     expect(afterStake.tokensAllocated).eq(beforeStake.tokensAllocated.add(tokensToAllocate))
@@ -111,6 +111,7 @@ describe('Staking:Allocation', () => {
     expect(afterAlloc.createdAtEpoch).eq(currentEpoch)
     expect(afterAlloc.collectedFees).eq(toGRT('0'))
     expect(afterAlloc.closedAtEpoch).eq(toBN('0'))
+    expect(afterState).to.eq(AllocationState.Active)
   }
 
   // This function tests collect with state updates
@@ -119,11 +120,9 @@ describe('Staking:Allocation', () => {
     _allocationID?: string,
   ): Promise<{ queryRebates: BigNumber; queryFeesBurnt: BigNumber }> => {
     const alloID = _allocationID ?? allocationID
+    const alloStateBefore = await staking.getAllocationState(alloID)
     // Should have a particular state before collecting
-    expect(await staking.getAllocationState(alloID)).to.be.oneOf([
-      AllocationState.Active,
-      AllocationState.Closed,
-    ])
+    expect(alloStateBefore).to.be.oneOf([AllocationState.Active, AllocationState.Closed])
 
     // Before state
     const beforeTokenSupply = await grt.totalSupply()
@@ -197,6 +196,7 @@ describe('Staking:Allocation', () => {
     const afterAlloc = await staking.getAllocation(alloID)
     const afterIndexerBalance = await grt.balanceOf(indexer.address)
     const afterStake = await staking.stakes(indexer.address)
+    const alloStateAfter = await staking.getAllocationState(alloID)
 
     // Check that protocol fees are burnt
     expect(afterTokenSupply).eq(beforeTokenSupply.sub(protocolFees).sub(queryFeesBurnt))
@@ -221,6 +221,7 @@ describe('Staking:Allocation', () => {
     expect(afterAlloc.distributedRebates).eq(
       beforeAlloc.distributedRebates.add(queryRebates).add(delegationRewards),
     )
+    expect(alloStateAfter).eq(alloStateBefore)
 
     // // Funds distributed to indexer or restaked
     const restake = (await staking.rewardsDestination(indexer.address)) === AddressZero
@@ -260,6 +261,48 @@ describe('Staking:Allocation', () => {
     // Check rebated amounts match, allow a small error margin of 5 wei
     // Due to rounding it's not possible to guarantee an exact match in case of multiple collections
     expect(rebatedAmountMultiple.sub(rebatedAmountFull)).lt(5)
+  }
+
+  const shouldCloseAllocation = async () => {
+    // Before state
+    const beforeStake = await staking.stakes(indexer.address)
+    const beforeAlloc = await staking.getAllocation(allocationID)
+    const beforeAlloState = await staking.getAllocationState(allocationID)
+    expect(beforeAlloState).eq(AllocationState.Active)
+
+    // Move at least one epoch to be able to close
+    await advanceToNextEpoch(epochManager)
+    await advanceToNextEpoch(epochManager)
+
+    // Calculations
+    const currentEpoch = await epochManager.currentEpoch()
+
+    // Close allocation
+    const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
+    await expect(tx)
+      .emit(staking, 'AllocationClosed')
+      .withArgs(
+        indexer.address,
+        subgraphDeploymentID,
+        currentEpoch,
+        beforeAlloc.tokens,
+        allocationID,
+        indexer.address,
+        poi,
+        false,
+      )
+
+    // After state
+    const afterStake = await staking.stakes(indexer.address)
+    const afterAlloc = await staking.getAllocation(allocationID)
+    const afterAlloState = await staking.getAllocationState(allocationID)
+
+    // Stake updated
+    expect(afterStake.tokensAllocated).eq(beforeStake.tokensAllocated.sub(beforeAlloc.tokens))
+    // Allocation updated
+    expect(afterAlloc.closedAtEpoch).eq(currentEpoch)
+    // State progressed
+    expect(afterAlloState).eq(AllocationState.Closed)
   }
   // -- Tests --
 
@@ -756,40 +799,7 @@ describe('Staking:Allocation', () => {
         })
 
         it('should close an allocation', async function () {
-          // Before state
-          const beforeStake = await staking.stakes(indexer.address)
-          const beforeAlloc = await staking.getAllocation(allocationID)
-
-          // Move at least one epoch to be able to close
-          await advanceToNextEpoch(epochManager)
-          await advanceToNextEpoch(epochManager)
-
-          // Calculations
-          const currentEpoch = await epochManager.currentEpoch()
-
-          // Close allocation
-          const tx = staking.connect(indexer.signer).closeAllocation(allocationID, poi)
-          await expect(tx)
-            .emit(staking, 'AllocationClosed')
-            .withArgs(
-              indexer.address,
-              subgraphDeploymentID,
-              currentEpoch,
-              beforeAlloc.tokens,
-              allocationID,
-              indexer.address,
-              poi,
-              false,
-            )
-
-          // After state
-          const afterStake = await staking.stakes(indexer.address)
-          const afterAlloc = await staking.getAllocation(allocationID)
-
-          // Stake updated
-          expect(afterStake.tokensAllocated).eq(beforeStake.tokensAllocated.sub(beforeAlloc.tokens))
-          // Allocation updated
-          expect(afterAlloc.closedAtEpoch).eq(currentEpoch)
+          await shouldCloseAllocation()
         })
 
         it('should close an allocation (by operator)', async function () {


### PR DESCRIPTION
https://github.com/graphprotocol/contracts/pull/838 introduces upgrade testing and a few state transition tests that help validate the code change in this PR.