### PR TITLE
fix: Lack of test coverage (OZ M-01)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ addresses-local.json
 localNetwork.json
 arbitrum-addresses-local.json
 tx-*.log
+addresses-fork.json
 
 # Keys
 .keystore

--- a/cli/network.ts
+++ b/cli/network.ts
@@ -320,6 +320,34 @@ export const deployContractAndSave = async (
   return deployResult.contract
 }
 
+export const deployContractImplementationAndSave = async (
+  name: string,
+  args: Array<ContractParam>,
+  sender: Signer,
+  addressBook: AddressBook,
+): Promise<Contract> => {
+  // Deploy the contract
+  const deployResult = await deployContract(name, args, sender)
+
+  // Save address entry
+  const entry = addressBook.getEntry(name)
+  entry.implementation = {
+    address: deployResult.contract.address,
+    constructorArgs: args.length === 0 ? undefined : args.map((e) => e.toString()),
+    creationCodeHash: deployResult.creationCodeHash,
+    runtimeCodeHash: deployResult.runtimeCodeHash,
+    txHash: deployResult.txHash,
+    libraries:
+      deployResult.libraries && Object.keys(deployResult.libraries).length > 0
+        ? deployResult.libraries
+        : undefined,
+  }
+  addressBook.setEntry(name, entry)
+  logger.info('> Contract saved to address book')
+
+  return deployResult.contract
+}
+
 export const deployContractWithProxyAndSave = async (
   name: string,
   args: Array<ContractParam>,

--- a/contracts/staking/libs/Exponential.sol
+++ b/contracts/staking/libs/Exponential.sol
@@ -6,7 +6,7 @@ import { LibFixedMath } from "./LibFixedMath.sol";
 
 /**
  * @title LibExponential library
- * @notice A library to compute qyery fee rebates using an exponential formula
+ * @notice A library to compute query fee rebates using an exponential formula
  */
 library LibExponential {
     /// @dev Maximum value of the exponent for which to compute the exponential before clamping to zero.

--- a/e2e/lib/accounts.ts
+++ b/e2e/lib/accounts.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers'
 import { ethers } from 'hardhat'
-import { GraphToken } from '../../../build/types/GraphToken'
+import { GraphToken } from '../../build/types/GraphToken'
 import { TransactionResponse } from '@ethersproject/providers'
 
 const checkBalance = async (

--- a/e2e/lib/curation.ts
+++ b/e2e/lib/curation.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumberish } from 'ethers'
-import { NetworkContracts } from '../../../cli/contracts'
-import { sendTransaction } from '../../../cli/network'
+import { NetworkContracts } from '../../cli/contracts'
+import { sendTransaction } from '../../cli/network'
 import { ensureGRTAllowance } from './accounts'
 
 export const signal = async (

--- a/e2e/lib/helpers.ts
+++ b/e2e/lib/helpers.ts
@@ -4,6 +4,7 @@ export function getGraphOptsFromArgv(): {
   l1GraphConfig: string | undefined
   l2GraphConfig: string | undefined
   disableSecureAccounts?: boolean | undefined
+  fork?: boolean | undefined
 } {
   const argv = process.argv.slice(2)
 
@@ -16,5 +17,6 @@ export function getGraphOptsFromArgv(): {
     l1GraphConfig: getArgv(2),
     l2GraphConfig: getArgv(3),
     disableSecureAccounts: getArgv(4),
+    fork: getArgv(5),
   }
 }

--- a/e2e/lib/staking.ts
+++ b/e2e/lib/staking.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumberish, ethers } from 'ethers'
-import { NetworkContracts } from '../../../cli/contracts'
-import { randomHexBytes, sendTransaction } from '../../../cli/network'
+import { NetworkContracts } from '../../cli/contracts'
+import { randomHexBytes, sendTransaction } from '../../cli/network'
 import { ensureGRTAllowance } from './accounts'
 
 export const stake = async (

--- a/e2e/lib/subgraph.ts
+++ b/e2e/lib/subgraph.ts
@@ -1,9 +1,9 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { BigNumber } from 'ethers'
 import { solidityKeccak256 } from 'ethers/lib/utils'
-import { NetworkContracts } from '../../../cli/contracts'
-import { randomHexBytes, sendTransaction } from '../../../cli/network'
 import hre from 'hardhat'
+import { NetworkContracts } from '../../cli/contracts'
+import { randomHexBytes, sendTransaction } from '../../cli/network'
 
 export const recreatePreviousSubgraphId = async (
   contracts: NetworkContracts,

--- a/e2e/scenarios/close-allocations.ts
+++ b/e2e/scenarios/close-allocations.ts
@@ -7,11 +7,11 @@
 //    npx hardhat e2e:scenario close-allocations --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { closeAllocation } from './lib/staking'
+import { closeAllocation } from '../lib/staking'
 import { advanceToNextEpoch } from '../../test/lib/testHelpers'
-import { fundAccountsETH } from './lib/accounts'
+import { fundAccountsETH } from '../lib/accounts'
 import { getIndexerFixtures } from './fixtures/indexers'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/create-subgraphs.test.ts
+++ b/e2e/scenarios/create-subgraphs.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { recreatePreviousSubgraphId } from './lib/subgraph'
+import { recreatePreviousSubgraphId } from '../lib/subgraph'
 import { BigNumber } from 'ethers'
 import { CuratorFixture, getCuratorFixtures } from './fixtures/curators'
 import { SubgraphFixture, getSubgraphFixtures, getSubgraphOwner } from './fixtures/subgraphs'

--- a/e2e/scenarios/create-subgraphs.ts
+++ b/e2e/scenarios/create-subgraphs.ts
@@ -5,12 +5,12 @@
 //    npx hardhat e2e:scenario create-subgraphs --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { publishNewSubgraph } from './lib/subgraph'
-import { fundAccountsETH, fundAccountsGRT } from './lib/accounts'
-import { signal } from './lib/curation'
+import { publishNewSubgraph } from '../lib/subgraph'
+import { fundAccountsETH, fundAccountsGRT } from '../lib/accounts'
+import { signal } from '../lib/curation'
 import { getSubgraphFixtures, getSubgraphOwner } from './fixtures/subgraphs'
 import { getCuratorFixtures } from './fixtures/curators'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/open-allocations.ts
+++ b/e2e/scenarios/open-allocations.ts
@@ -5,10 +5,10 @@
 //    npx hardhat e2e:scenario open-allocations --network <network> --graph-config config/graph.<network>.yml
 
 import hre from 'hardhat'
-import { allocateFrom, stake } from './lib/staking'
-import { fundAccountsETH, fundAccountsGRT } from './lib/accounts'
+import { allocateFrom, stake } from '../lib/staking'
+import { fundAccountsETH, fundAccountsGRT } from '../lib/accounts'
 import { getIndexerFixtures } from './fixtures/indexers'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()

--- a/e2e/scenarios/send-grt-to-l2.ts
+++ b/e2e/scenarios/send-grt-to-l2.ts
@@ -6,7 +6,7 @@
 
 import hre from 'hardhat'
 import { TASK_BRIDGE_TO_L2 } from '../../tasks/bridge/to-l2'
-import { getGraphOptsFromArgv } from './lib/helpers'
+import { getGraphOptsFromArgv } from '../lib/helpers'
 import { getBridgeFixture } from './fixtures/bridge'
 
 async function main() {

--- a/e2e/upgrades/example/Instructions.md
+++ b/e2e/upgrades/example/Instructions.md
@@ -1,0 +1,7 @@
+# Usage
+
+1) Upgrade the GNS contract, add a `uint256 public test;` storage variable
+2) Run the upgrade script:
+    ```
+    CHAIN_ID=1 FORK_URL=<RPC_URL> CONTRACT_NAME=GNS UPGRADE_NAME=example yarn test:upgrade
+    ```

--- a/e2e/upgrades/example/post-upgrade.test.ts
+++ b/e2e/upgrades/example/post-upgrade.test.ts
@@ -1,0 +1,14 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import hre from 'hardhat'
+
+chai.use(chaiAsPromised)
+
+describe('GNS contract', () => {
+  it(`'test' storage variable should exist`, async function () {
+    const graph = hre.graph()
+    const { GNS } = graph.contracts
+
+    await expect(GNS.test()).to.eventually.be.fulfilled
+  })
+})

--- a/e2e/upgrades/example/post-upgrade.ts
+++ b/e2e/upgrades/example/post-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the post-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/e2e/upgrades/example/pre-upgrade.test.ts
+++ b/e2e/upgrades/example/pre-upgrade.test.ts
@@ -1,0 +1,13 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import hre from 'hardhat'
+
+chai.use(chaiAsPromised)
+
+describe('GNS contract', () => {
+  it(`'test' storage variable should not exist`, async function () {
+    const graph = hre.graph()
+    const { GNS } = graph.contracts
+    await expect(GNS.test()).to.eventually.be.rejected
+  })
+})

--- a/e2e/upgrades/example/pre-upgrade.ts
+++ b/e2e/upgrades/example/pre-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the pre-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/e2e/upgrades/exponential-rebates/Instructions.md
+++ b/e2e/upgrades/exponential-rebates/Instructions.md
@@ -1,0 +1,12 @@
+# Usage
+
+Run with:
+
+```
+CHAIN_ID=1 \
+FORK_URL=https://mainnet.infura.io/v3/<INFURA_KEY> \
+FORK_BLOCK_NUMBER=17324022 \
+CONTRACT_NAME=L1Staking \
+UPGRADE_NAME=exponential-rebates \
+yarn test:upgrade
+```

--- a/e2e/upgrades/exponential-rebates/abis/staking.ts
+++ b/e2e/upgrades/exponential-rebates/abis/staking.ts
@@ -1,0 +1,23 @@
+export default [
+  {
+    inputs: [],
+    name: 'channelDisputeEpochs',
+    outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'rebates',
+    outputs: [
+      { internalType: 'uint256', name: 'fees', type: 'uint256' },
+      { internalType: 'uint256', name: 'effectiveAllocatedStake', type: 'uint256' },
+      { internalType: 'uint256', name: 'claimedRewards', type: 'uint256' },
+      { internalType: 'uint32', name: 'unclaimedAllocationsCount', type: 'uint32' },
+      { internalType: 'uint32', name: 'alphaNumerator', type: 'uint32' },
+      { internalType: 'uint32', name: 'alphaDenominator', type: 'uint32' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]

--- a/e2e/upgrades/exponential-rebates/abis/staking.ts
+++ b/e2e/upgrades/exponential-rebates/abis/staking.ts
@@ -20,4 +20,14 @@ export default [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [
+      { internalType: 'address', name: '_allocationID', type: 'address' },
+      { internalType: 'bool', name: '_restake', type: 'bool' },
+    ],
+    name: 'claim',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
 ]

--- a/e2e/upgrades/exponential-rebates/fixtures/allocations.ts
+++ b/e2e/upgrades/exponential-rebates/fixtures/allocations.ts
@@ -1,0 +1,30 @@
+// Valid allocation states for
+// - chain: Ethereum Mainnet
+// - block number: 17324022
+// Allocation ids obtained from network subgraph
+
+export enum AllocationState {
+  Null,
+  Active,
+  Closed,
+  Finalized,
+  Claimed,
+}
+
+export default [
+  { id: '0x00b7a526e1e42ba1f14e69f487aad31350164a9e', state: AllocationState.Null },
+  { id: '0x00b7a526e1e42ba1f14e69f487aad31350164a9f', state: AllocationState.Null },
+  { id: '0x00b7a526e1e42ba1f14e69f487aad31350164a90', state: AllocationState.Null },
+  { id: '0x00b7a526e1e42ba1f14e69f487aad31350164a9d', state: AllocationState.Active },
+  { id: '0x02a5e2312af00aa85a24cf4c43a8c0a6fd9a6c2d', state: AllocationState.Active },
+  { id: '0x0a272f72c14a226525fb4e2114f8a0052dc7dd38', state: AllocationState.Active },
+  { id: '0x016ad691b2572ed3192e366584d12e94699e12b2', state: AllocationState.Closed },
+  { id: '0x060df24858f3aa6d445645b73d0d2eeb117ae8a3', state: AllocationState.Closed },
+  { id: '0x08ee64a4505e9cd77f0cae15c56e795dca7384e3', state: AllocationState.Closed },
+  { id: '0x03f9e610fea2f8eab7321038997a50fe4ecc6aa5', state: AllocationState.Finalized },
+  { id: '0x0989e792c6ca9eb0a0f2f63d92e407cdc1e64c29', state: AllocationState.Finalized },
+  { id: '0x0d62657d6b75f462b28c000f6f6e41d56cc60069', state: AllocationState.Finalized },
+  { id: '0x0da397c2887632e7250a5f1a8a7ed56e437780f5', state: AllocationState.Claimed },
+  { id: '0x0d819c0e05782f41a4ab22fe9b5d439235093706', state: AllocationState.Claimed },
+  { id: '0x0afef3ebeb9f85ce60c89ecaa7d98e41335ce5a4', state: AllocationState.Claimed },
+]

--- a/e2e/upgrades/exponential-rebates/fixtures/indexers.ts
+++ b/e2e/upgrades/exponential-rebates/fixtures/indexers.ts
@@ -1,0 +1,66 @@
+// Valid for
+// - chain: Ethereum Mainnet
+// - block number: 17324022
+// Query to obtain data:
+// allocations (
+//   block: { number: 17324022 },
+//   where: {
+//     indexer_: { id: "0x87eba079059b75504c734820d6cf828476754b83" },
+//     status: Active
+//   },
+//   first:10
+// ){
+//  id
+//  status
+// }
+
+export default [
+  {
+    signer: null,
+    address: '0x87Eba079059B75504c734820d6cf828476754B83',
+    allocationsBatch1: [
+      {
+        id: '0x0074115940dee3ecb0c1d524c94b169cc5ea28ac',
+        status: 'Active',
+      },
+      {
+        id: '0x0419959df8ecfaeb98f273ad7e037bea2dac58b8',
+        status: 'Active',
+      },
+      {
+        id: '0x04d40e25064297f1548ffbca867edbc26f4e85bb',
+        status: 'Active',
+      },
+      {
+        id: '0x0607ae1824a834c44004eeee58f5513911fedc18',
+        status: 'Active',
+      },
+      {
+        id: '0x08abad5b5fbc5436e043d680b6721fda5c3ea370',
+        status: 'Active',
+      },
+    ],
+    allocationsBatch2: [
+      {
+        id: '0x10ffbcdf3f294c029621b85dca22651f819530e2',
+        status: 'Active',
+      },
+      {
+        id: '0x160c431e8c94e06164f44ed9deaeb3ff9972d4ec',
+        status: 'Active',
+      },
+      {
+        id: '0x23df5d592c149eb62c7f4caa22642d3e353009a3',
+        status: 'Active',
+      },
+      {
+        id: '0x2ddef43b8328a9e6e5c6e8ec4cea01d6aca514ec',
+        status: 'Active',
+      },
+      {
+        id: '0x30310400346f6384040afdc8d57a78b67907efb6',
+        status: 'Active',
+      },
+    ],
+  },
+]

--- a/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
@@ -1,17 +1,25 @@
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { Contract } from 'ethers'
+import { Contract, Signer, ethers } from 'ethers'
 import hre from 'hardhat'
 
 import removedABI from './abis/staking'
 import allocations, { AllocationState } from './fixtures/allocations'
+import indexers from './fixtures/indexers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { advanceEpochs, advanceToNextEpoch, randomHexBytes } from '../../../test/lib/testHelpers'
 
 chai.use(chaiAsPromised)
 
 describe('[AFTER UPGRADE] Exponential rebates upgrade', () => {
   const graph = hre.graph()
-  const { Staking } = graph.contracts
+  const { Staking, EpochManager } = graph.contracts
   const deployedStaking = new Contract(Staking.address, removedABI, graph.provider)
+  let deployer: SignerWithAddress
+
+  before(async function () {
+    deployer = await graph.getDeployer()
+  })
 
   describe('> Storage variables', () => {
     it(`channelDisputeEpochs should not exist`, async function () {
@@ -62,5 +70,40 @@ describe('[AFTER UPGRADE] Exponential rebates upgrade', () => {
         )
       }
     })
+  })
+
+  describe('> Indexer actions', () => {
+    before(async function () {
+      // Impersonate indexers
+      for (const indexer of indexers) {
+        await graph.provider.send('hardhat_impersonateAccount', [indexer.address])
+        await graph.provider.send('hardhat_setBalance', [indexer.address, '0x56BC75E2D63100000']) // 100 Eth
+        indexer.signer = await SignerWithAddress.create(graph.provider.getSigner(indexer.address))
+      }
+    })
+
+    // it('should be able to collect but not claim rebates', async function () {
+    //   for (const indexer of indexers) {
+    //     for (const allocation of indexer.allocationsBatch2) {
+    //       // Close allocation first
+    //       await advanceToNextEpoch(EpochManager)
+    //       await Staking.connect(indexer.signer).closeAllocation(allocation.id, randomHexBytes())
+
+    //       // Collect query fees
+    //       const assetHolder = await graph.getDeployer()
+    //       await expect(
+    //         Staking.connect(assetHolder).collect(ethers.utils.parseEther('1000'), allocation.id),
+    //       ).to.eventually.be.fulfilled
+
+    //       // Claim rebate
+    //       await advanceEpochs(EpochManager, 7)
+    //       const tx = await deployedStaking.connect(indexer.signer).claim(allocation.id, false)
+    //       console.log(tx)
+
+    //       await expect(deployedStaking.connect(indexer.signer).claim(allocation.id, false)).to
+    //         .eventually.be.rejected
+    //     }
+    //   }
+    // })
   })
 })

--- a/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
@@ -1,0 +1,14 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import hre from 'hardhat'
+
+chai.use(chaiAsPromised)
+
+// describe('GNS contract', () => {
+//   it(`'test' storage variable should exist`, async function () {
+//     const graph = hre.graph()
+//     const { GNS } = graph.contracts
+
+//     await expect(GNS.test()).to.eventually.be.fulfilled
+//   })
+// })

--- a/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/post-upgrade.test.ts
@@ -1,14 +1,66 @@
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
+import { Contract } from 'ethers'
 import hre from 'hardhat'
+
+import removedABI from './abis/staking'
+import allocations, { AllocationState } from './fixtures/allocations'
 
 chai.use(chaiAsPromised)
 
-// describe('GNS contract', () => {
-//   it(`'test' storage variable should exist`, async function () {
-//     const graph = hre.graph()
-//     const { GNS } = graph.contracts
+describe('[AFTER UPGRADE] Exponential rebates upgrade', () => {
+  const graph = hre.graph()
+  const { Staking } = graph.contracts
+  const deployedStaking = new Contract(Staking.address, removedABI, graph.provider)
 
-//     await expect(GNS.test()).to.eventually.be.fulfilled
-//   })
-// })
+  describe('> Storage variables', () => {
+    it(`channelDisputeEpochs should not exist`, async function () {
+      await expect(deployedStaking.channelDisputeEpochs()).to.eventually.be.rejected
+    })
+    it(`rebates should not exist`, async function () {
+      await expect(deployedStaking.rebates(123)).to.eventually.be.rejected
+    })
+  })
+
+  describe('> Allocation state transitions', () => {
+    it('Null allocations should remain Null', async function () {
+      for (const allocation of allocations.filter((a) => a.state === AllocationState.Null)) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          AllocationState.Null,
+        )
+      }
+    })
+
+    it('Active allocations should remain Active', async function () {
+      for (const allocation of allocations.filter((a) => a.state === AllocationState.Active)) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          AllocationState.Active,
+        )
+      }
+    })
+
+    it('Closed allocations should remain Closed', async function () {
+      for (const allocation of allocations.filter((a) => a.state === AllocationState.Closed)) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          AllocationState.Closed,
+        )
+      }
+    })
+
+    it('Finalized allocations should transition to Closed', async function () {
+      for (const allocation of allocations.filter((a) => a.state === AllocationState.Finalized)) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          AllocationState.Closed,
+        )
+      }
+    })
+
+    it('Claimed allocations should transition to Closed', async function () {
+      for (const allocation of allocations.filter((a) => a.state === AllocationState.Claimed)) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          AllocationState.Closed,
+        )
+      }
+    })
+  })
+})

--- a/e2e/upgrades/exponential-rebates/post-upgrade.ts
+++ b/e2e/upgrades/exponential-rebates/post-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the post-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
@@ -1,0 +1,23 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { Contract } from 'ethers'
+import hre from 'hardhat'
+
+import removedABI from './abis/staking'
+
+chai.use(chaiAsPromised)
+
+describe('Exponential rebates upgrade', () => {
+  const graph = hre.graph()
+  const { Staking } = graph.contracts
+  const deployedStaking = new Contract(Staking.address, removedABI, graph.provider)
+
+  describe('> Storage variables', () => {
+    it(`channelDisputeEpochs should exist`, async function () {
+      await expect(deployedStaking.channelDisputeEpochs()).to.eventually.be.fulfilled
+    })
+    it(`rebates should exist`, async function () {
+      await expect(deployedStaking.rebates(123)).to.eventually.be.fulfilled
+    })
+  })
+})

--- a/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
@@ -1,16 +1,20 @@
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { Contract } from 'ethers'
+import { Contract, ethers } from 'ethers'
 import hre from 'hardhat'
 
 import removedABI from './abis/staking'
 import allocations from './fixtures/allocations'
+import indexers from './fixtures/indexers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { randomHexBytes } from '../../../cli/network'
+import { advanceEpochs, advanceToNextEpoch } from '../../../test/lib/testHelpers'
 
 chai.use(chaiAsPromised)
 
 describe('[BEFORE UPGRADE] Exponential rebates upgrade', () => {
   const graph = hre.graph()
-  const { Staking } = graph.contracts
+  const { Staking, EpochManager } = graph.contracts
   const deployedStaking = new Contract(Staking.address, removedABI, graph.provider)
 
   describe('> Storage variables', () => {
@@ -28,6 +32,38 @@ describe('[BEFORE UPGRADE] Exponential rebates upgrade', () => {
         await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
           allocation.state,
         )
+      }
+    })
+  })
+
+  describe('> Indexer actions', () => {
+    before(async function () {
+      // Impersonate indexers
+      for (const indexer of indexers) {
+        await graph.provider.send('hardhat_impersonateAccount', [indexer.address])
+        await graph.provider.send('hardhat_setBalance', [indexer.address, '0x56BC75E2D63100000']) // 100 Eth
+        indexer.signer = await SignerWithAddress.create(graph.provider.getSigner(indexer.address))
+      }
+    })
+
+    it('should be able to collect and claim rebates', async function () {
+      for (const indexer of indexers) {
+        for (const allocation of indexer.allocationsBatch1) {
+          // Close allocation first
+          await advanceToNextEpoch(EpochManager)
+          await Staking.connect(indexer.signer).closeAllocation(allocation.id, randomHexBytes())
+
+          // Collect query fees
+          const assetHolder = await graph.getDeployer()
+          await expect(
+            Staking.connect(assetHolder).collect(ethers.utils.parseEther('1000'), allocation.id),
+          ).to.eventually.be.fulfilled
+
+          // Claim rebate
+          await advanceEpochs(EpochManager, 7)
+          await expect(deployedStaking.connect(indexer.signer).claim(allocation.id, false)).to
+            .eventually.be.fulfilled
+        }
       }
     })
   })

--- a/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
+++ b/e2e/upgrades/exponential-rebates/pre-upgrade.test.ts
@@ -4,10 +4,11 @@ import { Contract } from 'ethers'
 import hre from 'hardhat'
 
 import removedABI from './abis/staking'
+import allocations from './fixtures/allocations'
 
 chai.use(chaiAsPromised)
 
-describe('Exponential rebates upgrade', () => {
+describe('[BEFORE UPGRADE] Exponential rebates upgrade', () => {
   const graph = hre.graph()
   const { Staking } = graph.contracts
   const deployedStaking = new Contract(Staking.address, removedABI, graph.provider)
@@ -18,6 +19,16 @@ describe('Exponential rebates upgrade', () => {
     })
     it(`rebates should exist`, async function () {
       await expect(deployedStaking.rebates(123)).to.eventually.be.fulfilled
+    })
+  })
+
+  describe('> Allocation state transitions', () => {
+    it('should validate fixture data on forked chain', async function () {
+      for (const allocation of allocations) {
+        await expect(Staking.getAllocationState(allocation.id)).to.eventually.equal(
+          allocation.state,
+        )
+      }
     })
   })
 })

--- a/e2e/upgrades/exponential-rebates/pre-upgrade.ts
+++ b/e2e/upgrades/exponential-rebates/pre-upgrade.ts
@@ -1,10 +1,24 @@
-import hre from 'hardhat'
+import hre, { ethers } from 'hardhat'
 import { getGraphOptsFromArgv } from '../../lib/helpers'
 
 async function main() {
   const graphOpts = getGraphOptsFromArgv()
   const graph = hre.graph(graphOpts)
+  const { GraphToken, Staking } = graph.contracts
+
   console.log('Hello from the pre-upgrade script!')
+
+  // Make the deployer an asset holder
+  const deployer = await graph.getDeployer()
+  const { governor } = await graph.getNamedAccounts()
+  await Staking.connect(governor).setAssetHolder(deployer.address, true)
+
+  // Get some funds on the deployer
+  await GraphToken.connect(governor).transfer(deployer.address, ethers.utils.parseEther('100000'))
+  await graph.provider.send('hardhat_setBalance', [deployer.address, '0x56BC75E2D63100000']) // 100 Eth
+
+  // Approve Staking contract to pull GRT from new asset holder
+  await GraphToken.connect(deployer).approve(Staking.address, ethers.utils.parseEther('100000'))
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/e2e/upgrades/exponential-rebates/pre-upgrade.ts
+++ b/e2e/upgrades/exponential-rebates/pre-upgrade.ts
@@ -1,0 +1,17 @@
+import hre from 'hardhat'
+import { getGraphOptsFromArgv } from '../../lib/helpers'
+
+async function main() {
+  const graphOpts = getGraphOptsFromArgv()
+  const graph = hre.graph(graphOpts)
+  console.log('Hello from the pre-upgrade script!')
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/gre/accounts.ts
+++ b/gre/accounts.ts
@@ -19,10 +19,17 @@ const namedAccountList: AccountNames[] = [
 export async function getNamedAccounts(
   provider: EthersProviderWrapper,
   graphConfigPath: string,
+  impersonate?: boolean,
 ): Promise<NamedAccounts> {
   const namedAccounts = namedAccountList.reduce(async (accountsPromise, name) => {
     const accounts = await accountsPromise
     const address = getItemValue(readConfig(graphConfigPath, true), `general/${name}`)
+
+    // If we are impersonating, we need to set the balance of the account
+    if (impersonate) {
+      await provider.send('hardhat_impersonateAccount', [address])
+      await provider.send('hardhat_setBalance', [address, '0x56BC75E2D63100000']) // 100 ETH
+    }
     accounts[name] = await SignerWithAddress.create(provider.getSigner(address))
     return accounts
   }, Promise.resolve({} as NamedAccounts))

--- a/gre/providers.ts
+++ b/gre/providers.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment, Network } from 'hardhat/types/runtime'
+import { Network } from 'hardhat/types/runtime'
 import { NetworksConfig, HttpNetworkConfig } from 'hardhat/types/config'
 import { EthersProviderWrapper } from '@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper'
 import { HARDHAT_NETWORK_NAME } from 'hardhat/plugins'
@@ -42,6 +42,7 @@ export const getSecureAccountsProvider = async (
   mainNetworkName: string,
   isMainProvider: boolean,
   chainLabel: string,
+  caller: string,
   accountName?: string,
   accountPassword?: string,
 ): Promise<EthersProviderWrapper | undefined> => {
@@ -57,10 +58,10 @@ export const getSecureAccountsProvider = async (
     return undefined
   }
 
-  logDebug(`Using secure accounts provider for ${chainLabel}(${networkName})`)
+  logDebug(`Using secure accounts provider for ${chainLabel}(${networkName}) - Caller is ${caller}`)
   if (accountName === undefined || accountPassword === undefined) {
     console.log(
-      `== Using secure accounts, please unlock an account for ${chainLabel}(${networkName})`,
+      `== Using secure accounts, please unlock an account for ${chainLabel}(${networkName}) - Caller is ${caller}`,
     )
   }
 

--- a/gre/type-extensions.d.ts
+++ b/gre/type-extensions.d.ts
@@ -12,6 +12,7 @@ export interface GraphRuntimeEnvironmentOptions {
   graphConfig?: string
   enableTxLogging?: boolean
   disableSecureAccounts?: boolean
+  fork?: boolean
 
   // These are mostly for testing purposes
   l1AccountName?: string

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -155,14 +155,12 @@ const config: HardhatUserConfig = {
         interval: 13000,
       },
       hardfork: 'london',
-      graphConfig: 'config/graph.localhost.yml',
     },
     localhost: {
       chainId: 1337,
       url: 'http://localhost:8545',
       accounts:
         process.env.FORK === 'true' ? getAccountsKeys() : { mnemonic: DEFAULT_TEST_MNEMONIC },
-      graphConfig: 'config/graph.localhost.yml',
     },
     localnitrol1: {
       chainId: 1337,
@@ -181,6 +179,7 @@ const config: HardhatUserConfig = {
     addressBook: process.env.ADDRESS_BOOK ?? 'addresses.json',
     l1GraphConfig: process.env.L1_GRAPH_CONFIG ?? 'config/graph.localhost.yml',
     l2GraphConfig: process.env.L2_GRAPH_CONFIG ?? 'config/graph.arbitrum-localhost.yml',
+    fork: process.env.FORK === 'true',
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "test:gas": "RUN_EVM=true REPORT_GAS=true scripts/test",
     "test:coverage": "scripts/coverage",
     "test:gre": "cd gre && mocha --exit --recursive 'test/**/*.test.ts' && cd ..",
+    "test:upgrade": "scripts/upgrade",
     "lint": "yarn lint:ts && yarn lint:sol",
     "lint:fix": "yarn lint:ts:fix && yarn lint:sol:fix",
     "lint:ts": "eslint '**/*.{js,ts}'",

--- a/scripts/evm
+++ b/scripts/evm
@@ -19,9 +19,31 @@ evm_ping() {
     }'
 }
 
+evm_automine() {
+  curl --location --request POST "localhost:$TESTRPC_PORT/" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+      "jsonrpc":"2.0",
+      "method":"evm_setAutomine",
+      "params":[true],
+      "id":1
+    }'
+    echo
+}
+
 evm_start() {
+  local FORK_URL=$1
+  local FORK_BLOCK_NUMBER="$2"
   echo "Starting our own evm instance at port $TESTRPC_PORT"
-  npx hardhat node --port "$TESTRPC_PORT" > /dev/null &
+  if [[ -n "$FORK_URL" ]]; then
+    if [[ "$FORK_BLOCK_NUMBER" == "latest" ]]; then
+      npx hardhat node --port "$TESTRPC_PORT" --fork "$FORK_URL" > /dev/null &
+    else
+      npx hardhat node --port "$TESTRPC_PORT" --fork "$FORK_URL" --fork-block-number "$FORK_BLOCK_NUMBER" > /dev/null &
+    fi
+  else
+    npx hardhat node --port "$TESTRPC_PORT" > /dev/null & 
+  fi
   retries=0
   while ! evm_ping $TESTRPC_PORT; do
     ((retries=retries+1))
@@ -31,6 +53,8 @@ evm_start() {
     fi
     sleep 1
   done
+
+  echo -e "\nEVM instance is ready"
 }
 
 evm_kill() {

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -94,7 +94,7 @@ FORK=true npx hardhat e2e:upgrade "$UPGRADE_NAME" \
 
 # Kill evm
 print_separator "Clean up"
-read -p "Upgrade test finished! Do you want to stop the evm? (Y/n) " yn
+read -p "Upgrade test finished! Do you want to keep the evm running? (y/N) " yn
 if [[ $yn != "y" ]]; then
   evm_kill
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -eo pipefail
+source $(pwd)/scripts/evm
+
+print_separator() {
+  echo -e "\n############################################################################################"
+  echo "# $1"
+  echo "############################################################################################"
+}
+
+### > SCRIPT CONFIG <
+FORK_URL=${FORK_URL}
+FORK_BLOCK_NUMBER=${FORK_BLOCK_NUMBER:-"latest"}
+CHAIN_ID=${CHAIN_ID}
+
+NETWORK=${NETWORK:-"mainnet"}
+ADDRESS_BOOK=${ADDRESS_BOOK:-"addresses.json"}
+GRAPH_CONFIG=${GRAPH_CONFIG:-"config/graph.mainnet.yml"}
+CONTRACT_NAME=${CONTRACT_NAME}
+UPGRADE_NAME=${UPGRADE_NAME}
+
+if [[ -z "$FORK_URL" ]]; then
+  if [[ -n "$INFURA_KEY" ]]; then
+    FORK_URL="https://mainnet.infura.io/v3/$INFURA_KEY"
+  else
+    echo "Must specify FORK_URL or INFURA_KEY!"
+    exit 0
+  fi
+fi
+
+if [[ -z "$CHAIN_ID" ]]; then
+  echo "Must specify CHAIN_ID you are forking from!"
+  exit 0
+fi
+
+if [[ -z "$CONTRACT_NAME" ]]; then
+  echo "Must specify CONTRACT_NAME to upgrade!"
+  exit 0
+fi
+
+if [[ -z "$UPGRADE_NAME" ]]; then
+  echo "Must specify UPGRADE_NAME to upgrade!"
+  exit 0
+fi
+
+print_separator "Running upgrade tests with config"
+echo "- Using forking URL: $FORK_URL"
+echo "- Forking from chain id: $CHAIN_ID"
+echo "- Fork block number: $FORK_BLOCK_NUMBER"
+echo "- Upgrading contract: $CONTRACT_NAME"
+echo "- Upgrade name: $UPGRADE_NAME"
+
+### > SCRIPT START < ###
+## SETUP
+# Compile contracts
+print_separator "Building contracts"
+yarn build
+
+# Build fork address book with actual contract addresses from the forked chain
+jq "{\"$CHAIN_ID\"} + {"\"1337\"": .\"$CHAIN_ID\"} | del(.\"$CHAIN_ID\")" $ADDRESS_BOOK > addresses-fork.json
+
+# Start evm - fork it!
+print_separator "Starting forked chain"
+evm_kill
+evm_start "$FORK_URL" "$FORK_BLOCK_NUMBER"
+evm_automine
+
+# Run pre-upgrade scripts
+print_separator "Running pre-upgrade scripts and tests"
+FORK=true npx hardhat e2e:upgrade "$UPGRADE_NAME" \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --disable-secure-accounts
+
+# Run upgrade
+print_separator "Upgrading contract"
+FORK=true npx hardhat contracts:upgrade \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --contract "${CONTRACT_NAME}" \
+  --disable-secure-accounts
+
+# Run post-upgrade scripts
+print_separator "Running post-upgrade scripts and tests"
+FORK=true npx hardhat e2e:upgrade "$UPGRADE_NAME" \
+  --network localhost \
+  --graph-config "${GRAPH_CONFIG}" \
+  --address-book addresses-fork.json \
+  --disable-secure-accounts \
+  --post
+
+# Kill evm
+print_separator "Clean up"
+read -p "Upgrade test finished! Do you want to stop the evm? (Y/n) " yn
+if [[ $yn != "y" ]]; then
+  evm_kill
+fi
+

--- a/tasks/contracts/upgrade.ts
+++ b/tasks/contracts/upgrade.ts
@@ -1,0 +1,42 @@
+import { task } from 'hardhat/config'
+
+import { cliOpts } from '../../cli/defaults'
+import { deployContractImplementationAndSave } from '../../cli/network'
+import { getAddressBook } from '../../cli/address-book'
+
+task('contracts:upgrade', 'Upgrades a contract')
+  .addParam('contract', 'Name of the contract to upgrade')
+  .addFlag('disableSecureAccounts', 'Disable secure accounts on GRE')
+  .addOptionalParam('graphConfig', cliOpts.graphConfig.description, cliOpts.graphConfig.default)
+  .addOptionalParam('addressBook', cliOpts.addressBook.description, cliOpts.addressBook.default)
+  .addOptionalVariadicPositionalParam(
+    'init',
+    'Initialization arguments for the contract constructor',
+  )
+  .setAction(async (taskArgs, hre) => {
+    const graph = hre.graph(taskArgs)
+
+    const { GraphProxyAdmin } = graph.contracts
+    const { governor } = await graph.getNamedAccounts()
+    const deployer = await graph.getDeployer()
+
+    const contract = graph.contracts[taskArgs.contract]
+    if (!contract) {
+      throw new Error(`Contract ${taskArgs.contract} not found in address book`)
+    }
+    console.log(`Upgrading ${taskArgs.contract}...`)
+
+    // Deploy new implementation
+    const implementation = await deployContractImplementationAndSave(
+      taskArgs.contract,
+      taskArgs.init || [],
+      deployer,
+      getAddressBook(taskArgs.addressBook, graph.chainId.toString()),
+    )
+    console.log(`New implementation deployed at ${implementation.address}`)
+
+    // Upgrade proxy and accept implementation
+    await GraphProxyAdmin.connect(governor).upgrade(contract.address, implementation.address)
+    await GraphProxyAdmin.connect(governor).acceptProxy(implementation.address, contract.address)
+    console.log(`Proxy upgraded to ${implementation.address}`)
+  })


### PR DESCRIPTION
This PR addresses OZ M-01 but also brings in the upgrade testing scripts from https://github.com/graphprotocol/contracts/pull/831 as they are required to perform e2e tests on forked chains to correctly evaluate upgrade state transitions.



**Notes from #831**
> This PR extends the e2e framework to include contract upgrade testing via a new script. Using a local fork from mainnet or other sources it allows writing tests to validate contract upgrades, state transitions, etc.
> 
> The script will:
> 
> - Run a hardhat node forking from an RPC (mainnet or any network)
> - Runs a user defined pre-upgrade script (in case it’s useful)
> - Runs a user defined pre-upgrade test script (here you can write tests like usual, using GRE, etc)
> - Upgrades the specified contract in the fork using the current directory source code (this includes impersonating governance to accept upgrades)
> - Runs a user defined post-upgrade script (here you might do things like contract configuration that requires the new implementation address, add it to callhook whitelist for example)
> - Runs a user defined post-upgrade test script (here you can write tests to validate the deployment, maybe if the upgrade was fixing a bug you can verify it)
> 
> An example can be found in e2e/upgrades/example.

