### PR TITLE
fix: pausing test for should fail partial pause if not guardian or governor

### DIFF
--- a/test/governance/pausing.test.ts
+++ b/test/governance/pausing.test.ts
@@ -65,8 +65,8 @@ describe('Pausing', () => {
     await setPartialPause(guardian, false)
   })
   it('should fail partial pause if not guardian or governor', async function () {
-    const tx = controller.connect(me.signer).setPauseGuardian(guardian.address)
-    await expect(tx).revertedWith('Only Governor can call')
+    const tx = controller.connect(me.signer).setPartialPaused(true)
+    await expect(tx).revertedWith('Only Governor or Guardian can call')
   })
   it('should check that a function fails when partialPause is set', async function () {
     await setPartialPause(governor, true)


### PR DESCRIPTION
There's currently two tests performing the same actions possibly due to a copy/paste error:

```javascript
it('should fail pause guardian when not governor', async function () {
  const tx = controller.connect(me.signer).setPauseGuardian(guardian.address)
  await expect(tx).revertedWith('Only Governor can call')
})

it('should fail partial pause if not guardian or governor', async function () {
  const tx = controller.connect(me.signer).setPauseGuardian(guardian.address)
  await expect(tx).revertedWith('Only Governor can call')
})
```

From test title looks like the second one is meant to be testing that a non governor/guardian shouldn't be able to set partial pause status.