### PR TITLE
Staking: fix Delegation.tokensLockedUntil code comment

### DIFF
--- a/contracts/staking/IStakingData.sol
+++ b/contracts/staking/IStakingData.sol
@@ -44,7 +44,7 @@ interface IStakingData {
     struct Delegation {
         uint256 shares; // Shares owned by a delegator in the pool
         uint256 tokensLocked; // Tokens locked for undelegation
-        uint256 tokensLockedUntil; // Block when locked tokens can be withdrawn
+        uint256 tokensLockedUntil; // Epoch when locked tokens can be withdrawn
     }
 
     /**


### PR DESCRIPTION
This came up in our Tenderize audits done by Halborn.