### PR TITLE
fix(GNS): use the correct token amount when curation or owner tax are zero

### DIFF
--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -731,6 +731,11 @@ abstract contract GNS is GNSV3Storage, GraphUpgradeable, IGNS, Multicall {
         address _owner,
         uint32 _curationTaxPercentage
     ) internal returns (uint256) {
+        // If curation or owner tax are zero, we don't need to charge owner tax
+        // so the amount of tokens to signal will remain the same.
+        // Note if owner tax is zero but curation tax is nonzero, the curation tax
+        // will still be charged (in Curation or L2Curation) - this function just calculates
+        // the owner's additional tax.
         if (_curationTaxPercentage == 0 || ownerTaxPercentage == 0) {
             return _tokens;
         }

--- a/contracts/discovery/GNS.sol
+++ b/contracts/discovery/GNS.sol
@@ -732,7 +732,7 @@ abstract contract GNS is GNSV3Storage, GraphUpgradeable, IGNS, Multicall {
         uint32 _curationTaxPercentage
     ) internal returns (uint256) {
         if (_curationTaxPercentage == 0 || ownerTaxPercentage == 0) {
-            return 0;
+            return _tokens;
         }
 
         // Tax on the total bonding curve funds

--- a/test/gns.test.ts
+++ b/test/gns.test.ts
@@ -420,6 +420,11 @@ describe('L1GNS', () => {
         await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
       })
 
+      it('should publish a new version on an existing subgraph when owner tax is zero', async function () {
+        await gns.connect(governor.signer).setOwnerTaxPercentage(0)
+        await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
+      })
+
       it('should publish a new version on an existing subgraph with no current signal', async function () {
         const emptySignalSubgraph = await publishNewSubgraph(me, buildSubgraph(), gns)
         await publishNewVersion(me, emptySignalSubgraph.id, newSubgraph1, gns, curation)

--- a/test/l2/l2GNS.test.ts
+++ b/test/l2/l2GNS.test.ts
@@ -165,6 +165,11 @@ describe('L2GNS', () => {
       await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
     })
 
+    it('should publish a new version on an existing subgraph when owner tax is zero', async function () {
+      await gns.connect(governor.signer).setOwnerTaxPercentage(0)
+      await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
+    })
+
     it('should publish a new version on an existing subgraph with no current signal', async function () {
       const emptySignalSubgraph = await publishNewSubgraph(me, buildSubgraph(), gns)
       await publishNewVersion(me, emptySignalSubgraph.id, newSubgraph1, gns, curation)


### PR DESCRIPTION
Before this fix, if curation or owner tax were zero, GNS would try to mint signal for the new version with zero tokens, which would revert.