### PR TITLE
fix: add gns and staking counter part addresses when configuring bridge

### DIFF
--- a/packages/contracts/cli/commands/protocol/configure-bridge.ts
+++ b/packages/contracts/cli/commands/protocol/configure-bridge.ts
@@ -49,6 +49,7 @@ export const configureL1Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   const l2GNSCounterpart = l2AddressBook.getEntry('L2GNS')
   logger.info('L2 GNS address: ' + l2GNSCounterpart.address)
   await sendTransaction(cli.wallet, gns, 'setCounterpartGNSAddress', [l2GNSCounterpart.address])
+  await sendTransaction(cli.wallet, gateway, 'addToCallhookAllowlist', [gns.address])
 
   // Staking
   const staking = cli.contracts.L1Staking
@@ -57,6 +58,7 @@ export const configureL1Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   await sendTransaction(cli.wallet, staking, 'setCounterpartStakingAddress', [
     l2StakingCounterpart.address,
   ])
+  await sendTransaction(cli.wallet, gateway, 'addToCallhookAllowlist', [staking.address])
 }
 
 export const configureL2Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {

--- a/packages/contracts/cli/commands/protocol/configure-bridge.ts
+++ b/packages/contracts/cli/commands/protocol/configure-bridge.ts
@@ -15,16 +15,20 @@ export const configureL1Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   const l2AddressBook = getAddressBook(cliArgs.addressBook, l2ChainId)
   const arbAddressBook = getAddressBook(cliArgs.arbAddressBook, cli.chainId.toString())
 
+  // Gateway
   const gateway = cli.contracts['L1GraphTokenGateway']
 
   const l2GRT = l2AddressBook.getEntry('L2GraphToken')
   logger.info('L2 GRT address: ' + l2GRT.address)
   await sendTransaction(cli.wallet, gateway, 'setL2TokenAddress', [l2GRT.address])
 
-  const l2Counterpart = l2AddressBook.getEntry('L2GraphTokenGateway')
-  logger.info('L2 Gateway address: ' + l2Counterpart.address)
-  await sendTransaction(cli.wallet, gateway, 'setL2CounterpartAddress', [l2Counterpart.address])
+  const l2GatewayCounterpart = l2AddressBook.getEntry('L2GraphTokenGateway')
+  logger.info('L2 Gateway address: ' + l2GatewayCounterpart.address)
+  await sendTransaction(cli.wallet, gateway, 'setL2CounterpartAddress', [
+    l2GatewayCounterpart.address,
+  ])
 
+  // Escrow
   const bridgeEscrow = cli.contracts.BridgeEscrow
   logger.info('Escrow address: ' + bridgeEscrow.address)
   await sendTransaction(cli.wallet, gateway, 'setEscrowAddress', [bridgeEscrow.address])
@@ -39,6 +43,20 @@ export const configureL1Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
     l1Inbox.address,
     l1Router.address,
   ])
+
+  // GNS
+  const gns = cli.contracts.L1GNS
+  const l2GNSCounterpart = l2AddressBook.getEntry('L2GNS')
+  logger.info('L2 GNS address: ' + l2GNSCounterpart.address)
+  await sendTransaction(cli.wallet, gns, 'setCounterpartGNSAddress', [l2GNSCounterpart.address])
+
+  // Staking
+  const staking = cli.contracts.L1Staking
+  const l2StakingCounterpart = l2AddressBook.getEntry('L2Staking')
+  logger.info('L2 Staking address: ' + l2StakingCounterpart.address)
+  await sendTransaction(cli.wallet, staking, 'setCounterpartStakingAddress', [
+    l2StakingCounterpart.address,
+  ])
 }
 
 export const configureL2Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): Promise<void> => {
@@ -52,6 +70,7 @@ export const configureL2Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
   const l1AddressBook = getAddressBook(cliArgs.addressBook, l1ChainId)
   const arbAddressBook = getAddressBook(cliArgs.arbAddressBook, cli.chainId.toString())
 
+  // Gateway
   const gateway = cli.contracts['L2GraphTokenGateway']
   const token = cli.contracts['L2GraphToken']
 
@@ -70,6 +89,20 @@ export const configureL2Bridge = async (cli: CLIEnvironment, cliArgs: CLIArgs): 
 
   logger.info('L2 Gateway address: ' + gateway.address)
   await sendTransaction(cli.wallet, token, 'setGateway', [gateway.address])
+
+  // GNS
+  const gns = cli.contracts.L2GNS
+  const l1GNSCounterpart = l1AddressBook.getEntry('L1GNS')
+  logger.info('L1 GNS address: ' + l1GNSCounterpart.address)
+  await sendTransaction(cli.wallet, gns, 'setCounterpartGNSAddress', [l1GNSCounterpart.address])
+
+  // Staking
+  const staking = cli.contracts.L2Staking
+  const l1StakingCounterpart = l1AddressBook.getEntry('L1Staking')
+  logger.info('L1 Staking address: ' + l1StakingCounterpart.address)
+  await sendTransaction(cli.wallet, staking, 'setCounterpartStakingAddress', [
+    l1StakingCounterpart.address,
+  ])
 }
 
 export const configureL1BridgeCommand = {

--- a/packages/contracts/e2e/deployment/config/l1/graphToken.test.ts
+++ b/packages/contracts/e2e/deployment/config/l1/graphToken.test.ts
@@ -1,4 +1,4 @@
-import { isGraphChainId } from '@graphprotocol/sdk'
+import { isGraphL2ChainId } from '@graphprotocol/sdk'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import hre from 'hardhat'
@@ -10,7 +10,7 @@ describe('[L1] GraphToken', () => {
   let unauthorized: SignerWithAddress
 
   before(async function () {
-    if (isGraphChainId(graph.chainId)) this.skip()
+    if (isGraphL2ChainId(graph.chainId)) this.skip()
     unauthorized = (await graph.getTestAccounts())[0]
   })
 

--- a/packages/contracts/e2e/deployment/config/l1/l1GNS.test.ts
+++ b/packages/contracts/e2e/deployment/config/l1/l1GNS.test.ts
@@ -5,7 +5,7 @@ import { isGraphL2ChainId } from '@graphprotocol/sdk'
 
 describe('[L1] GNS', () => {
   const graph = hre.graph()
-  const { L1GNS } = graph.contracts
+  const { L1GNS, L1GraphTokenGateway } = graph.contracts
 
   let unauthorized: SignerWithAddress
 
@@ -18,6 +18,11 @@ describe('[L1] GNS', () => {
     it('counterpartGNSAddress should match the L2GNS address', async () => {
       const l2GNS = await L1GNS.counterpartGNSAddress()
       expect(l2GNS).eq(graph.l2.contracts.L2GNS.address)
+    })
+
+    it('should be added to callhookAllowlist', async () => {
+      const isAllowed = await L1GraphTokenGateway.callhookAllowlist(L1GNS.address)
+      expect(isAllowed).true
     })
   })
 })

--- a/packages/contracts/e2e/deployment/config/l1/l1GNS.test.ts
+++ b/packages/contracts/e2e/deployment/config/l1/l1GNS.test.ts
@@ -1,0 +1,23 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+import { isGraphL2ChainId } from '@graphprotocol/sdk'
+
+describe('[L1] GNS', () => {
+  const graph = hre.graph()
+  const { L1GNS } = graph.contracts
+
+  let unauthorized: SignerWithAddress
+
+  before(async function () {
+    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    unauthorized = (await graph.getTestAccounts())[0]
+  })
+
+  describe('L1GNS', () => {
+    it('counterpartGNSAddress should match the L2GNS address', async () => {
+      const l2GNS = await L1GNS.counterpartGNSAddress()
+      expect(l2GNS).eq(graph.l2.contracts.L2GNS.address)
+    })
+  })
+})

--- a/packages/contracts/e2e/deployment/config/l1/l1Staking.test.ts
+++ b/packages/contracts/e2e/deployment/config/l1/l1Staking.test.ts
@@ -5,7 +5,7 @@ import { isGraphL2ChainId } from '@graphprotocol/sdk'
 
 describe('[L1] Staking', () => {
   const graph = hre.graph()
-  const { L1Staking } = graph.contracts
+  const { L1Staking, L1GraphTokenGateway } = graph.contracts
 
   let unauthorized: SignerWithAddress
 
@@ -20,6 +20,11 @@ describe('[L1] Staking', () => {
       const l2StakingData = await hre.ethers.provider.getStorageAt(L1Staking.address, 24)
       const l2Staking = hre.ethers.utils.defaultAbiCoder.decode(['address'], l2StakingData)[0]
       expect(l2Staking).eq(graph.l2.contracts.L2Staking.address)
+    })
+
+    it('should be added to callhookAllowlist', async () => {
+      const isAllowed = await L1GraphTokenGateway.callhookAllowlist(L1Staking.address)
+      expect(isAllowed).true
     })
   })
 })

--- a/packages/contracts/e2e/deployment/config/l1/l1Staking.test.ts
+++ b/packages/contracts/e2e/deployment/config/l1/l1Staking.test.ts
@@ -1,0 +1,25 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+import { isGraphL2ChainId } from '@graphprotocol/sdk'
+
+describe('[L1] Staking', () => {
+  const graph = hre.graph()
+  const { L1Staking } = graph.contracts
+
+  let unauthorized: SignerWithAddress
+
+  before(async function () {
+    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    unauthorized = (await graph.getTestAccounts())[0]
+  })
+
+  describe('L1Staking', () => {
+    it('counterpartStakingAddress should match the L2Staking address', async () => {
+      // counterpartStakingAddress is internal so we access the storage directly
+      const l2StakingData = await hre.ethers.provider.getStorageAt(L1Staking.address, 24)
+      const l2Staking = hre.ethers.utils.defaultAbiCoder.decode(['address'], l2StakingData)[0]
+      expect(l2Staking).eq(graph.l2.contracts.L2Staking.address)
+    })
+  })
+})

--- a/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { isGraphL2ChainId } from '@graphprotocol/sdk'
+import { isGraphL1ChainId } from '@graphprotocol/sdk'
 
 describe('[L2] GNS', () => {
   const graph = hre.graph()
@@ -10,7 +10,7 @@ describe('[L2] GNS', () => {
   let unauthorized: SignerWithAddress
 
   before(async function () {
-    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    if (isGraphL1ChainId(graph.chainId)) this.skip()
     unauthorized = (await graph.getTestAccounts())[0]
   })
 

--- a/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
@@ -1,0 +1,23 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+import { isGraphL2ChainId } from '@graphprotocol/sdk'
+
+describe('[L2] GNS', () => {
+  const graph = hre.graph()
+  const { L2GNS } = graph.contracts
+
+  let unauthorized: SignerWithAddress
+
+  before(async function () {
+    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    unauthorized = (await graph.getTestAccounts())[0]
+  })
+
+  describe('L2GNS', () => {
+    it('counterpartGNSAddress should match the L1GNS address', async () => {
+      const l1GNS = await L2GNS.counterpartGNSAddress()
+      expect(l1GNS).eq(graph.l1.contracts.L1GNS.address)
+    })
+  })
+})

--- a/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2GNS.test.ts
@@ -5,7 +5,7 @@ import { isGraphL2ChainId } from '@graphprotocol/sdk'
 
 describe('[L2] GNS', () => {
   const graph = hre.graph()
-  const { L2GNS } = graph.contracts
+  const { L2GNS } = graph.l2.contracts
 
   let unauthorized: SignerWithAddress
 

--- a/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
@@ -5,7 +5,7 @@ import { isGraphL2ChainId } from '@graphprotocol/sdk'
 
 describe('[L2] Staking', () => {
   const graph = hre.graph()
-  const { L2Staking } = graph.contracts
+  const { L2Staking } = graph.l2.contracts
 
   let unauthorized: SignerWithAddress
 

--- a/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
@@ -1,0 +1,25 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+import { isGraphL2ChainId } from '@graphprotocol/sdk'
+
+describe('[L2] Staking', () => {
+  const graph = hre.graph()
+  const { L2Staking } = graph.contracts
+
+  let unauthorized: SignerWithAddress
+
+  before(async function () {
+    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    unauthorized = (await graph.getTestAccounts())[0]
+  })
+
+  describe('L2Staking', () => {
+    it('counterpartStakingAddress should match the L1Staking address', async () => {
+      // counterpartStakingAddress is internal so we access the storage directly
+      const l1StakingData = await hre.ethers.provider.getStorageAt(L2Staking.address, 24)
+      const l1Staking = hre.ethers.utils.defaultAbiCoder.decode(['address'], l1StakingData)[0]
+      expect(l1Staking).eq(graph.l1.contracts.L1Staking.address)
+    })
+  })
+})

--- a/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
+++ b/packages/contracts/e2e/deployment/config/l2/l2Staking.test.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { isGraphL2ChainId } from '@graphprotocol/sdk'
+import { isGraphL1ChainId } from '@graphprotocol/sdk'
 
 describe('[L2] Staking', () => {
   const graph = hre.graph()
@@ -10,7 +10,7 @@ describe('[L2] Staking', () => {
   let unauthorized: SignerWithAddress
 
   before(async function () {
-    if (isGraphL2ChainId(graph.chainId)) this.skip()
+    if (isGraphL1ChainId(graph.chainId)) this.skip()
     unauthorized = (await graph.getTestAccounts())[0]
   })
 

--- a/packages/contracts/tasks/bridge/configure.ts
+++ b/packages/contracts/tasks/bridge/configure.ts
@@ -32,6 +32,8 @@ task(TASK_BRIDGE_CONFIGURE_L1, 'Configure L1 bridge')
     await configureL1Bridge(graph.contracts, governor, {
       l2GRTAddress: graph.l2.contracts.GraphToken.address,
       l2GRTGatewayAddress: graph.l2.contracts.L2GraphTokenGateway.address,
+      l2GNSAddress: graph.l2.contracts.L2GNS.address,
+      l2StakingAddress: graph.l2.contracts.L2Staking.address,
       arbAddressBookPath: taskArgs.arbitrumAddressBook,
       chainId: graph.chainId,
     })
@@ -60,6 +62,8 @@ task(TASK_BRIDGE_CONFIGURE_L2, 'Configure L2 bridge')
     await configureL2Bridge(graph.contracts, governor, {
       l1GRTAddress: graph.l1.contracts.GraphToken.address,
       l1GRTGatewayAddress: graph.l1.contracts.L1GraphTokenGateway.address,
+      l1GNSAddress: graph.l1.contracts.L1GNS.address,
+      l1StakingAddress: graph.l1.contracts.L1Staking.address,
       arbAddressBookPath: taskArgs.arbitrumAddressBook,
       chainId: graph.chainId,
     })

--- a/packages/sdk/src/deployments/network/actions/bridge-config.ts
+++ b/packages/sdk/src/deployments/network/actions/bridge-config.ts
@@ -22,7 +22,14 @@ export const configureL1Bridge: GraphNetworkAction<{
     chainId: number
   },
 ): Promise<void> => {
-  const { l2GRTAddress, l2GRTGatewayAddress, l2GNSAddress, l2StakingAddress, arbAddressBookPath, chainId } = args
+  const {
+    l2GRTAddress,
+    l2GRTGatewayAddress,
+    l2GNSAddress,
+    l2StakingAddress,
+    arbAddressBookPath,
+    chainId,
+  } = args
   console.info(`>>> Setting L1 Bridge Configuration <<<\n`)
 
   const arbAddressBook = new SimpleAddressBook(arbAddressBookPath, chainId)
@@ -83,7 +90,14 @@ export const configureL2Bridge: GraphNetworkAction<{
     chainId: number
   },
 ): Promise<void> => {
-  const { l1GRTAddress, l1GRTGatewayAddress, l1GNSAddress, l1StakingAddress, arbAddressBookPath, chainId } = args
+  const {
+    l1GRTAddress,
+    l1GRTGatewayAddress,
+    l1GNSAddress,
+    l1StakingAddress,
+    arbAddressBookPath,
+    chainId,
+  } = args
   console.info(`>>> Setting L2 Bridge Configuration <<<\n`)
 
   const arbAddressBook = new SimpleAddressBook(arbAddressBookPath, chainId)

--- a/packages/sdk/src/deployments/network/actions/bridge-config.ts
+++ b/packages/sdk/src/deployments/network/actions/bridge-config.ts
@@ -6,6 +6,8 @@ import { SimpleAddressBook } from '../../lib/address-book'
 export const configureL1Bridge: GraphNetworkAction<{
   l2GRTAddress: string
   l2GRTGatewayAddress: string
+  l2GNSAddress: string
+  l2StakingAddress: string
   arbAddressBookPath: string
   chainId: number
 }> = async (
@@ -14,23 +16,27 @@ export const configureL1Bridge: GraphNetworkAction<{
   args: {
     l2GRTAddress: string
     l2GRTGatewayAddress: string
+    l2GNSAddress: string
+    l2StakingAddress: string
     arbAddressBookPath: string
     chainId: number
   },
 ): Promise<void> => {
-  const { l2GRTAddress, l2GRTGatewayAddress, arbAddressBookPath, chainId } = args
+  const { l2GRTAddress, l2GRTGatewayAddress, l2GNSAddress, l2StakingAddress, arbAddressBookPath, chainId } = args
   console.info(`>>> Setting L1 Bridge Configuration <<<\n`)
 
   const arbAddressBook = new SimpleAddressBook(arbAddressBookPath, chainId)
 
   const gateway = contracts.L1GraphTokenGateway!
 
+  // Gateway
   console.info('L2 GRT address: ' + l2GRTAddress)
   await gateway.connect(signer).setL2TokenAddress(l2GRTAddress)
 
   console.info('L2 Gateway address: ' + l2GRTGatewayAddress)
   await gateway.connect(signer).setL2CounterpartAddress(l2GRTGatewayAddress)
 
+  // Escrow
   const bridgeEscrow = contracts.BridgeEscrow!
   console.info('Escrow address: ' + bridgeEscrow.address)
   await gateway.connect(signer).setEscrowAddress(bridgeEscrow.address)
@@ -42,11 +48,27 @@ export const configureL1Bridge: GraphNetworkAction<{
     'L1 Inbox address: ' + l1Inbox.address + ' and L1 Router address: ' + l1Router.address,
   )
   await gateway.connect(signer).setArbitrumAddresses(l1Inbox.address, l1Router.address)
+
+  // GNS
+  const gns = contracts.L1GNS!
+  console.info('GNS address: ' + gns.address)
+  console.info('L2 GNS address: ' + l2GNSAddress)
+  await gns.connect(signer).setCounterpartGNSAddress(l2GNSAddress)
+  await gateway.connect(signer).addToCallhookAllowlist(gns.address)
+
+  // Staking
+  const staking = contracts.L1Staking!
+  console.info('Staking address: ' + staking.address)
+  console.info('L2 Staking address: ' + l2StakingAddress)
+  await staking.connect(signer).setCounterpartStakingAddress(l2StakingAddress)
+  await gateway.connect(signer).addToCallhookAllowlist(staking.address)
 }
 
 export const configureL2Bridge: GraphNetworkAction<{
   l1GRTAddress: string
   l1GRTGatewayAddress: string
+  l1GNSAddress: string
+  l1StakingAddress: string
   arbAddressBookPath: string
   chainId: number
 }> = async (
@@ -55,11 +77,13 @@ export const configureL2Bridge: GraphNetworkAction<{
   args: {
     l1GRTAddress: string
     l1GRTGatewayAddress: string
+    l1GNSAddress: string
+    l1StakingAddress: string
     arbAddressBookPath: string
     chainId: number
   },
 ): Promise<void> => {
-  const { l1GRTAddress, l1GRTGatewayAddress, arbAddressBookPath, chainId } = args
+  const { l1GRTAddress, l1GRTGatewayAddress, l1GNSAddress, l1StakingAddress, arbAddressBookPath, chainId } = args
   console.info(`>>> Setting L2 Bridge Configuration <<<\n`)
 
   const arbAddressBook = new SimpleAddressBook(arbAddressBookPath, chainId)
@@ -67,6 +91,7 @@ export const configureL2Bridge: GraphNetworkAction<{
   const gateway = contracts.L2GraphTokenGateway!
   const token = contracts.L2GraphToken!
 
+  // Gateway
   console.info('L1 GRT address: ' + l1GRTAddress)
   await gateway.connect(signer).setL1TokenAddress(l1GRTAddress)
   await token.connect(signer).setL1Address(l1GRTAddress)
@@ -80,4 +105,16 @@ export const configureL2Bridge: GraphNetworkAction<{
 
   console.info('L2 Gateway address: ' + gateway.address)
   await token.connect(signer).setGateway(gateway.address)
+
+  // GNS
+  const gns = contracts.L2GNS!
+  console.info('GNS address: ' + gns.address)
+  console.info('L1 GNS address: ' + l1GNSAddress)
+  await gns.connect(signer).setCounterpartGNSAddress(l1GNSAddress)
+
+  // Staking
+  const staking = contracts.L2Staking!
+  console.info('Staking address: ' + staking.address)
+  console.info('L1 Staking address: ' + l1StakingAddress)
+  await staking.connect(signer).setCounterpartStakingAddress(l1StakingAddress)
 }


### PR DESCRIPTION
Added missing configs on bridge setup, included checks in e2e tests. 
- Set `counterpartGNSAddress` on L1 and L2
- Set `counterpartStakingAddress` on L1 and L2
- Added `L1GNS` and `L1Staking` to `L1GraphTokenGateway.callhookAllowlist`