### PR TITLE
chore: add array to constructor argument types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn-error.log*
 node_modules/
 
 # Yarn
-.yarn/*
+.yarn/
 !.yarn/patches
 !.yarn/releases
 !.yarn/plugins

--- a/packages/sdk/src/deployments/lib/deploy/contract.ts
+++ b/packages/sdk/src/deployments/lib/deploy/contract.ts
@@ -103,10 +103,18 @@ export const deployContractAndSave: DeployAddressBookFunction = async (
     args: args,
   })
 
+  const constructorArgs = args.map((e) => {
+    if (Array.isArray(e)) {
+      return e.map((e) => e.toString())
+    } else {
+      return e.toString()
+    }
+  })
+
   // Save address entry
   addressBook.setEntry(name, {
     address: deployResult.contract.address,
-    constructorArgs: args.length === 0 ? undefined : args.map((e) => e.toString()),
+    constructorArgs: constructorArgs,
     creationCodeHash: deployResult.creationCodeHash,
     runtimeCodeHash: deployResult.runtimeCodeHash,
     txHash: deployResult.txHash,

--- a/packages/sdk/src/deployments/lib/types/address-book.ts
+++ b/packages/sdk/src/deployments/lib/types/address-book.ts
@@ -14,9 +14,11 @@ export type AddressBookJson<
   ContractName extends string = string,
 > = Record<ChainId, Record<ContractName, AddressBookEntry>>
 
+export type ConstructorArg = string | Array<string>
+
 export type AddressBookEntry = {
   address: string
-  constructorArgs?: Array<string>
+  constructorArgs?: Array<ConstructorArg>
   initArgs?: Array<string>
   proxy?: boolean
   implementation?: AddressBookEntry


### PR DESCRIPTION
Currently when using an array in constructor params the result for `address.json` is:

```json
"SubgraphAvailabilityManager": {
  "address": "0xcA8B14d9FA8F2a7347782e6B8F334093DCc3789F",
  "constructorArgs": [
    "0x559081D91F5Ff43dfE51A07C216F8E6893805B35",
    "0x9a86322dEa5136C74ee6d1b06F4Ab9A6bB2724E0",
    "5",
    "300",
    "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D,0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D,0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D,0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D,0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D"
  ],
  "creationCodeHash": "0x70ff001c11d5120782503f0d129f388d8800571f7e9dfbc81bbff048e3a58444",
  "runtimeCodeHash": "0x237aca4c61c6d9b391322c0b24e2d26d9d540787507c6d30c474c86866b15dea",
  "txHash": "0x66bbfcd338ccdf519ebde1b1656a0dc2716191d49ffdf85986572f65f39cca8f"
}
```

Note that the last parameter is a concatenated string with all the array values but we need it to be an array for when we verify the contract. With this change the result is:

```json
"SubgraphAvailabilityManager": {
  "address": "0x8fa39178Bdf76aca23635FF343BeeED7aA1D45ec",
  "constructorArgs": [
    "0x559081D91F5Ff43dfE51A07C216F8E6893805B35",
    "0x9a86322dEa5136C74ee6d1b06F4Ab9A6bB2724E0",
    "5",
    "300",
    [
      "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D",
      "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D",
      "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D",
      "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D",
      "0x840daec5dF962D49cf2EFd789c4E40A7b7e0117D"
    ]
  ],
  "creationCodeHash": "0x70ff001c11d5120782503f0d129f388d8800571f7e9dfbc81bbff048e3a58444",
  "runtimeCodeHash": "0x237aca4c61c6d9b391322c0b24e2d26d9d540787507c6d30c474c86866b15dea",
  "txHash": "0xf68af53d379c9ffbfa4794d5226fcd92e95bbce7017f5eefaacd147d0f5f40bc"
}
```