### PR TITLE
fix: correctly pass ts file list to tsc in prepack

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphprotocol/contracts
 
+## 6.1.2
+
+### Patch Changes
+
+- Correctly pass ts file list to tsc in prepack
+
 ## 6.1.1
 
 ### Patch Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/contracts",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Contracts for the Graph Protocol",
   "directories": {
     "test": "test"

--- a/packages/contracts/scripts/prepack
+++ b/packages/contracts/scripts/prepack
@@ -9,15 +9,11 @@ yarn clean
 yarn build
 
 # Refresh distribution folder
-rm -rf dist && mkdir -p dist/types/_src
+rm -rf dist && mkdir -p ${TYPECHAIN_DIR}
 cp -R build/abis/ dist/abis
-cp -R build/types/ dist/types/_src
-
-### Build Typechain bindings
+cp -R build/types/ ${TYPECHAIN_DIR}
 
 # Build and create TS declarations
-tsc -d ${TYPECHAIN_DIR}/_src/*.ts --outdir ${TYPECHAIN_DIR} --esModuleInterop
-# Copy back sources
-cp ${TYPECHAIN_DIR}/_src/*.ts ${TYPECHAIN_DIR}
-# Delete temporary src dir
-rm -rf ${TYPECHAIN_DIR}/_src
+pushd ${TYPECHAIN_DIR}
+ls *.ts **/*.ts | xargs tsc --esModuleInterop
+popd


### PR DESCRIPTION
For some reason the publish Action was failing as it was incorrectly interpreting the `*.ts` glob as a filename.