### PR TITLE
test: add _curationTaxPercentage 0 case

### DIFF
--- a/packages/contracts/test/unit/gns.test.ts
+++ b/packages/contracts/test/unit/gns.test.ts
@@ -420,6 +420,11 @@ describe('L1GNS', () => {
         await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
       })
 
+      it('should publish a new version on an existing subgraph when curation tax percentage is zero', async function () {
+        await curation.connect(governor).setCurationTaxPercentage(0)
+        await publishNewVersion(me, subgraph.id, newSubgraph1, gns, curation)
+      })
+
       it('should publish a new version on an existing subgraph with no current signal', async function () {
         const emptySignalSubgraph = await publishNewSubgraph(
           me,


### PR DESCRIPTION
This Pull Request adds a test case to ensure that the subgraph upgrade does not revert when _curationTaxPercentage is set to 0.

Resolves #891