### PR TITLE
chore: ensure yarn doesnt hoist packages past the workspace level

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+nmHoistingLimits: workspaces


### PR DESCRIPTION
This fixes problems with dependencies incorrectly declaring deps and messing up hoisting at the root level.

Commit was cherry picked from `horizon` branch.