### PR TITLE
feat(eslint): properly ignore paths in ignores config

### DIFF
--- a/packages/eslint-graph-config/README.md
+++ b/packages/eslint-graph-config/README.md
@@ -40,6 +40,12 @@ module.exports = [
       '@typescript-eslint/no-unsafe-argument': 'off',
     },
   },
+  {
+    ignores: [
+      'library/*',                // ignore its contents
+      '!node_modules/mylibrary/'  // unignore `node_modules/mylibrary` directory
+    ]
+  }
 ]
 ```
 

--- a/packages/eslint-graph-config/index.ts
+++ b/packages/eslint-graph-config/index.ts
@@ -31,7 +31,6 @@ export default [
       'no-only-tests': noOnlyTests,
       'no-secrets': noSecrets,
     },
-    ignores: ['dist/*', 'node_modules/*', 'build/*'],
     rules: {
       'prefer-const': 'warn',
       '@typescript-eslint/no-inferrable-types': 'warn',
@@ -46,5 +45,8 @@ export default [
         }],
       '@stylistic/brace-style': ['error', '1tbs'],
     },
+  },
+  {
+    ignores: ['**/dist/*', '**/node_modules/*', '**/build/*', '**/cache/*', '**/.graphclient/*'],
   },
 ]

--- a/packages/token-distribution/deploy/1_test.ts
+++ b/packages/token-distribution/deploy/1_test.ts
@@ -2,14 +2,14 @@ import { utils } from 'ethers'
 import consola from 'consola'
 
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { DeployFunction } from 'hardhat-deploy/types'
+import { DeployFunction, DeployOptions } from 'hardhat-deploy/types'
 
 const { parseEther } = utils
 
 const logger = consola.create({})
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deploy } = hre.deployments
+  const deploy = (name: string, options: DeployOptions) => hre.deployments.deploy(name, options)
   const { deployer } = await hre.getNamedAccounts()
 
   // -- Fake Graph Token --

--- a/packages/token-distribution/deploy/2_l1_manager_wallet.ts
+++ b/packages/token-distribution/deploy/2_l1_manager_wallet.ts
@@ -3,7 +3,7 @@ import { utils } from 'ethers'
 
 import '@nomiclabs/hardhat-ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { DeployFunction } from 'hardhat-deploy/types'
+import { DeployFunction, DeployOptions } from 'hardhat-deploy/types'
 
 import { GraphTokenMock } from '../build/typechain/contracts/GraphTokenMock'
 import { GraphTokenLockManager } from '../build/typechain/contracts/GraphTokenLockManager'
@@ -14,7 +14,7 @@ const { parseEther, formatEther } = utils
 const logger = consola.create({})
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deploy } = hre.deployments
+  const deploy = (name: string, options: DeployOptions) => hre.deployments.deploy(name, options)
   const { deployer } = await hre.getNamedAccounts()
 
   // -- Graph Token --

--- a/packages/token-distribution/deploy/3_l2_wallet.ts
+++ b/packages/token-distribution/deploy/3_l2_wallet.ts
@@ -1,15 +1,14 @@
 import consola from 'consola'
 import '@nomiclabs/hardhat-ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { DeployFunction } from 'hardhat-deploy/types'
+import { DeployFunction, DeployOptions } from 'hardhat-deploy/types'
 
 import { getDeploymentName } from './lib/utils'
-
 
 const logger = consola.create({})
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deploy } = hre.deployments
+  const deploy = (name: string, options: DeployOptions) => hre.deployments.deploy(name, options)
   const { deployer } = await hre.getNamedAccounts()
 
   // Deploy the master copy of GraphTokenLockWallet

--- a/packages/token-distribution/deploy/4_l1_transfer_tool.ts
+++ b/packages/token-distribution/deploy/4_l1_transfer_tool.ts
@@ -1,5 +1,4 @@
 import consola from 'consola'
-import { utils } from 'ethers'
 
 import '@nomiclabs/hardhat-ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -50,12 +49,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     owner = deployer
     logger.warn(`No owner address provided, will use the deployer address as owner: ${owner}`)
   }
-  
+
   // Deploy the L1GraphTokenLockTransferTool with a proxy.
   // hardhat-deploy doesn't get along with constructor arguments in the implementation
   // combined with an OpenZeppelin transparent proxy, so we need to do this using
   // the OpenZeppelin hardhat-upgrades tooling, and save the deployment manually.
-  
+
   // TODO modify this to use upgradeProxy if a deployment already exists?
   logger.info('Deploying L1GraphTokenLockTransferTool proxy...')
   const transferToolFactory = await ethers.getContractFactory('L1GraphTokenLockTransferTool')

--- a/packages/token-distribution/deploy/5_l2_manager.ts
+++ b/packages/token-distribution/deploy/5_l2_manager.ts
@@ -3,7 +3,7 @@ import { utils } from 'ethers'
 
 import '@nomiclabs/hardhat-ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { DeployFunction } from 'hardhat-deploy/types'
+import { DeployFunction, DeployOptions } from 'hardhat-deploy/types'
 
 import { GraphTokenMock } from '../build/typechain/contracts/GraphTokenMock'
 import { askConfirm, getDeploymentName, promptContractAddress } from './lib/utils'
@@ -14,7 +14,7 @@ const { parseEther, formatEther } = utils
 const logger = consola.create({})
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deploy } = hre.deployments
+  const deploy = (name: string, options: DeployOptions) => hre.deployments.deploy(name, options)
   const { deployer } = await hre.getNamedAccounts()
 
   // -- Graph Token --

--- a/packages/token-distribution/deploy/6_l2_transfer_tool.ts
+++ b/packages/token-distribution/deploy/6_l2_transfer_tool.ts
@@ -1,5 +1,4 @@
 import consola from 'consola'
-import { utils } from 'ethers'
 
 import '@nomiclabs/hardhat-ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -18,8 +17,6 @@ const artifacts = new Artifacts(ARTIFACTS_PATH)
 const l2TransferToolAbi = artifacts.readArtifactSync('L2GraphTokenLockTransferTool').abi
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer } = await hre.getNamedAccounts()
-
   // -- Graph Token --
 
   // Get the addresses we will use
@@ -40,12 +37,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     logger.warn('No L1 GRT address provided')
     process.exit(1)
   }
-  
+
   // Deploy the L2GraphTokenLockTransferTool with a proxy.
   // hardhat-deploy doesn't get along with constructor arguments in the implementation
   // combined with an OpenZeppelin transparent proxy, so we need to do this using
   // the OpenZeppelin hardhat-upgrades tooling, and save the deployment manually.
-  
+
   // TODO modify this to use upgradeProxy if a deployment already exists?
   logger.info('Deploying L2GraphTokenLockTransferTool proxy...')
   const transferToolFactory = await ethers.getContractFactory('L2GraphTokenLockTransferTool')

--- a/packages/token-distribution/deploy/lib/utils.ts
+++ b/packages/token-distribution/deploy/lib/utils.ts
@@ -12,10 +12,10 @@ export const askConfirm = async (message: string) => {
     type: 'confirm',
     message,
   })
-  return res.confirm
+  return res.confirm ? res.confirm as boolean : false
 }
 
-export const promptContractAddress = async (name: string, logger: Consola): Promise<string|null> => {
+export const promptContractAddress = async (name: string, logger: Consola): Promise<string | null> => {
   const res1 = await inquirer.prompt({
     name: 'contract',
     type: 'input',
@@ -37,5 +37,5 @@ export const getDeploymentName = async (defaultName: string): Promise<string> =>
     default: defaultName,
     message: 'Save deployment as?',
   })
-  return res['deployment-name']
+  return res['deployment-name'] as string
 }

--- a/packages/token-distribution/hardhat.config.ts
+++ b/packages/token-distribution/hardhat.config.ts
@@ -80,6 +80,7 @@ function setupNetworkConfig(config) {
 
 // Env
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 extendEnvironment(async (hre) => {
   const accounts = await hre.ethers.getSigners()
   try {
@@ -152,7 +153,6 @@ const config = {
     },
   },
   etherscan: {
-    //url: process.env.ETHERSCAN_API_URL,
     apiKey: process.env.ETHERSCAN_API_KEY,
     customChains: [
       {
@@ -163,7 +163,7 @@ const config = {
           browserURL: 'https://sepolia.arbiscan.io',
         },
       },
-    ]
+    ],
   },
   typechain: {
     outDir: 'build/typechain/contracts',

--- a/packages/token-distribution/ops/create.ts
+++ b/packages/token-distribution/ops/create.ts
@@ -2,7 +2,7 @@ import PQueue from 'p-queue'
 import fs from 'fs'
 import consola from 'consola'
 import inquirer from 'inquirer'
-import { utils, BigNumber, Event, ContractTransaction, ContractReceipt, Contract, ContractFactory } from 'ethers'
+import { BigNumber, Contract, ContractFactory, ContractReceipt, ContractTransaction, Event, utils } from 'ethers'
 
 import { NonceManager } from '@ethersproject/experimental'
 import { task } from 'hardhat/config'
@@ -47,7 +47,7 @@ export const askConfirm = async () => {
     type: 'confirm',
     message: `Are you sure you want to proceed?`,
   })
-  return res.confirm
+  return res.confirm ? res.confirm as boolean : false
 }
 
 const isValidAddress = (address: string) => {
@@ -68,10 +68,10 @@ export const isValidAddressOrFail = (address: string) => {
 
 const loadDeployData = (filepath: string): TokenLockConfigEntry[] => {
   const data = fs.readFileSync(filepath, 'utf8')
-  const entries = data.split('\n').map((e) => e.trim())
+  const entries = data.split('\n').map(e => e.trim())
   entries.shift() // remove the title from the csv
   return entries
-    .filter((entryData) => !!entryData)
+    .filter(entryData => !!entryData)
     .map((entryData) => {
       const entry = entryData.split(',')
       return {
@@ -89,9 +89,9 @@ const loadDeployData = (filepath: string): TokenLockConfigEntry[] => {
 
 const loadResultData = (filepath: string): TokenLockConfigEntry[] => {
   const data = fs.readFileSync(filepath, 'utf8')
-  const entries = data.split('\n').map((e) => e.trim())
+  const entries = data.split('\n').map(e => e.trim())
   return entries
-    .filter((entryData) => !!entryData)
+    .filter(entryData => !!entryData)
     .map((entryData) => {
       const entry = entryData.split(',')
       return {
@@ -246,7 +246,7 @@ const populateEntries = async (
   tokenAddress: string,
   ownerAddress: string,
 ) => {
-  const results = []
+  const results: TokenLockConfigEntry[] = []
   for (const entry of entries) {
     entry.owner = ownerAddress
     entry.salt = await calculateSalt(hre, entry, managerAddress, tokenAddress)
@@ -323,7 +323,7 @@ task('create-token-locks', 'Create token lock contracts from file')
     entries = await populateEntries(hre, entries, manager.address, tokenAddress, taskArgs.ownerAddress)
 
     // Filter out already deployed ones
-    entries = entries.filter((entry) => !deployedEntries.find((deployedEntry) => deployedEntry.salt === entry.salt))
+    entries = entries.filter(entry => !deployedEntries.find(deployedEntry => deployedEntry.salt === entry.salt))
     logger.success(`Total of ${entries.length} entries after removing already deployed. All good!`)
     if (entries.length === 0) {
       logger.warn('Nothing new to deploy')
@@ -378,7 +378,7 @@ task('create-token-locks', 'Create token lock contracts from file')
       const queue = new PQueue({ concurrency: 6 })
 
       for (const entry of entries) {
-        queue.add(async () => {
+        await queue.add(async () => {
           logger.log('')
           logger.info(`Creating contract...`)
           logger.log(prettyConfigEntry(entry))

--- a/packages/token-distribution/ops/delete.ts
+++ b/packages/token-distribution/ops/delete.ts
@@ -1,6 +1,6 @@
 import { task } from 'hardhat/config'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { prettyEnv, askConfirm, waitTransaction } from './create'
+import { askConfirm, prettyEnv, waitTransaction } from './create'
 import consola from 'consola'
 import { TxBuilder } from './tx-builder'
 

--- a/packages/token-distribution/ops/tx-builder.ts
+++ b/packages/token-distribution/ops/tx-builder.ts
@@ -1,8 +1,22 @@
 import fs from 'fs'
 import path from 'path'
 
+export interface BuilderTx {
+  to: string
+  data: string
+  value: number | string
+  contractMethod?: null
+  contractInputsValues?: null
+}
+
+interface TxBuilderContents {
+  createdAt: number
+  chainId: string
+  transactions: BuilderTx[]
+}
+
 export class TxBuilder {
-  contents: any
+  contents: TxBuilderContents
   outputFile: string
 
   constructor(chainId: string, _template?: string) {
@@ -20,7 +34,7 @@ export class TxBuilder {
     this.contents.chainId = chainId
   }
 
-  addTx(tx: any) {
+  addTx(tx: BuilderTx) {
     this.contents.transactions.push({ ...tx, contractMethod: null, contractInputsValues: null })
   }
 

--- a/packages/token-distribution/package.json
+++ b/packages/token-distribution/package.json
@@ -13,7 +13,7 @@
     "test:gas": "RUN_EVM=true REPORT_GAS=true scripts/test",
     "test:coverage": "scripts/coverage",
     "lint": "yarn run lint:ts && yarn run lint:sol",
-    "lint:ts": "eslint 'test/**/*.{js,ts}' --fix",
+    "lint:ts": "eslint '**/*.{js,ts}' --fix",
     "lint:sol": "prettier --write contracts/**/*.sol && solhint --fix contracts/**/*.sol --config node_modules/solhint-graph-config/index.js",
     "security": "scripts/security",
     "flatten": "scripts/flatten",

--- a/packages/token-distribution/tsconfig.json
+++ b/packages/token-distribution/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "exclude": ["dist", "node_modules"],
   "include": [
+    ".solcover.js",
     "eslint.config.js",
     "prettier.config.js",
     "./hardhat.config.ts",


### PR DESCRIPTION
Previously the `ignores` key was only being applied to the rules on the custom configuration object, this change forces the ignored paths to apply to all rules.

Also linting some files in `token-distribution` which were incorrectly ignored.