### PR TITLE
fix: add security contact to various contract NatSpecs (OZ N-03)

### DIFF
--- a/packages/horizon/contracts/payments/GraphPayments.sol
+++ b/packages/horizon/contracts/payments/GraphPayments.sol
@@ -16,6 +16,7 @@ import { GraphDirectory } from "../utilities/GraphDirectory.sol";
  * @notice This contract is part of the Graph Horizon payments protocol. It's designed
  * to pull funds (GRT) from the {PaymentsEscrow} and distribute them according to a
  * set of pre established rules.
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract GraphPayments is Initializable, MulticallUpgradeable, GraphDirectory, IGraphPayments {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/payments/GraphPayments.sol
+++ b/packages/horizon/contracts/payments/GraphPayments.sol
@@ -16,7 +16,8 @@ import { GraphDirectory } from "../utilities/GraphDirectory.sol";
  * @notice This contract is part of the Graph Horizon payments protocol. It's designed
  * to pull funds (GRT) from the {PaymentsEscrow} and distribute them according to a
  * set of pre established rules.
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract GraphPayments is Initializable, MulticallUpgradeable, GraphDirectory, IGraphPayments {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -17,6 +17,7 @@ import { GraphDirectory } from "../utilities/GraphDirectory.sol";
  * @notice This contract is part of the Graph Horizon payments protocol. It holds the funds (GRT)
  * for payments made through the payments protocol for services provided
  * via a Graph Horizon data service.
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, IPaymentsEscrow {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -17,7 +17,8 @@ import { GraphDirectory } from "../utilities/GraphDirectory.sol";
  * @notice This contract is part of the Graph Horizon payments protocol. It holds the funds (GRT)
  * for payments made through the payments protocol for services provided
  * via a Graph Horizon data service.
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, IPaymentsEscrow {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/payments/collectors/TAPCollector.sol
+++ b/packages/horizon/contracts/payments/collectors/TAPCollector.sol
@@ -17,7 +17,8 @@ import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
  * @dev Note that the contract expects the RAV aggregate value to be monotonically increasing, each successive RAV for the same
  * (data service-payer-receiver) tuple should have a value greater than the previous one. The contract will keep track of the tokens
  * already collected and calculate the difference to collect.
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract TAPCollector is EIP712, GraphDirectory, ITAPCollector {
     using PPMMath for uint256;

--- a/packages/horizon/contracts/payments/collectors/TAPCollector.sol
+++ b/packages/horizon/contracts/payments/collectors/TAPCollector.sol
@@ -17,6 +17,7 @@ import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
  * @dev Note that the contract expects the RAV aggregate value to be monotonically increasing, each successive RAV for the same
  * (data service-payer-receiver) tuple should have a value greater than the previous one. The contract will keep track of the tokens
  * already collected and calculate the difference to collect.
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract TAPCollector is EIP712, GraphDirectory, ITAPCollector {
     using PPMMath for uint256;

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -24,7 +24,8 @@ import { HorizonStakingBase } from "./HorizonStakingBase.sol";
  * This is due to the contract size limit on Arbitrum (24kB). The extension contract implements functionality to support
  * the legacy staking functions and the transfer tools. Both can be eventually removed without affecting the main
  * staking contract.
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -24,6 +24,7 @@ import { HorizonStakingBase } from "./HorizonStakingBase.sol";
  * This is due to the contract size limit on Arbitrum (24kB). The extension contract implements functionality to support
  * the legacy staking functions and the transfer tools. Both can be eventually removed without affecting the main
  * staking contract.
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -24,7 +24,8 @@ import { HorizonStakingBase } from "./HorizonStakingBase.sol";
  * without losing rewards or having service interruptions.
  * @dev TODO: Once the transition period and the transfer tools are deemed not necessary this contract
  * can be removed. It's expected the transition period to last for a full allocation cycle (28 epochs).
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizonStakingExtension {
     using TokenUtils for IGraphToken;

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -24,6 +24,7 @@ import { HorizonStakingBase } from "./HorizonStakingBase.sol";
  * without losing rewards or having service interruptions.
  * @dev TODO: Once the transition period and the transfer tools are deemed not necessary this contract
  * can be removed. It's expected the transition period to last for a full allocation cycle (28 epochs).
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizonStakingExtension {
     using TokenUtils for IGraphToken;

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -19,7 +19,7 @@ import { GraphDirectory } from "@graphprotocol/horizon/contracts/utilities/Graph
 import { DisputeManagerV1Storage } from "./DisputeManagerStorage.sol";
 import { AttestationManager } from "./utilities/AttestationManager.sol";
 
-/*
+/**
  * @title DisputeManager
  * @notice Provides a way to permissionlessly create disputes for incorrect behavior in the Subgraph Service.
  *
@@ -40,6 +40,7 @@ import { AttestationManager } from "./utilities/AttestationManager.sol";
  * Arbitration:
  * Disputes can only be accepted, rejected or drawn by the arbitrator role that can be delegated
  * to a EOA or DAO.
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
  */
 contract DisputeManager is
     Initializable,

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -40,7 +40,8 @@ import { AttestationManager } from "./utilities/AttestationManager.sol";
  * Arbitration:
  * Disputes can only be accepted, rejected or drawn by the arbitrator role that can be delegated
  * to a EOA or DAO.
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract DisputeManager is
     Initializable,

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -23,7 +23,8 @@ import { LegacyAllocation } from "./libraries/LegacyAllocation.sol";
 
 /**
  * @title SubgraphService contract
- * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ * @custom:security-contact Please email security+contracts@thegraph.com if you find any
+ * bugs. We may have an active bug bounty program.
  */
 contract SubgraphService is
     Initializable,

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -21,6 +21,10 @@ import { PPMMath } from "@graphprotocol/horizon/contracts/libraries/PPMMath.sol"
 import { Allocation } from "./libraries/Allocation.sol";
 import { LegacyAllocation } from "./libraries/LegacyAllocation.sol";
 
+/**
+ * @title SubgraphService contract
+ * @custom:security-contact Bug bounty program: https://immunefi.com/bug-bounty/thegraph/information/
+ */
 contract SubgraphService is
     Initializable,
     OwnableUpgradeable,


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-03 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-03), applying the recommended fixes to the contracts outlined. 


### Title: 
N-03 Lack of Security Contact

### Details: 
Providing a specific security contact (such as an email or ENS name) within a smart contract significantly simplifies the process for individuals to communicate if they identify a vulnerability in the code. This practice is quite beneficial as it permits the code owners to dictate the communication channel for vulnerability disclosure, eliminating the risk of miscommunication or failure to report due to a lack of knowledge on how to do so. In addition, if the contract incorporates third-party libraries and a bug surfaces in those, it becomes easier for their maintainers to contact the appropriate person about the problem and provide mitigation instructions.

Throughout the codebase, multiple instances of contracts without a security contact were identified:

The [DisputeManager contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol)
The [GraphPayments contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/GraphPayments.sol)
The [HorizonStaking contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol)
The [HorizonStakingExtension contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingExtension.sol)
The [PaymentsEscrow contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/PaymentsEscrow.sol)
The [SubgraphService contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/SubgraphService.sol)
The [TAPCollector contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/collectors/TAPCollector.sol)

Consider adding a NatSpec comment containing a security contact above each contract definition. Using the @custom:security-contact convention is recommended as it has been adopted by the [OpenZeppelin Wizard](https://wizard.openzeppelin.com/) and the [ethereum-lists](https://github.com/ethereum-lists/contracts#tracking-new-deployments).

##

### Key changes

- add security contact to DisputeManager.sol
- add security contact to GraphPayments.sol
- add security contact to HorizonStaking.sol
- add security contact to HorizonStakingExtension.sol
- add security contact to PaymentsEscrow.sol
- add security contact to SubgraphService.sol + add NatSpec before contract def
- add security contact to TAPCollector.sol