### PR TITLE
fix: remove unused errors, use LegacyAllocationAlreadyMigrated to prevent migrating a legacy allocation twice (OZ N-02)

### DIFF
--- a/packages/horizon/contracts/data-service/interfaces/IDataService.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataService.sol
@@ -61,11 +61,6 @@ interface IDataService {
     event ServiceProviderSlashed(address indexed serviceProvider, uint256 tokens);
 
     /**
-     * @notice Thrown to signal that a feature is not implemented by a data service.
-     */
-    error DataServiceFeatureNotImplemented();
-
-    /**
      * @notice Registers a service provider with the data service. The service provider can now
      * start providing the service.
      * @dev Before registering, the service provider must have created a provision in the

--- a/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
+++ b/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
@@ -39,11 +39,12 @@ library LegacyAllocation {
     /**
      * @notice Migrate a legacy allocation
      * @dev Requirements:
-     * - The allocation must not exist
+     * - The allocation must not have been previously migrated
      * @param self The legacy allocation list mapping
      * @param indexer The indexer that owns the allocation
      * @param allocationId The allocation id
      * @param subgraphDeploymentId The subgraph deployment id the allocation is for
+     * @custom:error LegacyAllocationAlreadyMigrated if the allocation has already been migrated
      */
     function migrate(
         mapping(address => State) storage self,
@@ -51,7 +52,9 @@ library LegacyAllocation {
         address allocationId,
         bytes32 subgraphDeploymentId
     ) internal {
-        require(!self[allocationId].exists(), LegacyAllocationExists(allocationId));
+        if (self[allocationId].exists()) {
+            revert LegacyAllocationAlreadyMigrated(allocationId);
+        }
 
         State memory allocation = State({ indexer: indexer, subgraphDeploymentId: subgraphDeploymentId });
         self[allocationId] = allocation;

--- a/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
+++ b/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
@@ -52,9 +52,7 @@ library LegacyAllocation {
         address allocationId,
         bytes32 subgraphDeploymentId
     ) internal {
-        if (self[allocationId].exists()) {
-            revert LegacyAllocationAlreadyMigrated(allocationId);
-        }
+        require(!self[allocationId].exists(), LegacyAllocationAlreadyMigrated(allocationId);
 
         State memory allocation = State({ indexer: indexer, subgraphDeploymentId: subgraphDeploymentId });
         self[allocationId] = allocation;

--- a/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
+++ b/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol
@@ -52,7 +52,7 @@ library LegacyAllocation {
         address allocationId,
         bytes32 subgraphDeploymentId
     ) internal {
-        require(!self[allocationId].exists(), LegacyAllocationAlreadyMigrated(allocationId);
+        require(!self[allocationId].exists(), LegacyAllocationAlreadyMigrated(allocationId));
 
         State memory allocation = State({ indexer: indexer, subgraphDeploymentId: subgraphDeploymentId });
         self[allocationId] = allocation;

--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -136,12 +136,6 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
     error AllocationManagerInvalidZeroAllocationId();
 
     /**
-     * @notice Thrown when attempting to create an allocation with zero tokens
-     * @param allocationId The id of the allocation
-     */
-    error AllocationManagerZeroTokensAllocation(address allocationId);
-
-    /**
      * @notice Thrown when attempting to collect indexing rewards on a closed allocationl
      * @param allocationId The id of the allocation
      */

--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -169,7 +169,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
     /**
      * @notice Imports a legacy allocation id into the subgraph service
      * This is a governor only action that is required to prevent indexers from re-using allocation ids from the
-     * legacy staking contract.
+     * legacy staking contract. It will revert with LegacyAllocationAlreadyMigrated if the allocation has already been migrated.
      * @param _indexer The address of the indexer
      * @param _allocationId The id of the allocation
      * @param _subgraphDeploymentId The id of the subgraph deployment


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-02 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-02), applying the recommended fixes.


### Title: 
N-02 Unused Errors

### Details: 
Unused errors can negatively affect code intent and readability.

The [AllocationManagerZeroTokensAllocation](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L140), [DataServiceFeatureNotImplemented](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataService.sol#L66), and [LegacyAllocationAlreadyMigrated](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/LegacyAllocation.sol#L37) errors are unused.

Consider deleting the AllocationManagerZeroTokensAllocation error since creating allocations with no tokens is allowed for altruistic allocations. In addition, consider deleting the DataServiceFeatureNotImplemented error and using LegacyAllocationAlreadyMigrated to prevent migrating a legacy allocation twice.

##

### Key changes

- removed unused AllocationManagerZeroTokensAllocation 
- removed unused DataServiceFeatureNotImplemented
- now using LegacyAllocationAlreadyMigrated to prevent migrating a legacy allocation twice