### PR TITLE
fix: address inconsistent parameter and mapping order (OZ N-05)

### DIFF
--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -79,7 +79,7 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
      * @param caller The address of the caller.
      * @param serviceProvider The address of the service provider.
      */
-    error ProvisionManagerNotAuthorized(address caller, address serviceProvider);
+    error ProvisionManagerNotAuthorized(address serviceProvider, address caller);
 
     /**
      * @notice Thrown when a provision is not found.
@@ -93,7 +93,7 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
     modifier onlyAuthorizedForProvision(address serviceProvider) {
         require(
             _graphStaking().isAuthorized(msg.sender, serviceProvider, address(this)),
-            ProvisionManagerNotAuthorized(msg.sender, serviceProvider)
+            ProvisionManagerNotAuthorized(serviceProvider, msg.sender)
         );
         _;
     }

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -76,8 +76,8 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
 
     /**
      * @notice Thrown when the caller is not authorized to manage the provision of a service provider.
+     * @param serviceProvider The address of the serviceProvider.
      * @param caller The address of the caller.
-     * @param serviceProvider The address of the service provider.
      */
     error ProvisionManagerNotAuthorized(address serviceProvider, address caller);
 

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -92,7 +92,7 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
      */
     modifier onlyAuthorizedForProvision(address serviceProvider) {
         require(
-            _graphStaking().isAuthorized(msg.sender, serviceProvider, address(this)),
+            _graphStaking().isAuthorized(serviceProvider, address(this), msg.sender),
             ProvisionManagerNotAuthorized(serviceProvider, msg.sender)
         );
         _;

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -108,14 +108,14 @@ interface IHorizonStakingMain {
     /**
      * @dev Emitted when an operator is allowed or denied by a service provider for a particular verifier
      * @param serviceProvider The address of the service provider
-     * @param operator The address of the operator
      * @param verifier The address of the verifier
+     * @param operator The address of the operator
      * @param allowed Whether the operator is allowed or denied
      */
     event OperatorSet(
         address indexed serviceProvider,
-        address indexed operator,
         address indexed verifier,
+        address indexed operator,
         bool allowed
     );
 
@@ -865,11 +865,11 @@ interface IHorizonStakingMain {
      * Additional requirements:
      * - The `verifier` must be allowed to be used for locked provisions.
      *
-     * @param operator Address to authorize or unauthorize
      * @param verifier The verifier / data service on which they'll be allowed to operate
+     * @param operator Address to authorize or unauthorize
      * @param allowed Whether the operator is authorized or not
      */
-    function setOperatorLocked(address operator, address verifier, bool allowed) external;
+    function setOperatorLocked(address verifier, address operator, bool allowed) external;
 
     /**
      * @notice Sets a verifier as a globally allowed verifier for locked provisions.
@@ -904,11 +904,11 @@ interface IHorizonStakingMain {
     /**
      * @notice Authorize or unauthorize an address to be an operator for the caller on a data service.
      * @dev Emits a {OperatorSet} event.
-     * @param operator Address to authorize or unauthorize
      * @param verifier The verifier / data service on which they'll be allowed to operate
+     * @param operator Address to authorize or unauthorize
      * @param allowed Whether the operator is authorized or not
      */
-    function setOperator(address operator, address verifier, bool allowed) external;
+    function setOperator(address verifier, address operator, bool allowed) external;
 
     /**
      * @notice Check if an operator is authorized for the caller on a specific verifier / data service.

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -912,10 +912,10 @@ interface IHorizonStakingMain {
 
     /**
      * @notice Check if an operator is authorized for the caller on a specific verifier / data service.
-     * @param operator The address to check for auth
      * @param serviceProvider The service provider on behalf of whom they're claiming to act
      * @param verifier The verifier / data service on which they're claiming to act
+     * @param operator The address to check for auth
      * @return Whether the operator is authorized or not
      */
-    function isAuthorized(address operator, address serviceProvider, address verifier) external view returns (bool);
+    function isAuthorized(address serviceProvider, address verifier, address operator) external view returns (bool);
 }

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -336,7 +336,7 @@ interface IHorizonStakingMain {
      * @param serviceProvider The service provider address
      * @param verifier The verifier address
      */
-    error HorizonStakingNotAuthorized(address caller, address serviceProvider, address verifier);
+    error HorizonStakingNotAuthorized(address serviceProvider, address verifier, address caller);
 
     /**
      * @notice Thrown when attempting to create a provision with an invalid maximum verifier cut.

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -48,7 +48,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     modifier onlyAuthorized(address serviceProvider, address verifier) {
         require(
             _isAuthorized(msg.sender, serviceProvider, verifier),
-            HorizonStakingNotAuthorized(msg.sender, serviceProvider, verifier)
+            HorizonStakingNotAuthorized(serviceProvider, verifier, msg.sender)
         );
         _;
     }

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -466,9 +466,9 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     /**
      * @notice See {IHorizonStakingMain-setOperatorLocked}.
      */
-    function setOperatorLocked(address operator, address verifier, bool allowed) external override notPaused {
+    function setOperatorLocked(address verifier, address operator, bool allowed) external override notPaused {
         require(_allowedLockedVerifiers[verifier], HorizonStakingVerifierNotAllowed(verifier));
-        _setOperator(operator, verifier, allowed);
+        _setOperator(verifier, operator, allowed);
     }
 
     /*
@@ -514,8 +514,8 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     /**
      * @notice See {IHorizonStakingMain-setOperator}.
      */
-    function setOperator(address operator, address verifier, bool allowed) external override notPaused {
-        _setOperator(operator, verifier, allowed);
+    function setOperator(address verifier, address operator, bool allowed) external override notPaused {
+        _setOperator(verifier, operator, allowed);
     }
 
     /**
@@ -960,7 +960,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @dev Note that this function handles the special case where the verifier is the subgraph data service,
      * where the operator settings are stored in the legacy mapping.
      */
-    function _setOperator(address _operator, address _verifier, bool _allowed) private {
+    function _setOperator(address _verifier, address _operator, bool _allowed) private {
         require(_operator != msg.sender, HorizonStakingCallerIsServiceProvider());
         if (_verifier == SUBGRAPH_DATA_SERVICE_ADDRESS) {
             _legacyOperatorAuth[msg.sender][_operator] = _allowed;

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -967,7 +967,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
         } else {
             _operatorAuth[msg.sender][_verifier][_operator] = _allowed;
         }
-        emit OperatorSet(msg.sender, _operator, _verifier, _allowed);
+        emit OperatorSet(msg.sender, _verifier, _operator, _allowed);
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -47,7 +47,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      */
     modifier onlyAuthorized(address serviceProvider, address verifier) {
         require(
-            _isAuthorized(msg.sender, serviceProvider, verifier),
+            _isAuthorized(serviceProvider, verifier, msg.sender),
             HorizonStakingNotAuthorized(serviceProvider, verifier, msg.sender)
         );
         _;
@@ -526,7 +526,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
         address verifier,
         address operator
     ) external view override returns (bool) {
-        return _isAuthorized(operator, serviceProvider, verifier);
+        return _isAuthorized(serviceProvider, verifier, operator);
     }
 
     /*
@@ -975,7 +975,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @dev Note that this function handles the special case where the verifier is the subgraph data service,
      * where the operator settings are stored in the legacy mapping.
      */
-    function _isAuthorized(address _operator, address _serviceProvider, address _verifier) private view returns (bool) {
+    function _isAuthorized(address _serviceProvider, address _verifier, address _operator) private view returns (bool) {
         if (_operator == _serviceProvider) {
             return true;
         }

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -522,9 +522,9 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @notice See {IHorizonStakingMain-isAuthorized}.
      */
     function isAuthorized(
-        address operator,
         address serviceProvider,
-        address verifier
+        address verifier,
+        address operator
     ) external view override returns (bool) {
         return _isAuthorized(operator, serviceProvider, verifier);
     }

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -753,7 +753,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
 
         // before
         bool beforeOperatorAllowed = _getStorage_OperatorAuth(msgSender, operator, verifier, legacy);
-        bool beforeOperatorAllowedGetter = staking.isAuthorized(operator, msgSender, verifier);
+        bool beforeOperatorAllowedGetter = staking.isAuthorized(msgSender, verifier, operator);
         assertEq(beforeOperatorAllowed, beforeOperatorAllowedGetter);
 
         // setOperator
@@ -767,7 +767,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
 
         // after
         bool afterOperatorAllowed = _getStorage_OperatorAuth(msgSender, operator, verifier, legacy);
-        bool afterOperatorAllowedGetter = staking.isAuthorized(operator, msgSender, verifier);
+        bool afterOperatorAllowedGetter = staking.isAuthorized(msgSender, verifier, operator);
         assertEq(afterOperatorAllowed, afterOperatorAllowedGetter);
 
         // assert
@@ -1390,9 +1390,9 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         );
 
         bool isAuth = staking.isAuthorized(
-            msgSender,
             beforeValues.allocation.indexer,
-            subgraphDataServiceLegacyAddress
+            subgraphDataServiceLegacyAddress,
+            msgSender
         );
         address rewardsDestination = _getStorage_RewardsDestination(beforeValues.allocation.indexer);
 

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -752,7 +752,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         bool legacy = verifier == subgraphDataServiceLegacyAddress;
 
         // before
-        bool beforeOperatorAllowed = _getStorage_OperatorAuth(msgSender, operator, verifier, legacy);
+        bool beforeOperatorAllowed = _getStorage_OperatorAuth(msgSender, verifier, operator, legacy);
         bool beforeOperatorAllowedGetter = staking.isAuthorized(msgSender, verifier, operator);
         assertEq(beforeOperatorAllowed, beforeOperatorAllowedGetter);
 
@@ -766,9 +766,9 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         }
 
         // after
-        bool afterOperatorAllowed = _getStorage_OperatorAuth(msgSender, operator, verifier, legacy);
+        bool afterOperatorAllowed = _getStorage_OperatorAuth(msgSender, verifier, operator, legacy);
         bool afterOperatorAllowedGetter = staking.isAuthorized(msgSender, verifier, operator);
-        assertEq(afterOperatorAllowed, afterOperatorAllowedGetter);
+        assertEq(afterOperatorAllowed, afterOperatorAllowedGetter, "afterOperatorAllowedGetter FAIL");
 
         // assert
         assertEq(afterOperatorAllowed, allow);
@@ -1686,8 +1686,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
 
     function _getStorage_OperatorAuth(
         address serviceProvider,
-        address operator,
         address verifier,
+        address operator,
         bool legacy
     ) internal view returns (bool) {
         uint256 slotNumber = legacy ? 21 : 31;
@@ -1699,8 +1699,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             slot = uint256(
                 keccak256(
                     abi.encode(
-                        operator,
-                        keccak256(abi.encode(verifier, keccak256(abi.encode(serviceProvider, slotNumber))))
+                        verifier,
+                        keccak256(abi.encode(operator, keccak256(abi.encode(serviceProvider, slotNumber))))
                     )
                 )
             );

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -41,7 +41,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
 
     modifier useOperator() {
         vm.startPrank(users.indexer);
-        _setOperator(users.operator, subgraphDataServiceAddress, true);
+        _setOperator(subgraphDataServiceAddress, users.operator, true);
         vm.startPrank(users.operator);
         _;
         vm.stopPrank();
@@ -736,15 +736,15 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         assertEq(afterProvision.createdAt, beforeProvision.createdAt);
     }
 
-    function _setOperator(address operator, address verifier, bool allow) internal {
-        __setOperator(operator, verifier, allow, false);
+    function _setOperator(address verifier, address operator, bool allow) internal {
+        __setOperator(verifier, operator, allow, false);
     }
 
-    function _setOperatorLocked(address operator, address verifier, bool allow) internal {
-        __setOperator(operator, verifier, allow, true);
+    function _setOperatorLocked(address verifier, address operator, bool allow) internal {
+        __setOperator(verifier, operator, allow, true);
     }
 
-    function __setOperator(address operator, address verifier, bool allow, bool locked) private {
+    function __setOperator(address verifier, address operator, bool allow, bool locked) private {
         (, address msgSender, ) = vm.readCallers();
 
         // staking contract knows the address of the legacy subgraph service
@@ -758,11 +758,11 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
 
         // setOperator
         vm.expectEmit(address(staking));
-        emit IHorizonStakingMain.OperatorSet(msgSender, operator, verifier, allow);
+        emit IHorizonStakingMain.OperatorSet(msgSender, verifier, operator, allow);
         if (locked) {
-            staking.setOperatorLocked(operator, verifier, allow);
+            staking.setOperatorLocked(verifier, operator, allow);
         } else {
-            staking.setOperator(operator, verifier, allow);
+            staking.setOperator(verifier, operator, allow);
         }
 
         // after
@@ -1699,8 +1699,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             slot = uint256(
                 keccak256(
                     abi.encode(
-                        verifier,
-                        keccak256(abi.encode(operator, keccak256(abi.encode(serviceProvider, slotNumber))))
+                        operator,
+                        keccak256(abi.encode(verifier, keccak256(abi.encode(serviceProvider, slotNumber))))
                     )
                 )
             );

--- a/packages/horizon/test/staking/operator/locked.t.sol
+++ b/packages/horizon/test/staking/operator/locked.t.sol
@@ -12,22 +12,22 @@ contract HorizonStakingOperatorLockedTest is HorizonStakingTest {
      */
 
     function testOperatorLocked_Set() public useIndexer useLockedVerifier(subgraphDataServiceAddress) {
-        _setOperatorLocked(users.operator, subgraphDataServiceAddress, true);
+        _setOperatorLocked(subgraphDataServiceAddress, users.operator, true);
     }
 
     function testOperatorLocked_RevertWhen_VerifierNotAllowed() public useIndexer {
         bytes memory expectedError = abi.encodeWithSignature("HorizonStakingVerifierNotAllowed(address)", subgraphDataServiceAddress);
         vm.expectRevert(expectedError);
-        staking.setOperatorLocked(users.operator, subgraphDataServiceAddress, true);
+        staking.setOperatorLocked(subgraphDataServiceAddress, users.operator, true);
     }
 
     function testOperatorLocked_RevertWhen_CallerIsServiceProvider() public useIndexer useLockedVerifier(subgraphDataServiceAddress) {
         bytes memory expectedError = abi.encodeWithSignature("HorizonStakingCallerIsServiceProvider()");
         vm.expectRevert(expectedError);
-        staking.setOperatorLocked(users.indexer, subgraphDataServiceAddress, true);
+        staking.setOperatorLocked(subgraphDataServiceAddress, users.indexer, true);
     }
 
     function testOperatorLocked_SetLegacySubgraphService() public useIndexer useLockedVerifier(subgraphDataServiceLegacyAddress) {
-        _setOperatorLocked(users.operator, subgraphDataServiceLegacyAddress, true);
+        _setOperatorLocked(subgraphDataServiceLegacyAddress, users.operator, true);
     }
 }

--- a/packages/horizon/test/staking/operator/operator.t.sol
+++ b/packages/horizon/test/staking/operator/operator.t.sol
@@ -12,17 +12,17 @@ contract HorizonStakingOperatorTest is HorizonStakingTest {
      */
 
     function testOperator_SetOperator() public useIndexer {
-        _setOperator(users.operator, subgraphDataServiceAddress, true);
+        _setOperator(subgraphDataServiceAddress, users.operator, true);
     }
 
     function testOperator_RevertWhen_CallerIsServiceProvider() public useIndexer {
         bytes memory expectedError = abi.encodeWithSignature("HorizonStakingCallerIsServiceProvider()");
         vm.expectRevert(expectedError);
-        staking.setOperator(users.indexer, subgraphDataServiceAddress, true);
+        staking.setOperator(subgraphDataServiceAddress, users.indexer, true);
     }
 
     function testOperator_RemoveOperator() public useIndexer {
-        _setOperator(users.operator, subgraphDataServiceAddress, true);
-        _setOperator(users.operator, subgraphDataServiceAddress, false);
+        _setOperator(subgraphDataServiceAddress, users.operator, true);
+        _setOperator(subgraphDataServiceAddress, users.operator, false);
     }
 }

--- a/packages/horizon/test/staking/provision/deprovision.t.sol
+++ b/packages/horizon/test/staking/provision/deprovision.t.sol
@@ -75,9 +75,9 @@ contract HorizonStakingDeprovisionTest is HorizonStakingTest {
         vm.startPrank(users.operator);
         bytes memory expectedError = abi.encodeWithSignature(
             "HorizonStakingNotAuthorized(address,address,address)",
-            users.operator,
             users.indexer,
-            subgraphDataServiceAddress
+            subgraphDataServiceAddress,
+            users.operator
         );
         vm.expectRevert(expectedError);
         staking.deprovision(users.indexer, subgraphDataServiceAddress, 0);

--- a/packages/horizon/test/staking/provision/locked.t.sol
+++ b/packages/horizon/test/staking/provision/locked.t.sol
@@ -17,7 +17,7 @@ contract HorizonStakingProvisionLockedTest is HorizonStakingTest {
         uint256 provisionTokens = staking.getProviderTokensAvailable(users.indexer, subgraphDataServiceAddress);
         assertEq(provisionTokens, 0);
 
-        _setOperatorLocked(users.operator, subgraphDataServiceAddress, true);
+        _setOperatorLocked(subgraphDataServiceAddress, users.operator, true);
 
         vm.startPrank(users.operator);
         _provisionLocked(
@@ -39,7 +39,7 @@ contract HorizonStakingProvisionLockedTest is HorizonStakingTest {
         assertEq(provisionTokens, 0);
 
         // Set operator
-        _setOperatorLocked(users.operator, subgraphDataServiceAddress, true);
+        _setOperatorLocked(subgraphDataServiceAddress, users.operator, true);
 
         // Disable locked verifier
         vm.startPrank(users.governor);

--- a/packages/horizon/test/staking/provision/locked.t.sol
+++ b/packages/horizon/test/staking/provision/locked.t.sol
@@ -66,9 +66,9 @@ contract HorizonStakingProvisionLockedTest is HorizonStakingTest {
         vm.startPrank(users.operator);
         bytes memory expectedError = abi.encodeWithSignature(
             "HorizonStakingNotAuthorized(address,address,address)",
-            users.operator,
             users.indexer,
-            subgraphDataServiceAddress
+            subgraphDataServiceAddress,
+            users.operator
         );
         vm.expectRevert(expectedError);
         staking.provisionLocked(

--- a/packages/horizon/test/staking/provision/parameters.t.sol
+++ b/packages/horizon/test/staking/provision/parameters.t.sol
@@ -53,9 +53,9 @@ contract HorizonStakingProvisionParametersTest is HorizonStakingTest {
         vm.expectRevert(
             abi.encodeWithSignature(
                 "HorizonStakingNotAuthorized(address,address,address)",
-                msg.sender,
                 users.indexer,
-                subgraphDataServiceAddress
+                subgraphDataServiceAddress,
+                msg.sender
             )
         );
         staking.setProvisionParameters(users.indexer, subgraphDataServiceAddress, maxVerifierCut, thawingPeriod);

--- a/packages/horizon/test/staking/provision/provision.t.sol
+++ b/packages/horizon/test/staking/provision/provision.t.sol
@@ -101,9 +101,9 @@ contract HorizonStakingProvisionTest is HorizonStakingTest {
         vm.startPrank(users.operator);
         bytes memory expectedError = abi.encodeWithSignature(
             "HorizonStakingNotAuthorized(address,address,address)",
-            users.operator,
             users.indexer,
-            subgraphDataServiceAddress
+            subgraphDataServiceAddress,
+            users.operator
         );
         vm.expectRevert(expectedError);
         staking.provision(users.indexer, subgraphDataServiceAddress, amount, maxVerifierCut, thawingPeriod);

--- a/packages/horizon/test/staking/provision/reprovision.t.sol
+++ b/packages/horizon/test/staking/provision/reprovision.t.sol
@@ -37,7 +37,7 @@ contract HorizonStakingReprovisionTest is HorizonStakingTest {
 
         // Switch to indexer to set operator for new data service
         vm.startPrank(users.indexer);
-        _setOperator(users.operator, newDataService, true);
+        _setOperator(newDataService, users.operator, true);
 
         // Switch back to operator
         vm.startPrank(users.operator);

--- a/packages/horizon/test/staking/provision/reprovision.t.sol
+++ b/packages/horizon/test/staking/provision/reprovision.t.sol
@@ -58,9 +58,9 @@ contract HorizonStakingReprovisionTest is HorizonStakingTest {
         vm.startPrank(users.operator);
         bytes memory expectedError = abi.encodeWithSignature(
             "HorizonStakingNotAuthorized(address,address,address)",
-            users.operator,
             users.indexer,
-            newDataService
+            newDataService,
+            users.operator
         );
         vm.expectRevert(expectedError);
         staking.reprovision(users.indexer, subgraphDataServiceAddress, newDataService, 0);

--- a/packages/horizon/test/staking/provision/thaw.t.sol
+++ b/packages/horizon/test/staking/provision/thaw.t.sol
@@ -49,9 +49,9 @@ contract HorizonStakingThawTest is HorizonStakingTest {
         vm.startPrank(users.operator);
         bytes memory expectedError = abi.encodeWithSignature(
             "HorizonStakingNotAuthorized(address,address,address)",
-            users.operator,
             users.indexer,
-            subgraphDataServiceAddress
+            subgraphDataServiceAddress,
+            users.operator
         );
         vm.expectRevert(expectedError);
         staking.thaw(users.indexer, subgraphDataServiceAddress, amount);

--- a/packages/horizon/test/staking/serviceProvider/serviceProvider.t.sol
+++ b/packages/horizon/test/staking/serviceProvider/serviceProvider.t.sol
@@ -25,7 +25,7 @@ contract HorizonStakingServiceProviderTest is HorizonStakingTest {
         assertEq(sp.tokensStaked, amount);
         assertEq(sp.tokensProvisioned, amount);
 
-        _setOperator(users.operator, subgraphDataServiceAddress, true);
+        _setOperator(subgraphDataServiceAddress, users.operator, true);
         resetPrank(users.operator);
         _stakeTo(users.indexer, operatorAmount);
         sp = staking.getServiceProvider(users.indexer);

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -39,7 +39,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
 
     modifier useOperator() {
         resetPrank(users.indexer);
-        staking.setOperator(users.operator, address(subgraphService), true);
+        staking.setOperator(address(subgraphService), users.operator, true);
         resetPrank(users.operator);
         _;
         vm.stopPrank();

--- a/packages/subgraph-service/test/subgraphService/allocation/start.t.sol
+++ b/packages/subgraph-service/test/subgraphService/allocation/start.t.sol
@@ -60,8 +60,8 @@ contract SubgraphServiceAllocationStartTest is SubgraphServiceTest {
         bytes memory data = _generateData(tokens);
         vm.expectRevert(abi.encodeWithSelector(
             ProvisionManager.ProvisionManagerNotAuthorized.selector,
-            users.operator,
-            users.indexer
+            users.indexer,
+            users.operator
         ));
         subgraphService.startService(users.indexer, data);
     }

--- a/packages/subgraph-service/test/subgraphService/allocation/stop.t.sol
+++ b/packages/subgraph-service/test/subgraphService/allocation/stop.t.sol
@@ -49,8 +49,8 @@ contract SubgraphServiceAllocationStopTest is SubgraphServiceTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 ProvisionManager.ProvisionManagerNotAuthorized.selector,
-                users.operator,
-                users.indexer
+                users.indexer,
+                users.operator
             )
         );
         subgraphService.stopService(users.indexer, data);

--- a/packages/subgraph-service/test/subgraphService/collect/query/query.t.sol
+++ b/packages/subgraph-service/test/subgraphService/collect/query/query.t.sol
@@ -112,8 +112,8 @@ contract SubgraphServiceRegisterTest is SubgraphServiceTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 ProvisionManager.ProvisionManagerNotAuthorized.selector,
-                users.operator,
-                users.indexer
+                users.indexer,
+                users.operator
             )
         );
         subgraphService.collect(users.indexer, paymentType, data);

--- a/packages/subgraph-service/test/subgraphService/provider/register.t.sol
+++ b/packages/subgraph-service/test/subgraphService/provider/register.t.sol
@@ -41,8 +41,8 @@ contract SubgraphServiceProviderRegisterTest is SubgraphServiceTest {
         resetPrank(users.operator);
         vm.expectRevert(abi.encodeWithSelector(
             ProvisionManager.ProvisionManagerNotAuthorized.selector,
-            users.operator,
-            users.indexer
+            users.indexer,
+            users.operator
         ));
         bytes memory data = abi.encode("url", "geoHash", users.rewardsDestination);
         subgraphService.register(users.indexer, data);

--- a/packages/subgraph-service/test/subgraphService/provision/accept.t.sol
+++ b/packages/subgraph-service/test/subgraphService/provision/accept.t.sol
@@ -47,8 +47,8 @@ contract SubgraphServiceProvisionAcceptTest is SubgraphServiceTest {
         resetPrank(users.operator);
         vm.expectRevert(abi.encodeWithSelector(
             ProvisionManager.ProvisionManagerNotAuthorized.selector,
-            users.operator,
-            users.indexer
+            users.indexer,
+            users.operator
         ));
         subgraphService.acceptProvisionPendingParameters(users.indexer, "");
     }


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-05 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-05), applying the recommended fixes.


### Title: 
N-05 Inconsistent Parameter and Mapping Order

### Details: 
In the HorizonStaking contract, the [_isAuthorized function](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L949) has the following parameter order: _operator, _serviceProvider, _verifier. On the other hand, the [_operatorAuth mapping](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingStorage.sol#L162) uses this order: _serviceProvider, _verifier, _operator. In addition, the [_legacyOperatorAuth variable](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingStorage.sol#L108) is defined as a mapping from an operator to a service provider to a boolean status. However, [it is being used](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L937) as a mapping from a service provider to an operator to a boolean status.

These inconsistencies can lead to confusion and potential errors during integration or modification, as developers may misinterpret the correct parameter order.

Consider aligning the parameter order in both the _isAuthorized function and the _operatorAuth mapping for improved consistency. Moreover, consider updating the keys and value names in the _legacyOperatorAuth mapping definition to match its usage.

##

### Key changes:

- Aligned the parameter order in the _isAuthorized function
- Aligned the parameter order in the isAuthorized function
- Aligned the parameter order in the _operatorAuth function
- Aligned the parameter order in the ProvisionManagerNotAuthorized function
- Aligned the parameter order in the HorizonStakingNotAuthorized function

##

### Consistent peramater order:

- ### ServiceProvider, Verifier, Operator