### PR TITLE
fix: update EIP712_ALLOCATION_PROOF_TYPEHASH from variable to constant. (OZ N-06)

### DIFF
--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -30,7 +30,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
     using TokenUtils for IGraphToken;
 
     ///@dev EIP712 typehash for allocation proof
-    bytes32 private immutable EIP712_ALLOCATION_PROOF_TYPEHASH =
+    bytes32 private constant EIP712_ALLOCATION_PROOF_TYPEHASH =
         keccak256("AllocationIdProof(address indexer,address allocationId)");
 
     /**


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-06 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-06), applying the recommended fixes.


### Title: 
N-06 Variable Could Be constant

### Details: 
If a variable is only ever assigned a value when it is declared, then it could be declared as constant.

The [EIP712_ALLOCATION_PROOF_TYPEHASH state variable](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L31-L32) could be constant.

To better convey the intended use of variables, consider adding the constant keyword to variables that are only set when they are declared.

##

### Key changes

- Updated EIP712_ALLOCATION_PROOF_TYPEHASH to be a constant