### PR TITLE
fix: address typographical errors throughout codebase. (OZ N-07)

### DIFF
--- a/packages/contracts/contracts/curation/Curation.sol
+++ b/packages/contracts/contracts/curation/Curation.sol
@@ -257,7 +257,7 @@ contract Curation is CurationV2Storage, GraphUpgradeable {
 
     /**
      * @notice Get the amount of token reserves in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of token reserves in the curation pool
      */
     function getCurationPoolTokens(bytes32 _subgraphDeploymentID) external view override returns (uint256) {
@@ -286,7 +286,7 @@ contract Curation is CurationV2Storage, GraphUpgradeable {
 
     /**
      * @notice Get the amount of signal in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of signal minted for the subgraph deployment
      */
     function getCurationPoolSignal(bytes32 _subgraphDeploymentID) public view override returns (uint256) {

--- a/packages/contracts/contracts/curation/ICuration.sol
+++ b/packages/contracts/contracts/curation/ICuration.sol
@@ -84,14 +84,14 @@ interface ICuration {
 
     /**
      * @notice Get the amount of signal in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of signal minted for the subgraph deployment
      */
     function getCurationPoolSignal(bytes32 _subgraphDeploymentID) external view returns (uint256);
 
     /**
      * @notice Get the amount of token reserves in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of token reserves in the curation pool
      */
     function getCurationPoolTokens(bytes32 _subgraphDeploymentID) external view returns (uint256);

--- a/packages/contracts/contracts/l2/curation/L2Curation.sol
+++ b/packages/contracts/contracts/l2/curation/L2Curation.sol
@@ -147,7 +147,7 @@ contract L2Curation is CurationV3Storage, GraphUpgradeable, IL2Curation {
 
     /**
      * @notice Assign Graph Tokens collected as curation fees to the curation pool reserve.
-     * @dev This function can only be called by the Staking contract and will do the bookeeping of
+     * @dev This function can only be called by the Staking contract and will do the Bookkeeping of
      * transferred tokens into this contract.
      * @param _subgraphDeploymentID SubgraphDeployment where funds should be allocated as reserves
      * @param _tokens Amount of Graph Tokens to add to reserves
@@ -326,7 +326,7 @@ contract L2Curation is CurationV3Storage, GraphUpgradeable, IL2Curation {
 
     /**
      * @notice Get the amount of token reserves in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of token reserves in the curation pool
      */
     function getCurationPoolTokens(bytes32 _subgraphDeploymentID) external view override returns (uint256) {
@@ -355,7 +355,7 @@ contract L2Curation is CurationV3Storage, GraphUpgradeable, IL2Curation {
 
     /**
      * @notice Get the amount of signal in a curation pool.
-     * @param _subgraphDeploymentID Subgraph deployment curation poool
+     * @param _subgraphDeploymentID Subgraph deployment curation pool
      * @return Amount of signal minted for the subgraph deployment
      */
     function getCurationPoolSignal(bytes32 _subgraphDeploymentID) public view override returns (uint256) {

--- a/packages/contracts/contracts/rewards/IRewardsIssuer.sol
+++ b/packages/contracts/contracts/rewards/IRewardsIssuer.sol
@@ -33,9 +33,9 @@ interface IRewardsIssuer {
     function getSubgraphAllocatedTokens(bytes32 _subgraphDeploymentId) external view returns (uint256);
 
     /**
-     * @notice Wether or not an allocation is active (i.e open)
+     * @notice Whether or not an allocation is active (i.e open)
      * @param _allocationId Allocation Id
-     * @return Wether or not the allocation is active
+     * @return Whether or not the allocation is active
      */
     function isActiveAllocation(address _allocationId) external view returns (bool);
 }

--- a/packages/contracts/contracts/staking/Staking.sol
+++ b/packages/contracts/contracts/staking/Staking.sol
@@ -912,7 +912,7 @@ abstract contract Staking is StakingV4Storage, GraphUpgradeable, IStakingBase, M
             if (curationFees > 0) {
                 // Transfer and call collect()
                 // This function transfer tokens to a trusted protocol contracts
-                // Then we call collect() to do the transfer bookeeping
+                // Then we call collect() to do the transfer Bookkeeping
                 rewardsManager().onSubgraphSignalUpdate(_subgraphDeploymentID);
                 TokenUtils.pushTokens(_graphToken, address(curation), curationFees);
                 curation.collect(_subgraphDeploymentID, curationFees);

--- a/packages/contracts/contracts/staking/libs/Stakes.sol
+++ b/packages/contracts/contracts/staking/libs/Stakes.sol
@@ -85,7 +85,7 @@ library Stakes {
     /**
      * @dev Unlock tokens.
      * @param stake Stake data
-     * @param _tokens Amount of tokens to unkock
+     * @param _tokens Amount of tokens to unlock
      */
     function unlockTokens(Stakes.Indexer storage stake, uint256 _tokens) internal {
         stake.tokensLocked = stake.tokensLocked.sub(_tokens);

--- a/packages/horizon/contracts/interfaces/ITAPCollector.sol
+++ b/packages/horizon/contracts/interfaces/ITAPCollector.sol
@@ -35,7 +35,7 @@ interface ITAPCollector is IPaymentsCollector {
     }
 
     /**
-     * Trown when the caller is not the data service the RAV was issued to
+     * Thrown when the caller is not the data service the RAV was issued to
      * @param caller The address of the caller
      * @param dataService The address of the data service
      */

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
@@ -162,7 +162,7 @@ interface IHorizonStakingExtension is IRewardsIssuer, IL2StakingBase {
     function isAllocation(address allocationID) external view returns (bool);
 
     /**
-     * @notice Retrun the time in blocks to unstake
+     * @notice Return the time in blocks to unstake
      * @return Thawing period in blocks
      */
     // solhint-disable-next-line func-name-mixedcase

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -253,7 +253,7 @@ interface IHorizonStakingMain {
      * @param thawRequestId The ID of the thaw request
      * @param tokens The amount of tokens being released
      * @param shares The amount of shares being released
-     * @param thawingUntil The timestamp until the stake has thawn
+     * @param thawingUntil The timestamp until the stake has thawed
      */
     event ThawRequestFulfilled(bytes32 indexed thawRequestId, uint256 tokens, uint256 shares, uint64 thawingUntil);
 
@@ -417,7 +417,7 @@ interface IHorizonStakingMain {
     error HorizonStakingStillThawing(uint256 until);
 
     /**
-     * @notice Thrown when a service provider attempts to operate on verifieres that are not allowed.
+     * @notice Thrown when a service provider attempts to operate on verifiers that are not allowed.
      * @dev Only applies to stake from locked wallets.
      */
     error HorizonStakingVerifierNotAllowed(address verifier);
@@ -578,7 +578,7 @@ interface IHorizonStakingMain {
     /**
      * @notice Remove tokens from a provision and move them back to the service provider's idle stake.
      * @dev The parameter `nThawRequests` can be set to a non zero value to fulfill a specific number of thaw
-     * requests in the event that fulfulling all of them results in a gas limit error.
+     * requests in the event that fulfilling all of them results in a gas limit error.
      *
      * Requirements:
      * - Must have previously initiated a thaw request using {thaw}.
@@ -704,7 +704,7 @@ interface IHorizonStakingMain {
      * @notice Withdraw undelegated tokens from a provision after thawing.
      * Tokens can be automatically re-delegated to another provision by setting `newServiceProvider`.
      * @dev The parameter `nThawRequests` can be set to a non zero value to fulfill a specific number of thaw
-     * requests in the event that fulfulling all of them results in a gas limit error.
+     * requests in the event that fulfilling all of them results in a gas limit error.
      *
      * Requirements:
      * - Must have previously initiated a thaw request using {undelegate}.
@@ -744,7 +744,7 @@ interface IHorizonStakingMain {
     /**
      * @notice Delegate tokens to the subgraph data service provision.
      * This function is for backwards compatibility with the legacy staking contract.
-     * It only allows delegting to the subgraph data service and DOES NOT have slippage protection.
+     * It only allows delegating to the subgraph data service and DOES NOT have slippage protection.
      * @dev See {delegate}.
      * @param serviceProvider The service provider address
      * @param tokens The amount of tokens to delegate
@@ -754,7 +754,7 @@ interface IHorizonStakingMain {
     /**
      * @notice Undelegate tokens from the subgraph data service provision and start thawing them.
      * This function is for backwards compatibility with the legacy staking contract.
-     * It only allows undelegting from the subgraph data service.
+     * It only allows undelegating from the subgraph data service.
      * @dev See {undelegate}.
      * @param serviceProvider The service provider address
      * @param shares The amount of shares to undelegate

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
@@ -39,7 +39,7 @@ interface IHorizonStakingTypes {
      * @dev See {ServiceProviderInternal} for the actual storage representation
      */
     struct ServiceProvider {
-        // Total amount of tokens on the provider stake (only staked by the provider, inludes all provisions)
+        // Total amount of tokens on the provider stake (only staked by the provider, includes all provisions)
         uint256 tokensStaked;
         // Total amount of tokens locked in provisions (only staked by the provider)
         uint256 tokensProvisioned;
@@ -50,7 +50,7 @@ interface IHorizonStakingTypes {
      * @dev It contains deprecated fields from the `Indexer` struct to maintain storage compatibility.
      */
     struct ServiceProviderInternal {
-        // Total amount of tokens on the provider stake (only staked by the provider, inludes all provisions)
+        // Total amount of tokens on the provider stake (only staked by the provider, includes all provisions)
         uint256 tokensStaked;
         // (Deprecated) Tokens used in allocations
         uint256 __DEPRECATED_tokensAllocated; // solhint-disable-line graph/leading-underscore

--- a/packages/horizon/contracts/payments/GraphPayments.sol
+++ b/packages/horizon/contracts/payments/GraphPayments.sol
@@ -24,7 +24,7 @@ contract GraphPayments is Initializable, MulticallUpgradeable, GraphDirectory, I
 
     /**
      * @notice Constructor for the {GraphPayments} contract
-     * @dev This contract is upgradeable however we stil use the constructor to set
+     * @dev This contract is upgradeable however we still use the constructor to set
      * a few immutable variables.
      * @param controller The address of the Graph controller
      * @param protocolPaymentCut The protocol tax in PPM

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -62,7 +62,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     }
 
     /**
-     * @dev The staking contract is upgradeable however we stil use the constructor to set
+     * @dev The staking contract is upgradeable however we still use the constructor to set
      * a few immutable variables.
      * @param controller The address of the Graph controller contract.
      * @param stakingExtensionAddress The address of the staking extension contract.
@@ -903,7 +903,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      *
      * @param _thawRequestId The ID of the current thaw request
      * @param _acc The accumulator data for the thaw requests being fulfilled
-     * @return Wether the thaw request is still thawing, indicating that the traversal should continue or stop.
+     * @return Whether the thaw request is still thawing, indicating that the traversal should continue or stop.
      * @return The updated accumulator data
      */
     function _fulfillThawRequest(bytes32 _thawRequestId, bytes memory _acc) private returns (bool, bytes memory) {

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -39,7 +39,7 @@ abstract contract HorizonStakingBase is
     address internal immutable SUBGRAPH_DATA_SERVICE_ADDRESS;
 
     /**
-     * @dev The staking contract is upgradeable however we stil use the constructor to set
+     * @dev The staking contract is upgradeable however we still use the constructor to set
      * a few immutable variables.
      * @param controller The address of the Graph controller contract.
      * @param subgraphDataServiceAddress The address of the subgraph data service.

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -41,7 +41,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizon
     }
 
     /**
-     * @dev The staking contract is upgradeable however we stil use the constructor to set
+     * @dev The staking contract is upgradeable however we still use the constructor to set
      * a few immutable variables.
      * @param controller The address of the Graph controller contract.
      * @param subgraphDataServiceAddress The address of the subgraph data service.
@@ -296,7 +296,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizon
     }
 
     /**
-     * @notice Retrun the time in blocks to unstake
+     * @notice Return the time in blocks to unstake
      * Deprecated, now enforced by each data service (verifier)
      * @return Thawing period in blocks
      */
@@ -569,7 +569,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizon
             if (curationFees > 0) {
                 // Transfer and call collect()
                 // This function transfer tokens to a trusted protocol contracts
-                // Then we call collect() to do the transfer bookeeping
+                // Then we call collect() to do the transfer Bookkeeping
                 _graphRewardsManager().onSubgraphSignalUpdate(_subgraphDeploymentID);
                 _graphToken().pushTokens(address(curation), curationFees);
                 curation.collect(_subgraphDeploymentID, curationFees);

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -272,7 +272,7 @@ contract DisputeManager is
     }
 
     /**
-     * @notice Once the dispute period ends, if the disput status remains Pending,
+     * @notice Once the dispute period ends, if the dispute status remains Pending,
      * the fisherman can cancel the dispute and get back their initial deposit.
      * @dev Cancel a dispute with Id `disputeId`
      * @param disputeId Id of the dispute to be cancelled

--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -142,7 +142,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
     error AllocationManagerZeroTokensAllocation(address allocationId);
 
     /**
-     * @notice Thrown when attempting to collect indexing rewards on a closed allocationl
+     * @notice Thrown when attempting to collect indexing rewards on a closed allocation
      * @param allocationId The id of the allocation
      */
     error AllocationManagerAllocationClosed(address allocationId);
@@ -454,7 +454,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
     }
 
     /**
-     * @notice Verifies ownsership of an allocation id by verifying an EIP712 allocation proof
+     * @notice Verifies ownership of an allocation id by verifying an EIP712 allocation proof
      * @dev Requirements:
      * - Signer must be the allocation id address
      * @param _indexer The address of the indexer


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-07 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-07), applying the recommended fixes.


### Title: 
N-07 Typographical Errors

### Details: 
Throughout the codebase, multiple instances of typographical errors were identified:

[Wether](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L891) should be "Whether" (also in the [IRewardsIssuer contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/rewards/IRewardsIssuer.sol#L29C6-L31C54)).
[poriver](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L595) should be "provider".
[bookeping](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/staking/Staking.sol#L915) should be "bookkeeping".
[unkock](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/staking/libs/Stakes.sol#L88) should be "unlock".
[Trown](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/ITAPCollector.sol#L38) should be "Thrown".
[Retrun](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol#L164) should be "Return" (similarly [here](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingExtension.sol#L298)).
[thawn](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L256) should be "thawed".
[verifieres](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L416) should be "verifiers".
[fulfulling](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L570) should be "fulfilling".
[delegting](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L736) should be "delegating".
[undelegting](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L746) should be "undelegating".
[stil](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingBase.sol#L42) should be "still".
[Bookeeping](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingExtension.sol#L559) should be "Bookkeeping".
[ownsership](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L448) should be "ownership".
[Emmited](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/interfaces/ISubgraphService.sol#L58) should be "Emited".
[allocationl](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L143) should be "allocation".
[disput](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L265) should be "dispute".
Throughout the [IHorizonStakingTypes interface](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol), "inludes" should be "includes".
Throughout the Curation and L2Curation contracts, [poool](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/curation/Curation.sol#L260) should be "pool".
Consider fixing the aforementioned typographical errors in order to improve the readability of the codebase.

##

### Key changes

- Addressed all typographical errors outlined in the audit, applying the recommended fixes. 