### PR TITLE
fix: add override keyword in functions (OZ N-09)

### DIFF
--- a/packages/horizon/contracts/data-service/extensions/DataServicePausable.sol
+++ b/packages/horizon/contracts/data-service/extensions/DataServicePausable.sol
@@ -30,14 +30,14 @@ abstract contract DataServicePausable is Pausable, DataService, IDataServicePaus
     /**
      * @notice See {IDataServicePausable-pause}
      */
-    function pause() external onlyPauseGuardian whenNotPaused {
+    function pause() external override onlyPauseGuardian whenNotPaused {
         _pause();
     }
 
     /**
      * @notice See {IDataServicePausable-pause}
      */
-    function unpause() external onlyPauseGuardian whenPaused {
+    function unpause() external override onlyPauseGuardian whenPaused {
         _unpause();
     }
 

--- a/packages/horizon/contracts/data-service/extensions/DataServicePausableUpgradeable.sol
+++ b/packages/horizon/contracts/data-service/extensions/DataServicePausableUpgradeable.sol
@@ -26,14 +26,14 @@ abstract contract DataServicePausableUpgradeable is PausableUpgradeable, DataSer
     /**
      * @notice See {IDataServicePausable-pause}
      */
-    function pause() external onlyPauseGuardian whenNotPaused {
+    function pause() external override onlyPauseGuardian whenNotPaused {
         _pause();
     }
 
     /**
      * @notice See {IDataServicePausable-pause}
      */
-    function unpause() external onlyPauseGuardian whenPaused {
+    function unpause() external override onlyPauseGuardian whenPaused {
         _unpause();
     }
 

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -351,7 +351,7 @@ contract SubgraphService is
     /**
      * @notice See {ISubgraphService.setRewardsDestination}
      */
-    function setRewardsDestination(address rewardsDestination) external {
+    function setRewardsDestination(address rewardsDestination) external override {
         _setRewardsDestination(msg.sender, rewardsDestination);
     }
 


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-09 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-09), applying the recommended fixes.


### Title: 
N-09 Missing override Keyword in Functions

### Details: 
Throughout the codebase, multiple instances of functions lacking the override keyword were identified:

The [pause](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServicePausable.sol#L33) and [unpause](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServicePausable.sol#L40) functions of the DataServicePausable contract
The [pause](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServicePausableUpgradeable.sol#L29) and [unpause](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServicePausableUpgradeable.sol#L36) functions of the DataServicePausableUpgradeable contract
The [setRewardsDestination](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/SubgraphService.sol#L325) function of the SubgraphService contract
Functions that override the base contract functions ought to have the override keyword. Otherwise, it can be confusing for readers and developers, leading to potential misunderstandings about a function's origin and behavior. As such, consider using the override keyword for all functions that override base contract functions to enhance code readability and clarity.

##

### Key changes

- Added the override keyword to the functions outlined, applying the recommended fixes. 