### PR TITLE
fix: remove unused return values. (OZ N-10)

### DIFF
--- a/packages/subgraph-service/contracts/libraries/Allocation.sol
+++ b/packages/subgraph-service/contracts/libraries/Allocation.sol
@@ -96,12 +96,10 @@ library Allocation {
      * @param self The allocation list mapping
      * @param allocationId The allocation id
      */
-    function presentPOI(mapping(address => State) storage self, address allocationId) internal returns (State memory) {
+    function presentPOI(mapping(address => State) storage self, address allocationId) internal {
         State storage allocation = _get(self, allocationId);
         require(allocation.isOpen(), AllocationClosed(allocationId, allocation.closedAt));
         allocation.lastPOIPresentedAt = block.timestamp;
-
-        return allocation;
     }
 
     /**
@@ -116,12 +114,10 @@ library Allocation {
         mapping(address => State) storage self,
         address allocationId,
         uint256 accRewardsPerAllocatedToken
-    ) internal returns (State memory) {
+    ) internal {
         State storage allocation = _get(self, allocationId);
         require(allocation.isOpen(), AllocationClosed(allocationId, allocation.closedAt));
         allocation.accRewardsPerAllocatedToken = accRewardsPerAllocatedToken;
-
-        return allocation;
     }
 
     /**
@@ -131,15 +127,10 @@ library Allocation {
      * @param self The allocation list mapping
      * @param allocationId The allocation id
      */
-    function clearPendingRewards(
-        mapping(address => State) storage self,
-        address allocationId
-    ) internal returns (State memory) {
+    function clearPendingRewards(mapping(address => State) storage self, address allocationId) internal {
         State storage allocation = _get(self, allocationId);
         require(allocation.isOpen(), AllocationClosed(allocationId, allocation.closedAt));
         allocation.accRewardsPending = 0;
-
-        return allocation;
     }
 
     /**
@@ -149,12 +140,10 @@ library Allocation {
      * @param self The allocation list mapping
      * @param allocationId The allocation id
      */
-    function close(mapping(address => State) storage self, address allocationId) internal returns (State memory) {
+    function close(mapping(address => State) storage self, address allocationId) internal {
         State storage allocation = _get(self, allocationId);
         require(allocation.isOpen(), AllocationClosed(allocationId, allocation.closedAt));
         allocation.closedAt = block.timestamp;
-
-        return allocation;
     }
 
     /**

--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -396,7 +396,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
      *
      * @param _allocationId The id of the allocation to be closed
      */
-    function _closeAllocation(address _allocationId) internal returns (Allocation.State memory) {
+    function _closeAllocation(address _allocationId) internal {
         Allocation.State memory allocation = allocations.get(_allocationId);
 
         // Take rewards snapshot to prevent other allos from counting tokens from this allo
@@ -414,7 +414,6 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
             allocation.tokens;
 
         emit AllocationClosed(allocation.indexer, _allocationId, allocation.subgraphDeploymentId, allocation.tokens);
-        return allocations[_allocationId];
     }
 
     /**


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-10 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-10), applying the recommended fixes.


### Title: 
N-10 Redundant Return Values

### Details: 
Throughout the codebase, multiple instances of functions with unused return values were identified:

The [_closeAllocation](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L390) function of the AllocationManager contract
The [presentPOI](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/Allocation.sol#L98), [clearPendingRewards](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/Allocation.sol#L133), [close](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/Allocation.sol#L151), and [snapshotRewards](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/Allocation.sol#L114) functions of the Allocation library
Consider removing these unused return values to simplify the code and improve readability, ensuring that functions only return values that are actively utilized by their callers.

##

### Key changes

- Removed the unused return value for the the `_closeAllocation ` function of the AllocationManager contract.
- Removed the unused return value for the the `presentPOI`, `clearPendingRewards`, `close`, and `snapshotRewards `functions function of the Allocation library.