### PR TITLE
fix: remove use of magic numbers in __ProvisionManager_init_unchained function (OZ N-11)

### DIFF
--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -25,11 +25,11 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
 
     // Constants
     uint32 private constant DEFAULT_MIN_VERIFIER_CUT = type(uint32).min;
-    uint32 private constant DEFAULT_MAX_VERIFIER_CUT = uint32(PPMMath.MAX_PPM);
+    uint32 internal constant DEFAULT_MAX_VERIFIER_CUT = uint32(PPMMath.MAX_PPM);
     uint64 private constant DEFAULT_MIN_THAWING_PERIOD = type(uint64).min;
-    uint64 private constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
+    uint64 internal constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
     uint256 private constant DEFAULT_MIN_PROVISION_TOKENS = type(uint256).min;
-    uint256 private constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
+    uint256 internal constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
 
     /**
      * @notice Emitted when the provision tokens range is set.

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -24,11 +24,11 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
     using UintRange for uint256;
 
     // Constants
-    uint32 private constant DEFAULT_MIN_VERIFIER_CUT = type(uint32).min;
+    uint32 internal constant DEFAULT_MIN_VERIFIER_CUT = type(uint32).min;
     uint32 internal constant DEFAULT_MAX_VERIFIER_CUT = uint32(PPMMath.MAX_PPM);
-    uint64 private constant DEFAULT_MIN_THAWING_PERIOD = type(uint64).min;
+    uint64 internal constant DEFAULT_MIN_THAWING_PERIOD = type(uint64).min;
     uint64 internal constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
-    uint256 private constant DEFAULT_MIN_PROVISION_TOKENS = type(uint256).min;
+    uint256 internal constant DEFAULT_MIN_PROVISION_TOKENS = type(uint256).min;
     uint256 internal constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
 
     /**

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -23,6 +23,14 @@ import { ProvisionManagerV1Storage } from "./ProvisionManagerStorage.sol";
 abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionManagerV1Storage {
     using UintRange for uint256;
 
+    // Constants
+    uint32 private constant DEFAULT_MIN_UINT32 = 0;
+    uint64 private constant DEFAULT_MIN_UINT64 = 0;
+    uint256 private constant DEFAULT_MIN_UINT256 = 0;
+    uint64 private constant DEFAULT_MAX_UINT64 = type(uint64).max;
+    uint256 private constant DEFAULT_MAX_UINT256 = type(uint256).max;
+    uint32 private constant MAX_PPM = uint32(PPMMath.MAX_PPM);
+
     /**
      * @notice Emitted when the provision tokens range is set.
      * @param min The minimum allowed value for the provision tokens.
@@ -115,9 +123,9 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
      */
     // solhint-disable-next-line func-name-mixedcase
     function __ProvisionManager_init_unchained() internal onlyInitializing {
-        _setProvisionTokensRange(type(uint256).min, type(uint256).max);
-        _setVerifierCutRange(type(uint32).min, uint32(PPMMath.MAX_PPM));
-        _setThawingPeriodRange(type(uint64).min, type(uint64).max);
+        _setProvisionTokensRange(DEFAULT_MIN_UINT256, DEFAULT_MAX_UINT256);
+        _setVerifierCutRange(DEFAULT_MIN_UINT32, MAX_PPM);
+        _setThawingPeriodRange(DEFAULT_MIN_UINT64, DEFAULT_MAX_UINT64);
     }
 
     /**

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -24,12 +24,12 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
     using UintRange for uint256;
 
     // Constants
-    uint32 private constant DEFAULT_MIN_VERIFIER_CUT = 0;
-    uint64 private constant DEFAULT_MIN_THAWING_PERIOD = 0;
-    uint256 private constant DEFAULT_MIN_PROVISION_TOKENS = 0;
-    uint64 private constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
-    uint256 private constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
+    uint32 private constant DEFAULT_MIN_VERIFIER_CUT = type(uint32).min;
     uint32 private constant DEFAULT_MAX_VERIFIER_CUT = uint32(PPMMath.MAX_PPM);
+    uint64 private constant DEFAULT_MIN_THAWING_PERIOD = type(uint64).min;
+    uint64 private constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
+    uint256 private constant DEFAULT_MIN_PROVISION_TOKENS = type(uint256).min;
+    uint256 private constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
 
     /**
      * @notice Emitted when the provision tokens range is set.

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -24,12 +24,12 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
     using UintRange for uint256;
 
     // Constants
-    uint32 private constant DEFAULT_MIN_UINT32 = 0;
-    uint64 private constant DEFAULT_MIN_UINT64 = 0;
-    uint256 private constant DEFAULT_MIN_UINT256 = 0;
-    uint64 private constant DEFAULT_MAX_UINT64 = type(uint64).max;
-    uint256 private constant DEFAULT_MAX_UINT256 = type(uint256).max;
-    uint32 private constant MAX_PPM = uint32(PPMMath.MAX_PPM);
+    uint32 private constant DEFAULT_MIN_VERIFIER_CUT = 0;
+    uint64 private constant DEFAULT_MIN_THAWING_PERIOD = 0;
+    uint256 private constant DEFAULT_MIN_PROVISION_TOKENS = 0;
+    uint64 private constant DEFAULT_MAX_THAWING_PERIOD = type(uint64).max;
+    uint256 private constant DEFAULT_MAX_PROVISION_TOKENS = type(uint256).max;
+    uint32 private constant DEFAULT_MAX_VERIFIER_CUT = uint32(PPMMath.MAX_PPM);
 
     /**
      * @notice Emitted when the provision tokens range is set.
@@ -123,9 +123,9 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
      */
     // solhint-disable-next-line func-name-mixedcase
     function __ProvisionManager_init_unchained() internal onlyInitializing {
-        _setProvisionTokensRange(DEFAULT_MIN_UINT256, DEFAULT_MAX_UINT256);
-        _setVerifierCutRange(DEFAULT_MIN_UINT32, MAX_PPM);
-        _setThawingPeriodRange(DEFAULT_MIN_UINT64, DEFAULT_MAX_UINT64);
+        _setProvisionTokensRange(DEFAULT_MIN_PROVISION_TOKENS, DEFAULT_MAX_PROVISION_TOKENS);
+        _setVerifierCutRange(DEFAULT_MIN_VERIFIER_CUT, DEFAULT_MAX_VERIFIER_CUT);
+        _setThawingPeriodRange(DEFAULT_MIN_THAWING_PERIOD, DEFAULT_MAX_THAWING_PERIOD);
     }
 
     /**

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -21,9 +21,14 @@ import { PPMMath } from "@graphprotocol/horizon/contracts/libraries/PPMMath.sol"
 import { Allocation } from "./libraries/Allocation.sol";
 import { LegacyAllocation } from "./libraries/LegacyAllocation.sol";
 
+import { ProvisionManager } from "@graphprotocol/horizon/contracts/data-service/utilities/ProvisionManager.sol";
+
+
+
 contract SubgraphService is
     Initializable,
     OwnableUpgradeable,
+    ProvisionManager,
     DataService,
     DataServicePausableUpgradeable,
     DataServiceFees,
@@ -359,7 +364,7 @@ contract SubgraphService is
      * @notice See {ISubgraphService.setMinimumProvisionTokens}
      */
     function setMinimumProvisionTokens(uint256 minimumProvisionTokens) external override onlyOwner {
-        _setProvisionTokensRange(minimumProvisionTokens, type(uint256).max);
+        _setProvisionTokensRange(minimumProvisionTokens, DEFAULT_MAX_PROVISION_TOKENS);
     }
 
     /**
@@ -473,7 +478,7 @@ contract SubgraphService is
      */
     function _getThawingPeriodRange() internal view override returns (uint64 min, uint64 max) {
         uint64 disputePeriod = _disputeManager().getDisputePeriod();
-        return (disputePeriod, type(uint64).max);
+        return (disputePeriod, DEFAULT_MAX_THAWING_PERIOD);
     }
 
     /**
@@ -483,7 +488,7 @@ contract SubgraphService is
      */
     function _getVerifierCutRange() internal view override returns (uint32 min, uint32 max) {
         uint32 verifierCut = _disputeManager().getVerifierCut();
-        return (verifierCut, uint32(PPMMath.MAX_PPM));
+        return (verifierCut, DEFAULT_MAX_VERIFIER_CUT);
     }
 
     /**

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -22,9 +22,6 @@ import { PPMMath } from "@graphprotocol/horizon/contracts/libraries/PPMMath.sol"
 import { Allocation } from "./libraries/Allocation.sol";
 import { LegacyAllocation } from "./libraries/LegacyAllocation.sol";
 
-
-
-
 contract SubgraphService is
     Initializable,
     OwnableUpgradeable,

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -22,14 +22,12 @@ import { PPMMath } from "@graphprotocol/horizon/contracts/libraries/PPMMath.sol"
 import { Allocation } from "./libraries/Allocation.sol";
 import { LegacyAllocation } from "./libraries/LegacyAllocation.sol";
 
-import { ProvisionManager } from "@graphprotocol/horizon/contracts/data-service/utilities/ProvisionManager.sol";
 
 
 
 contract SubgraphService is
     Initializable,
     OwnableUpgradeable,
-    ProvisionManager,
     MulticallUpgradeable,
     DataService,
     DataServicePausableUpgradeable,


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-11 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-11), applying the recommended fixes.


### Title: 
N-11 Use Constants for Default Values

### Details: 
In the ProvisionManager contract, the [__ProvisionManager_init_unchained function](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol#L151) initializes multiple default values such as type(uint256).min, type(uint256).max, type(uint32).min, type(uint32).max, type(uint64).min, and type(uint64).max directly within the function body.

This approach introduces magic numbers, reducing code readability and maintainability. Moreover, it could potentially introduce errors since the same literal values are used in [another part of the codebase](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/SubgraphService.sol#L436C5-L456C6) as well. In addition, the verifierCutRange is set between 0 and uint32.max but the maximum should be set to MAX_PPM.

Consider revising all uses of literal values, defining constants for them where applicable, and setting a more sensible maximum value for verifierCutRange.

##

### Key changes

- Removed the use of magic numbers inside the __ProvisionManager_init_unchained function, now using constants for default values. 
