### PR TITLE
fix: reorder parameter use in mulPPM function call in mulPPMRoundUp function. (OZ N-12)

### DIFF
--- a/packages/horizon/contracts/libraries/PPMMath.sol
+++ b/packages/horizon/contracts/libraries/PPMMath.sol
@@ -42,7 +42,7 @@ library PPMMath {
      */
     function mulPPMRoundUp(uint256 a, uint256 b) internal pure returns (uint256) {
         require(isValidPPM(b), PPMMathInvalidPPM(b));
-        return a - mulPPM(MAX_PPM - b, a);
+        return a - mulPPM(a, MAX_PPM - b);
     }
 
     /**


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-12 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-12), applying the recommended fixes.


#### Title and details found from the above link.  


##

### Key changes

- Order of parameter use changed from `(MAX_PPM - b, a)` to `(a, MAX_PPM - b)`
