### PR TITLE
fix: standardize naming conventions throughout the codebase (OZ N-13)

### DIFF
--- a/packages/contracts/contracts/disputes/DisputeManager.sol
+++ b/packages/contracts/contracts/disputes/DisputeManager.sol
@@ -29,7 +29,7 @@ import "./IDisputeManager.sol";
  * Indexers present a Proof of Indexing (POI) when they close allocations to prove
  * they were indexing a subgraph. The Staking contract emits that proof with the format
  * keccak256(indexer.address, POI).
- * Any challenger can dispute the validity of a POI by submitting a dispute to this contract
+ * Any fisherman can dispute the validity of a POI by submitting a dispute to this contract
  * along with a deposit.
  *
  * Arbitration:
@@ -355,8 +355,8 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
      * @param _deposit Amount of tokens staked as deposit
      */
     function createQueryDispute(bytes calldata _attestationData, uint256 _deposit) external override returns (bytes32) {
-        // Get funds from submitter
-        _pullSubmitterDeposit(_deposit);
+        // Get funds from fisherman
+        _pullFishermanDeposit(_deposit);
 
         // Create a dispute
         return
@@ -372,7 +372,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
      * @dev Create query disputes for two conflicting attestations.
      * A conflicting attestation is a proof presented by two different indexers
      * where for the same request on a subgraph the response is different.
-     * For this type of dispute the submitter is not required to present a deposit
+     * For this type of dispute the fisherman is not required to present a deposit
      * as one of the attestation is considered to be right.
      * Two linked disputes will be created and if the arbitrator resolve one, the other
      * one will be automatically resolved.
@@ -470,14 +470,14 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
     /**
      * @dev Create an indexing dispute for the arbitrator to resolve.
      * The disputes are created in reference to an allocationID
-     * This function is called by a challenger that will need to `_deposit` at
+     * This function is called by a fisherman that will need to `_deposit` at
      * least `minimumDeposit` GRT tokens.
      * @param _allocationID The allocation to dispute
      * @param _deposit Amount of tokens staked as deposit
      */
     function createIndexingDispute(address _allocationID, uint256 _deposit) external override returns (bytes32) {
-        // Get funds from submitter
-        _pullSubmitterDeposit(_deposit);
+        // Get funds from fisherman
+        _pullFishermanDeposit(_deposit);
 
         // Create a dispute
         return _createIndexingDisputeWithAllocation(msg.sender, _deposit, _allocationID);
@@ -485,7 +485,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
 
     /**
      * @dev Create indexing dispute internal function.
-     * @param _fisherman The challenger creating the dispute
+     * @param _fisherman The fisherman creating the dispute
      * @param _deposit Amount of tokens staked as deposit
      * @param _allocationID Allocation disputed
      */
@@ -621,10 +621,10 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
     }
 
     /**
-     * @dev Pull deposit from submitter account.
+     * @dev Pull deposit from fisherman account.
      * @param _deposit Amount of tokens to deposit
      */
-    function _pullSubmitterDeposit(uint256 _deposit) private {
+    function _pullFishermanDeposit(uint256 _deposit) private {
         // Ensure that fisherman has staked at least the minimum amount
         require(_deposit >= minimumDeposit, "Dispute deposit is under minimum required");
 
@@ -633,17 +633,17 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
     }
 
     /**
-     * @dev Make the staking contract slash the indexer and reward the challenger.
-     * Give the challenger a reward equal to the fishermanRewardPercentage of slashed amount
+     * @dev Make the staking contract slash the indexer and reward the fisherman.
+     * Give the fisherman a reward equal to the fishermanRewardPercentage of slashed amount
      * @param _indexer Address of the indexer
-     * @param _challenger Address of the challenger
+     * @param _fisherman Address of the fisherman
      * @param _disputeType Type of dispute
      * @return slashAmount Dispute slash amount
      * @return rewardsAmount Dispute rewards amount
      */
     function _slashIndexer(
         address _indexer,
-        address _challenger,
+        address _fisherman,
         DisputeType _disputeType
     ) private returns (uint256 slashAmount, uint256 rewardsAmount) {
         IStaking staking = staking();
@@ -660,7 +660,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
 
         // Have staking contract slash the indexer and reward the fisherman
         // Give the fisherman a reward equal to the fishermanRewardPercentage of slashed amount
-        staking.slash(_indexer, slashAmount, rewardsAmount, _challenger);
+        staking.slash(_indexer, slashAmount, rewardsAmount, _fisherman);
     }
 
     /**

--- a/packages/contracts/contracts/disputes/DisputeManager.sol
+++ b/packages/contracts/contracts/disputes/DisputeManager.sol
@@ -606,7 +606,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
     }
 
     /**
-     * @dev Resolve the conflicting dispute if there is any for the one passed to this function.
+     * @dev Draw the conflicting dispute if there is any for the one passed to this function.
      * @param _dispute Dispute
      * @return True if resolved
      */

--- a/packages/contracts/contracts/governance/Controller.sol
+++ b/packages/contracts/contracts/governance/Controller.sol
@@ -89,10 +89,10 @@ contract Controller is Governed, Pausable, IController {
     /**
      * @notice Change the partial paused state of the contract
      * Partial pause is intended as a partial pause of the protocol
-     * @param _toPause True if the contracts should be (partially) paused, false otherwise
+     * @param _toPartialPause True if the contracts should be (partially) paused, false otherwise
      */
-    function setPartialPaused(bool _toPause) external override onlyGovernorOrGuardian {
-        _setPartialPaused(_toPause);
+    function setPartialPaused(bool _toPartialPause) external override onlyGovernorOrGuardian {
+        _setPartialPaused(_toPartialPause);
     }
 
     /**

--- a/packages/contracts/contracts/governance/Pausable.sol
+++ b/packages/contracts/contracts/governance/Pausable.sol
@@ -14,7 +14,7 @@ abstract contract Pausable {
     bool internal _paused;
 
     /// Timestamp for the last time the partial pause was set
-    uint256 public lastPausePartialTime;
+    uint256 public lastPartialPauseTime;
     /// Timestamp for the last time the full pause was set
     uint256 public lastPauseTime;
 
@@ -39,7 +39,7 @@ abstract contract Pausable {
         }
         _partialPaused = _toPartialPause;
         if (_partialPaused) {
-            lastPausePartialTime = block.timestamp;
+            lastPartialPauseTime = block.timestamp;
         }
         emit PartialPauseChanged(_partialPaused);
     }

--- a/packages/contracts/contracts/governance/Pausable.sol
+++ b/packages/contracts/contracts/governance/Pausable.sol
@@ -31,13 +31,13 @@ abstract contract Pausable {
 
     /**
      * @dev Change the partial paused state of the contract
-     * @param _toPause New value for the partial pause state (true means the contracts will be partially paused)
+     * @param _toPartialPause New value for the partial pause state (true means the contracts will be partially paused)
      */
-    function _setPartialPaused(bool _toPause) internal {
-        if (_toPause == _partialPaused) {
+    function _setPartialPaused(bool _toPartialPause) internal {
+        if (_toPartialPause == _partialPaused) {
             return;
         }
-        _partialPaused = _toPause;
+        _partialPaused = _toPartialPause;
         if (_partialPaused) {
             lastPausePartialTime = block.timestamp;
         }

--- a/packages/contracts/test/unit/disputes/common.ts
+++ b/packages/contracts/test/unit/disputes/common.ts
@@ -16,7 +16,7 @@ export interface Dispute {
 export function createQueryDisputeID(
   attestation: Attestation,
   indexerAddress: string,
-  submitterAddress: string,
+  fishermanAddress: string,
 ): string {
   return solidityKeccak256(
     ['bytes32', 'bytes32', 'bytes32', 'address', 'address'],
@@ -25,7 +25,7 @@ export function createQueryDisputeID(
       attestation.responseCID,
       attestation.subgraphDeploymentID,
       indexerAddress,
-      submitterAddress,
+      fishermanAddress,
     ],
   )
 }

--- a/packages/horizon/contracts/data-service/extensions/DataServiceFees.sol
+++ b/packages/horizon/contracts/data-service/extensions/DataServiceFees.sol
@@ -22,8 +22,8 @@ abstract contract DataServiceFees is DataService, DataServiceFeesV1Storage, IDat
     /**
      * @notice See {IDataServiceFees-releaseStake}
      */
-    function releaseStake(uint256 n) external virtual override {
-        _releaseStake(msg.sender, n);
+    function releaseStake(uint256 numClaimsToRelease) external virtual override {
+        _releaseStake(msg.sender, numClaimsToRelease);
     }
 
     /**
@@ -61,14 +61,14 @@ abstract contract DataServiceFees is DataService, DataServiceFeesV1Storage, IDat
     /**
      * @notice See {IDataServiceFees-releaseStake}
      */
-    function _releaseStake(address _serviceProvider, uint256 _n) internal {
+    function _releaseStake(address _serviceProvider, uint256 _numClaimsToRelease) internal {
         LinkedList.List storage claimsList = claimsLists[_serviceProvider];
         (uint256 claimsReleased, bytes memory data) = claimsList.traverse(
             _getNextStakeClaim,
             _processStakeClaim,
             _deleteStakeClaim,
             abi.encode(0, _serviceProvider),
-            _n
+            _numClaimsToRelease
         );
 
         emit StakeClaimsReleased(_serviceProvider, claimsReleased, abi.decode(data, (uint256)));

--- a/packages/horizon/contracts/data-service/extensions/DataServiceFees.sol
+++ b/packages/horizon/contracts/data-service/extensions/DataServiceFees.sol
@@ -49,7 +49,7 @@ abstract contract DataServiceFees is DataService, DataServiceFeesV1Storage, IDat
         claims[claimId] = StakeClaim({
             tokens: _tokens,
             createdAt: block.timestamp,
-            releaseAt: _unlockTimestamp,
+            releasableAt: _unlockTimestamp,
             nextClaim: bytes32(0)
         });
         if (claimsList.count != 0) claims[claimsList.tail].nextClaim = claimId;
@@ -86,7 +86,7 @@ abstract contract DataServiceFees is DataService, DataServiceFeesV1Storage, IDat
         StakeClaim memory claim = _getStakeClaim(_claimId);
 
         // early exit
-        if (claim.releaseAt > block.timestamp) {
+        if (claim.releasableAt > block.timestamp) {
             return (true, LinkedList.NULL_BYTES);
         }
 
@@ -95,7 +95,7 @@ abstract contract DataServiceFees is DataService, DataServiceFeesV1Storage, IDat
 
         // process
         feesProvisionTracker.release(serviceProvider, claim.tokens);
-        emit StakeClaimReleased(serviceProvider, _claimId, claim.tokens, claim.releaseAt);
+        emit StakeClaimReleased(serviceProvider, _claimId, claim.tokens, claim.releasableAt);
 
         // encode
         _acc = abi.encode(tokensClaimed + claim.tokens, serviceProvider);

--- a/packages/horizon/contracts/data-service/interfaces/IDataService.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataService.sol
@@ -25,7 +25,7 @@ interface IDataService {
      * @notice Emitted when a service provider accepts a provision in {Graph Horizon staking contract}.
      * @param serviceProvider The address of the service provider.
      */
-    event ProvisionAccepted(address indexed serviceProvider);
+    event ProvisionPendingParametersAccepted(address indexed serviceProvider);
 
     /**
      * @notice Emitted when a service provider starts providing the service.
@@ -83,7 +83,7 @@ interface IDataService {
      * contract}.
      * @dev Provides a way for the data service to validate and accept provision parameter changes. Call {_acceptProvision}.
      *
-     * Emits a {ProvisionAccepted} event.
+     * Emits a {ProvisionPendingParametersAccepted} event.
      *
      * @param serviceProvider The address of the service provider.
      * @param data Custom data, usage defined by the data service.

--- a/packages/horizon/contracts/data-service/interfaces/IDataService.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataService.sol
@@ -79,7 +79,7 @@ interface IDataService {
     function register(address serviceProvider, bytes calldata data) external;
 
     /**
-     * @notice Accepts staged parameters in the provision of a service provider in the {Graph Horizon staking
+     * @notice Accepts pending parameters in the provision of a service provider in the {Graph Horizon staking
      * contract}.
      * @dev Provides a way for the data service to validate and accept provision parameter changes. Call {_acceptProvision}.
      *

--- a/packages/horizon/contracts/data-service/interfaces/IDataService.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataService.sol
@@ -88,7 +88,7 @@ interface IDataService {
      * @param serviceProvider The address of the service provider.
      * @param data Custom data, usage defined by the data service.
      */
-    function acceptProvision(address serviceProvider, bytes calldata data) external;
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external;
 
     /**
      * @notice Service provider starts providing the service.

--- a/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol
@@ -32,7 +32,7 @@ interface IDataServiceFees is IDataService {
         // Timestamp when the claim was created
         uint256 createdAt;
         // Timestamp when the claim will expire and tokens can be released
-        uint256 releaseAt;
+        uint256 releasableAt;
         // Next claim in the linked list
         bytes32 nextClaim;
     }
@@ -56,13 +56,13 @@ interface IDataServiceFees is IDataService {
      * @param serviceProvider The address of the service provider
      * @param claimId The id of the stake claim
      * @param tokens The amount of tokens released
-     * @param releaseAt The timestamp when the tokens were released
+     * @param releasableAt The timestamp when the tokens were released
      */
     event StakeClaimReleased(
         address indexed serviceProvider,
         bytes32 indexed claimId,
         uint256 tokens,
-        uint256 releaseAt
+        uint256 releasableAt
     );
 
     /**

--- a/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol
@@ -89,7 +89,7 @@ interface IDataServiceFees is IDataService {
      * stake claims that releasing them all at once would exceed the block gas limit.
      * @dev This function can be overriden and/or disabled.
      * @dev Emits a {StakeClaimsReleased} event, and a {StakeClaimReleased} event for each claim released.
-     * @param n Amount of stake claims to process. If 0, all stake claims are processed.
+     * @param numClaimsToRelease Amount of stake claims to process. If 0, all stake claims are processed.
      */
-    function releaseStake(uint256 n) external;
+    function releaseStake(uint256 numClaimsToRelease) external;
 }

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -82,7 +82,7 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
     /**
      * @notice Checks if the caller is authorized to manage the provision of a service provider.
      */
-    modifier onlyProvisionAuthorized(address serviceProvider) {
+    modifier onlyAuthorizedForProvision(address serviceProvider) {
         require(
             _graphStaking().isAuthorized(msg.sender, serviceProvider, address(this)),
             ProvisionManagerNotAuthorized(msg.sender, serviceProvider)

--- a/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
+++ b/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol
@@ -125,7 +125,7 @@ abstract contract ProvisionManager is Initializable, GraphDirectory, ProvisionMa
      * the {HorizonStaking} contract.
      * @dev Checks the pending provision parameters, not the current ones.
      *
-     * Emits a {ProvisionAccepted} event.
+     * Emits a {ProvisionPendingParametersAccepted} event.
      *
      * @param _serviceProvider The address of the service provider.
      */

--- a/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
+++ b/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
@@ -131,9 +131,9 @@ interface IPaymentsEscrow {
     /**
      * @notice Thrown when setting the thawing period to a value greater than the maximum
      * @param thawingPeriod The thawing period
-     * @param maxThawingPeriod The maximum thawing period
+     * @param maxWaitPeriod The maximum wait period
      */
-    error PaymentsEscrowThawingPeriodTooLong(uint256 thawingPeriod, uint256 maxThawingPeriod);
+    error PaymentsEscrowThawingPeriodTooLong(uint256 thawingPeriod, uint256 maxWaitPeriod);
 
     /**
      * @notice Thrown when a collector has insufficient allowance to collect funds

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -31,7 +31,7 @@ contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, 
 
     /// @notice The maximum thawing period (in seconds) for both escrow withdrawal and signer revocation
     /// @dev This is a precautionary measure to avoid inadvertedly locking funds for too long
-    uint256 public constant MAX_THAWING_PERIOD = 90 days;
+    uint256 public constant MAX_WAIT_PERIOD = 90 days;
 
     /// @notice Thawing period in seconds for authorized collectors
     uint256 public immutable REVOKE_COLLECTOR_THAWING_PERIOD;
@@ -56,12 +56,12 @@ contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, 
         uint256 withdrawEscrowThawingPeriod
     ) GraphDirectory(controller) {
         require(
-            revokeCollectorThawingPeriod <= MAX_THAWING_PERIOD,
-            PaymentsEscrowThawingPeriodTooLong(revokeCollectorThawingPeriod, MAX_THAWING_PERIOD)
+            revokeCollectorThawingPeriod <= MAX_WAIT_PERIOD,
+            PaymentsEscrowThawingPeriodTooLong(revokeCollectorThawingPeriod, MAX_WAIT_PERIOD)
         );
         require(
-            withdrawEscrowThawingPeriod <= MAX_THAWING_PERIOD,
-            PaymentsEscrowThawingPeriodTooLong(withdrawEscrowThawingPeriod, MAX_THAWING_PERIOD)
+            withdrawEscrowThawingPeriod <= MAX_WAIT_PERIOD,
+            PaymentsEscrowThawingPeriodTooLong(withdrawEscrowThawingPeriod, MAX_WAIT_PERIOD)
         );
 
         REVOKE_COLLECTOR_THAWING_PERIOD = revokeCollectorThawingPeriod;

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -226,16 +226,16 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     function setProvisionParameters(
         address serviceProvider,
         address verifier,
-        uint32 maxVerifierCut,
-        uint64 thawingPeriod
+        uint32 newMaxVerifierCut,
+        uint64 newThawingPeriod
     ) external override notPaused onlyAuthorized(serviceProvider, verifier) {
         Provision storage prov = _provisions[serviceProvider][verifier];
         require(prov.createdAt != 0, HorizonStakingInvalidProvision(serviceProvider, verifier));
 
-        if ((prov.maxVerifierCutPending != maxVerifierCut) || (prov.thawingPeriodPending != thawingPeriod)) {
-            prov.maxVerifierCutPending = maxVerifierCut;
-            prov.thawingPeriodPending = thawingPeriod;
-            emit ProvisionParametersStaged(serviceProvider, verifier, maxVerifierCut, thawingPeriod);
+        if ((prov.maxVerifierCutPending != newMaxVerifierCut) || (prov.thawingPeriodPending != newThawingPeriod)) {
+            prov.maxVerifierCutPending = newMaxVerifierCut;
+            prov.thawingPeriodPending = newThawingPeriod;
+            emit ProvisionParametersStaged(serviceProvider, verifier, newMaxVerifierCut, newThawingPeriod);
         }
     }
 

--- a/packages/horizon/test/data-service/extensions/DataServiceFees.t.sol
+++ b/packages/horizon/test/data-service/extensions/DataServiceFees.t.sol
@@ -159,12 +159,12 @@ contract DataServiceFeesTest is HorizonStakingSharedTest {
         assertEq(beforeLockedStake + calcValues.stakeToLock, afterLockedStake);
 
         // it should create a stake claim
-        (uint256 claimTokens, uint256 createdAt, uint256 releaseAt, bytes32 nextClaim) = dataService.claims(
+        (uint256 claimTokens, uint256 createdAt, uint256 releasableAt, bytes32 nextClaim) = dataService.claims(
             calcValues.predictedClaimId
         );
         assertEq(claimTokens, calcValues.stakeToLock);
         assertEq(createdAt, block.timestamp);
-        assertEq(releaseAt, calcValues.unlockTimestamp);
+        assertEq(releasableAt, calcValues.unlockTimestamp);
         assertEq(nextClaim, bytes32(0));
 
         // it should update the list
@@ -196,12 +196,12 @@ contract DataServiceFeesTest is HorizonStakingSharedTest {
             head: beforeHead
         });
         while (calcValues.head != bytes32(0) && (calcValues.claimsCount < numClaimsToRelease || numClaimsToRelease == 0)) {
-            (uint256 claimTokens, , uint256 releaseAt, bytes32 nextClaim) = dataService.claims(calcValues.head);
-            if (releaseAt > block.timestamp) {
+            (uint256 claimTokens, , uint256 releasableAt, bytes32 nextClaim) = dataService.claims(calcValues.head);
+            if (releasableAt > block.timestamp) {
                 break;
             }
 
-            emit IDataServiceFees.StakeClaimReleased(serviceProvider, calcValues.head, claimTokens, releaseAt);
+            emit IDataServiceFees.StakeClaimReleased(serviceProvider, calcValues.head, claimTokens, releasableAt);
             calcValues.head = nextClaim;
             calcValues.tokensReleased += claimTokens;
             calcValues.claimsCount++;

--- a/packages/horizon/test/data-service/implementations/DataServiceBase.sol
+++ b/packages/horizon/test/data-service/implementations/DataServiceBase.sol
@@ -19,7 +19,7 @@ contract DataServiceBase is DataService {
 
     function register(address serviceProvider, bytes calldata data) external {}
 
-    function acceptProvision(address serviceProvider, bytes calldata data) external {}
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external {}
 
     function startService(address serviceProvider, bytes calldata data) external {}
 

--- a/packages/horizon/test/data-service/implementations/DataServiceBaseUpgradeable.sol
+++ b/packages/horizon/test/data-service/implementations/DataServiceBaseUpgradeable.sol
@@ -15,7 +15,7 @@ contract DataServiceBaseUpgradeable is DataService {
 
     function register(address serviceProvider, bytes calldata data) external {}
 
-    function acceptProvision(address serviceProvider, bytes calldata data) external {}
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external {}
 
     function startService(address serviceProvider, bytes calldata data) external {}
 

--- a/packages/horizon/test/data-service/implementations/DataServiceImpFees.sol
+++ b/packages/horizon/test/data-service/implementations/DataServiceImpFees.sol
@@ -15,7 +15,7 @@ contract DataServiceImpFees is DataServiceFees {
 
     function register(address serviceProvider, bytes calldata data) external {}
 
-    function acceptProvision(address serviceProvider, bytes calldata data) external {}
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external {}
 
     function startService(address serviceProvider, bytes calldata data) external {}
 

--- a/packages/horizon/test/data-service/implementations/DataServiceImpPausable.sol
+++ b/packages/horizon/test/data-service/implementations/DataServiceImpPausable.sol
@@ -23,7 +23,7 @@ contract DataServiceImpPausable is DataServicePausable {
 
     function register(address serviceProvider, bytes calldata data) external {}
 
-    function acceptProvision(address serviceProvider, bytes calldata data) external {}
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external {}
 
     function startService(address serviceProvider, bytes calldata data) external {}
 

--- a/packages/horizon/test/data-service/implementations/DataServiceImpPausableUpgradeable.sol
+++ b/packages/horizon/test/data-service/implementations/DataServiceImpPausableUpgradeable.sol
@@ -17,7 +17,7 @@ contract DataServiceImpPausableUpgradeable is DataServicePausableUpgradeable {
 
     function register(address serviceProvider, bytes calldata data) external {}
 
-    function acceptProvision(address serviceProvider, bytes calldata data) external {}
+    function acceptProvisionPendingParameters(address serviceProvider, bytes calldata data) external {}
 
     function startService(address serviceProvider, bytes calldata data) external {}
 

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -34,7 +34,7 @@ import { AttestationManager } from "./utilities/AttestationManager.sol";
  * Indexers present a Proof of Indexing (POI) when they close allocations to prove
  * they were indexing a subgraph. The Staking contract emits that proof with the format
  * keccak256(indexer.address, POI).
- * Any challenger can dispute the validity of a POI by submitting a dispute to this contract
+ * Any fisherman can dispute the validity of a POI by submitting a dispute to this contract
  * along with a deposit.
  *
  * Arbitration:
@@ -127,18 +127,18 @@ contract DisputeManager is
      * @notice Create an indexing dispute for the arbitrator to resolve.
      * The disputes are created in reference to an allocationId and specifically
      * a POI for that allocation.
-     * This function is called by a challenger and it will pull `disputeDeposit` GRT tokens.
+     * This function is called by a fisherman and it will pull `disputeDeposit` GRT tokens.
      *
      * Requirements:
-     * - Challenger must have previously approved this contract to pull `disputeDeposit` amount
+     * - fisherman must have previously approved this contract to pull `disputeDeposit` amount
      *   of tokens from their balance.
      *
      * @param allocationId The allocation to dispute
      * @param poi The Proof of Indexing (POI) being disputed
      */
     function createIndexingDispute(address allocationId, bytes32 poi) external override returns (bytes32) {
-        // Get funds from submitter
-        _pullSubmitterDeposit();
+        // Get funds from fisherman
+        _pullFishermanDeposit();
 
         // Create a dispute
         return _createIndexingDisputeWithAllocation(msg.sender, disputeDeposit, allocationId, poi);
@@ -146,17 +146,17 @@ contract DisputeManager is
 
     /**
      * @notice Create a query dispute for the arbitrator to resolve.
-     * This function is called by a challenger and it will pull `disputeDeposit` GRT tokens.
+     * This function is called by a fisherman and it will pull `disputeDeposit` GRT tokens.
      *
      * * Requirements:
-     * - Challenger must have previously approved this contract to pull `disputeDeposit` amount
+     * - fisherman must have previously approved this contract to pull `disputeDeposit` amount
      *   of tokens from their balance.
      *
-     * @param attestationData Attestation bytes submitted by the challenger
+     * @param attestationData Attestation bytes submitted by the fisherman
      */
     function createQueryDispute(bytes calldata attestationData) external override returns (bytes32) {
-        // Get funds from submitter
-        _pullSubmitterDeposit();
+        // Get funds from fisherman
+        _pullFishermanDeposit();
 
         // Create a dispute
         return
@@ -172,7 +172,7 @@ contract DisputeManager is
      * @notice Create query disputes for two conflicting attestations.
      * A conflicting attestation is a proof presented by two different indexers
      * where for the same request on a subgraph the response is different.
-     * For this type of dispute the submitter is not required to present a deposit
+     * For this type of dispute the fisherman is not required to present a deposit
      * as one of the attestation is considered to be right.
      * Two linked disputes will be created and if the arbitrator resolve one, the other
      * one will be automatically resolved.
@@ -515,7 +515,7 @@ contract DisputeManager is
 
     /**
      * @notice Create indexing dispute internal function.
-     * @param _fisherman The challenger creating the dispute
+     * @param _fisherman The fisherman creating the dispute
      * @param _deposit Amount of tokens staked as deposit
      * @param _allocationId Allocation disputed
      * @param _poi The POI being disputed
@@ -590,16 +590,16 @@ contract DisputeManager is
     }
 
     /**
-     * @notice Pull `disputeDeposit` from submitter account.
+     * @notice Pull `disputeDeposit` from fisherman account.
      */
-    function _pullSubmitterDeposit() private {
+    function _pullFishermanDeposit() private {
         // Transfer tokens to deposit from fisherman to this contract
         _graphToken().pullTokens(msg.sender, disputeDeposit);
     }
 
     /**
-     * @notice Make the subgraph service contract slash the indexer and reward the challenger.
-     * Give the challenger a reward equal to the fishermanRewardPercentage of slashed amount
+     * @notice Make the subgraph service contract slash the indexer and reward the fisherman.
+     * Give the fisherman a reward equal to the fishermanRewardPercentage of slashed amount
      * @param _indexer Address of the indexer
      * @param _tokensSlash Amount of tokens to slash from the indexer
      * @param _tokensStakeSnapshot Snapshot of the indexer's stake at the time of the dispute creation

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -560,7 +560,7 @@ contract DisputeManager is
     }
 
     /**
-     * @notice Resolve the conflicting dispute if there is any for the one passed to this function.
+     * @notice Draw the conflicting dispute if there is any for the one passed to this function.
      * @param _dispute Dispute
      * @return True if resolved
      */

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -110,7 +110,7 @@ contract SubgraphService is
     function register(
         address indexer,
         bytes calldata data
-    ) external override onlyProvisionAuthorized(indexer) onlyValidProvision(indexer) whenNotPaused {
+    ) external override onlyAuthorizedForProvision(indexer) onlyValidProvision(indexer) whenNotPaused {
         (string memory url, string memory geohash, address rewardsDestination) = abi.decode(
             data,
             (string, string, address)
@@ -145,7 +145,7 @@ contract SubgraphService is
     function acceptProvisionPendingParameters(
         address indexer,
         bytes calldata
-    ) external override onlyProvisionAuthorized(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {
+    ) external override onlyAuthorizedForProvision(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {
         _checkProvisionTokens(indexer);
         _acceptProvisionParameters(indexer);
         emit ProvisionAccepted(indexer);
@@ -181,7 +181,7 @@ contract SubgraphService is
     )
         external
         override
-        onlyProvisionAuthorized(indexer)
+        onlyAuthorizedForProvision(indexer)
         onlyValidProvision(indexer)
         onlyRegisteredIndexer(indexer)
         whenNotPaused
@@ -216,7 +216,7 @@ contract SubgraphService is
     function stopService(
         address indexer,
         bytes calldata data
-    ) external override onlyProvisionAuthorized(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {
+    ) external override onlyAuthorizedForProvision(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {
         address allocationId = abi.decode(data, (address));
         require(
             allocations.get(allocationId).indexer == indexer,
@@ -254,7 +254,7 @@ contract SubgraphService is
     )
         external
         override
-        onlyProvisionAuthorized(indexer)
+        onlyAuthorizedForProvision(indexer)
         onlyValidProvision(indexer)
         onlyRegisteredIndexer(indexer)
         whenNotPaused
@@ -326,7 +326,7 @@ contract SubgraphService is
         uint256 tokens
     )
         external
-        onlyProvisionAuthorized(indexer)
+        onlyAuthorizedForProvision(indexer)
         onlyValidProvision(indexer)
         onlyRegisteredIndexer(indexer)
         whenNotPaused

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -131,7 +131,7 @@ contract SubgraphService is
 
     /**
      * @notice Accept staged parameters in the provision of a service provider
-     * @dev Implements {IDataService-acceptProvision}
+     * @dev Implements {IDataService-acceptProvisionPendingParameters}
      *
      * Requirements:
      * - The indexer must be registered
@@ -142,7 +142,7 @@ contract SubgraphService is
      *
      * @param indexer The address of the indexer to accept the provision for
      */
-    function acceptProvision(
+    function acceptProvisionPendingParameters(
         address indexer,
         bytes calldata
     ) external override onlyProvisionAuthorized(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -138,7 +138,7 @@ contract SubgraphService is
      * - Must have previously staged provision parameters, using {IHorizonStaking-setProvisionParameters}
      * - The new provision parameters must be valid according to the subgraph service rules
      *
-     * Emits a {ProvisionAccepted} event
+     * Emits a {ProvisionPendingParametersAccepted} event
      *
      * @param indexer The address of the indexer to accept the provision for
      */
@@ -148,7 +148,7 @@ contract SubgraphService is
     ) external override onlyAuthorizedForProvision(indexer) onlyRegisteredIndexer(indexer) whenNotPaused {
         _checkProvisionTokens(indexer);
         _acceptProvisionParameters(indexer);
-        emit ProvisionAccepted(indexer);
+        emit ProvisionPendingParametersAccepted(indexer);
     }
 
     /**

--- a/packages/subgraph-service/test/SubgraphBaseTest.t.sol
+++ b/packages/subgraph-service/test/SubgraphBaseTest.t.sol
@@ -189,7 +189,7 @@ abstract contract SubgraphBaseTest is Utils, Constants {
         resetPrank(users.deployer);
         subgraphService.transferOwnership(users.governor);
         resetPrank(users.governor);
-        staking.setMaxThawingPeriod(MAX_THAWING_PERIOD);
+        staking.setMaxThawingPeriod(MAX_WAIT_PERIOD);
         epochManager.setEpochLength(EPOCH_LENGTH);
         subgraphService.setMaxPOIStaleness(maxPOIStaleness);
         subgraphService.setCurationCut(curationCut);

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -328,7 +328,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
             uint64 disputePeriod = disputeManager.getDisputePeriod();
             assertEq(stakeClaim.tokens, tokensToLock);
             assertEq(stakeClaim.createdAt, block.timestamp);
-            assertEq(stakeClaim.releaseAt, block.timestamp + disputePeriod);
+            assertEq(stakeClaim.releasableAt, block.timestamp + disputePeriod);
             assertEq(stakeClaim.nextClaim, bytes32(0));
         } else if (_paymentType == IGraphPayments.PaymentTypes.IndexingRewards) {
             // Update allocation after collecting rewards
@@ -419,7 +419,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
     }
 
     function _getStakeClaim(bytes32 _claimId) private view returns (IDataServiceFees.StakeClaim memory) {
-        (uint256 tokens, uint256 createdAt, uint256 releaseAt, bytes32 nextClaim) = subgraphService.claims(_claimId);
-        return IDataServiceFees.StakeClaim(tokens, createdAt, releaseAt, nextClaim);
+        (uint256 tokens, uint256 createdAt, uint256 releasableAt, bytes32 nextClaim) = subgraphService.claims(_claimId);
+        return IDataServiceFees.StakeClaim(tokens, createdAt, releasableAt, nextClaim);
     }
 }

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -86,7 +86,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
         emit IDataService.ProvisionAccepted(_indexer);
 
         // Accept provision
-        subgraphService.acceptProvision(_indexer, _data);
+        subgraphService.acceptProvisionPendingParameters(_indexer, _data);
 
         // Update provision after acceptance
         provision = staking.getProvision(_indexer, address(subgraphService));

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -83,7 +83,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
         uint64 thawingPeriodPending = provision.thawingPeriodPending;
 
         vm.expectEmit(address(subgraphService));
-        emit IDataService.ProvisionAccepted(_indexer);
+        emit IDataService.ProvisionPendingParametersAccepted(_indexer);
 
         // Accept provision
         subgraphService.acceptProvisionPendingParameters(_indexer, _data);

--- a/packages/subgraph-service/test/subgraphService/provision/accept.t.sol
+++ b/packages/subgraph-service/test/subgraphService/provision/accept.t.sol
@@ -40,7 +40,7 @@ contract SubgraphServiceProvisionAcceptTest is SubgraphServiceTest {
             ISubgraphService.SubgraphServiceIndexerNotRegistered.selector,
             users.indexer
         ));
-        subgraphService.acceptProvision(users.indexer, "");
+        subgraphService.acceptProvisionPendingParameters(users.indexer, "");
     }
 
     function test_SubgraphService_Provision_Accept_RevertWhen_NotAuthorized() public {
@@ -50,7 +50,7 @@ contract SubgraphServiceProvisionAcceptTest is SubgraphServiceTest {
             users.operator,
             users.indexer
         ));
-        subgraphService.acceptProvision(users.indexer, "");
+        subgraphService.acceptProvisionPendingParameters(users.indexer, "");
     }
 
     function test_SubgraphService_Provision_Accept_RevertIf_InvalidVerifierCut(
@@ -75,7 +75,7 @@ contract SubgraphServiceProvisionAcceptTest is SubgraphServiceTest {
             fishermanRewardPercentage,
             MAX_PPM
         ));
-        subgraphService.acceptProvision(users.indexer, "");
+        subgraphService.acceptProvisionPendingParameters(users.indexer, "");
     }
 
     function test_SubgraphService_Provision_Accept_RevertIf_InvalidDisputePeriod(
@@ -100,6 +100,6 @@ contract SubgraphServiceProvisionAcceptTest is SubgraphServiceTest {
             disputePeriod,
             type(uint64).max
         ));
-        subgraphService.acceptProvision(users.indexer, "");
+        subgraphService.acceptProvisionPendingParameters(users.indexer, "");
     }
 }

--- a/packages/subgraph-service/test/utils/Constants.sol
+++ b/packages/subgraph-service/test/utils/Constants.sol
@@ -18,7 +18,7 @@ abstract contract Constants {
     uint256 public constant maxPOIStaleness = 28 days;
     uint256 public constant curationCut = 10000;
     // Staking
-    uint64 internal constant MAX_THAWING_PERIOD = 28 days;
+    uint64 internal constant MAX_WAIT_PERIOD = 28 days;
     // GraphEscrow parameters
     uint256 internal constant withdrawEscrowThawingPeriod = 60;
     uint256 internal constant revokeCollectorThawingPeriod = 60;


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-13 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-13), applying some of the recommended fixes.

##

### Title: 
N-13 Naming Suggestions

##

### Details: 
Throughout the codebase, multiple instances where code would benefit from renaming were identified:

- [function releaseStake(uint256 n)](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol#L94) could be function releaseStake(uint256 numClaimsToRelease).
- [function _setPartialPaused(bool _toPause)](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/governance/Pausable.sol#L36) could be function _setPartialPaused(bool _toPartialPause).
- [lastPausePartialTime](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/contracts/contracts/governance/Pausable.sol#L17) could be lastPartialPauseTime.
- [acceptProvision](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataService.sol#L96) could be acceptProvisionPendingParameters. Additionally, [staged](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataService.sol#L87) could be pending.
- Multiple variables follow the convention of __DEPRECATED_{variable_name}, whereas they will only be deprecated after the transition period. Consider renaming them to __DEPRECATING_{variable_name} and switching to the current naming after they are truly deprecated.
- [IHorizonStakingMain](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L17) could be IHorizonStaking to ease reading and match the implementing contract.
- [maxVerifierCut and thawingPeriod](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L229C8-L230C29) could be newMaxVerifierCut and newThawingPeriod.
- [sharesThawing and tokensThawing](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L684C9-L685C52) could be sharesStillThawing and tokensStillThawing.
- [onlyProvisionAuthorized](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol#L84) could be onlyAuthorizedForProvision.
- [ProvisionAccepted](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataService.sol#L28) could be ProvisionPendingParametersAccepted.
- [releaseAt](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/interfaces/IDataServiceFees.sol#L65) could be releasableAt.
- [_tokens](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServiceRescuable.sol#L66) could be amount.
- [Resolve the conflicting dispute](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L535) could be Draw the conflicting dispute.
- In order to avoid confusion, consider limiting the use of thawing and unthawing to only instances referring to provisions. We suggest renaming [MAX_THAWING_PERIOD](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/PaymentsEscrow.sol#L33) to MAX_WAIT_PERIOD and taking a likewise approach when dealing with all the similar occurrences in the PaymentsEscrow contract.
- In the [DisputeManager contract](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L43), the terms "challenger" and "submitter" are used interchangeably with "fisherman", leading to potential confusion. Consider consistently using the term "fisherman".
Consider reviewing the aforementioned suggestions and applying them to improve code clarity and readability.

##

### Review suggestion

- It might make more sense to look at the induvidual commits instead of the files changed.

##

### Key changes

- [releaseStake n parameter changed to numClaimsToRelease.](https://github.com/graphprotocol/contracts/pull/1047/commits/b5893f0ac4b4fa6eabbae2dff8859b1205bc37bc)
- [function _setPartialPaused(bool _toPause) chnaged to function _setPartialPaused(bool _toPartialPause).](https://github.com/graphprotocol/contracts/pull/1047/commits/8375c8bd5d48abd73dc7a41d29c2ab5435e9d730)
- [lastPausePartialTime now lastPartialPauseTime](https://github.com/graphprotocol/contracts/pull/1047/commits/bd3e534caac84103bba85a25eb5279f1fd1df036)
- [acceptProvision updated to acceptProvisionPendingParameters.](https://github.com/graphprotocol/contracts/pull/1047/commits/cfdfc23ca5c57f5d5772f1bc634ce05d86df9b2f)
- [rename staged to pending.](https://github.com/graphprotocol/contracts/pull/1047/commits/3de19467721c3f53755199898b9e620520b42fd4)
- [rename maxVerifierCut to newMaxVerifierCut and thawingPeriod to newThawingPeriod.](https://github.com/graphprotocol/contracts/pull/1047/commits/b376801670c5052098355b956937d7ee9ff922cf)
- [onlyProvisionAuthorized now onlyAuthorizedForProvision.](https://github.com/graphprotocol/contracts/pull/1047/commits/a62ba22061d6567f0441ec5ff11533746fee6891)
- [ProvisionAccepted now ProvisionPendingParametersAccepted.](https://github.com/graphprotocol/contracts/pull/1047/commits/2c2caabcfb77ccd8e02fadace7c13b6015c3cdef)
- [releaseAt updated to releasableAt.](https://github.com/graphprotocol/contracts/pull/1047/commits/149d88e2e6e5cc75d7db52208973cff2d50bfa3d)
- ["Resolve the conflicting dispute" updated to "Draw the conflicting dispute" in the dispute manager contract.](https://github.com/graphprotocol/contracts/pull/1047/commits/2c4706d137fc5c5df11dd4bcbb80c2763787657f)
- [Update MAX_THAWING_PERIOD to MAX_WAIT_PERIOD in payments escrow contract.](https://github.com/graphprotocol/contracts/pull/1047/commits/c16d89473b4e96dcd4caf4ca8d72c9061dd2ebea)
- [Terms "challenger" and "submitter" updated to "fisherman".](https://github.com/graphprotocol/contracts/pull/1047/commits/40f4934359c7db33edc4e62ce039368475539fc9)

##

### Ignored suggestions

- Multiple variables follow the convention of __DEPRECATED_{variable_name}, whereas they will only be deprecated after the transition period. Consider renaming them to __DEPRECATING_{variable_name} and switching to the current naming after they are truly deprecated.
- [IHorizonStakingMain](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol#L17) could be IHorizonStaking to ease reading and match the implementing contract.
- [sharesThawing and tokensThawing](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStaking.sol#L684C9-L685C52) could be sharesStillThawing and tokensStillThawing.
- [_tokens](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServiceRescuable.sol#L66) could be amount.
