### PR TITLE
fix: emit new events in AuthorizedCollector and TokensRescued. (OZ N-14)

### DIFF
--- a/packages/horizon/contracts/data-service/extensions/DataServiceRescuable.sol
+++ b/packages/horizon/contracts/data-service/extensions/DataServiceRescuable.sol
@@ -70,6 +70,6 @@ abstract contract DataServiceRescuable is DataService, IDataServiceRescuable {
         if (Denominations.isNativeToken(_token)) Address.sendValue(payable(_to), _tokens);
         else SafeERC20.safeTransfer(IERC20(_token), _to, _tokens);
 
-        emit TokensRescued(msg.sender, _to, _tokens);
+        emit TokensRescued(msg.sender, _to, _token, _tokens);
     }
 }

--- a/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
@@ -11,6 +11,10 @@ import { IDataService } from "./IDataService.sol";
 interface IDataServiceRescuable is IDataService {
     /**
      * @notice Emitted when tokens are rescued from the contract.
+     * @param from The address initiating the rescue
+     * @param to The address receiving the rescued tokens
+     * @param token The address of the token being rescued
+     * @param tokens The amount of tokens rescued
      */
     event TokensRescued(address indexed from, address indexed to, address token, uint256 tokens);
 

--- a/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
@@ -16,7 +16,7 @@ interface IDataServiceRescuable is IDataService {
      * @param token The address of the token being rescued
      * @param tokens The amount of tokens rescued
      */
-    event TokensRescued(address indexed from, address indexed to, address token, uint256 tokens);
+    event TokensRescued(address indexed from, address indexed to, address indexed token, uint256 tokens);
 
     /**
      * @notice Emitted when a rescuer is set.

--- a/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
+++ b/packages/horizon/contracts/data-service/interfaces/IDataServiceRescuable.sol
@@ -12,7 +12,7 @@ interface IDataServiceRescuable is IDataService {
     /**
      * @notice Emitted when tokens are rescued from the contract.
      */
-    event TokensRescued(address indexed from, address indexed to, uint256 tokens);
+    event TokensRescued(address indexed from, address indexed to, address token, uint256 tokens);
 
     /**
      * @notice Emitted when a rescuer is set.

--- a/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
+++ b/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
@@ -38,9 +38,15 @@ interface IPaymentsEscrow {
      * @notice Emitted when a payer authorizes a collector to collect funds
      * @param payer The address of the payer
      * @param collector The address of the collector
-     * @param allowance The number of tokens the collector is allowed to collect
+     * @param addedAllowance The amount of tokens added to the collector's allowance
+     * @param newTotalAllowance The new total allowance after addition
      */
-    event AuthorizedCollector(address indexed payer, address indexed collector, uint256 allowance);
+    event AuthorizedCollector(
+        address indexed payer,
+        address indexed collector,
+        uint256 addedAllowance,
+        uint256 newTotalAllowance
+    );
 
     /**
      * @notice Emitted when a payer thaws a collector

--- a/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
+++ b/packages/horizon/contracts/interfaces/IPaymentsEscrow.sol
@@ -38,8 +38,9 @@ interface IPaymentsEscrow {
      * @notice Emitted when a payer authorizes a collector to collect funds
      * @param payer The address of the payer
      * @param collector The address of the collector
+     * @param allowance The number of tokens the collector is allowed to collect
      */
-    event AuthorizedCollector(address indexed payer, address indexed collector);
+    event AuthorizedCollector(address indexed payer, address indexed collector, uint256 allowance);
 
     /**
      * @notice Emitted when a payer thaws a collector

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -82,7 +82,7 @@ contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, 
         require(allowance != 0, PaymentsEscrowInvalidZeroTokens());
         Collector storage collector = authorizedCollectors[msg.sender][collector_];
         collector.allowance += allowance;
-        emit AuthorizedCollector(msg.sender, collector_, collector.allowance);
+        emit AuthorizedCollector(msg.sender, collector_, allowance, collector.allowance);
     }
 
     /**

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -82,7 +82,7 @@ contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, 
         require(allowance != 0, PaymentsEscrowInvalidZeroTokens());
         Collector storage collector = authorizedCollectors[msg.sender][collector_];
         collector.allowance += allowance;
-        emit AuthorizedCollector(msg.sender, collector_);
+        emit AuthorizedCollector(msg.sender, collector_, collector.allowance);
     }
 
     /**

--- a/packages/horizon/test/escrow/collector.t.sol
+++ b/packages/horizon/test/escrow/collector.t.sol
@@ -16,7 +16,12 @@ contract GraphEscrowCollectorTest is GraphEscrowTest {
     function _approveCollector(uint256 tokens) internal {
         (uint256 beforeAllowance,) = escrow.authorizedCollectors(users.gateway, users.verifier);
         vm.expectEmit(address(escrow));
-        emit IPaymentsEscrow.AuthorizedCollector(users.gateway, users.verifier);
+        emit IPaymentsEscrow.AuthorizedCollector(
+            users.gateway, // payer
+            users.verifier, // collector
+            tokens, // addedAllowance
+            beforeAllowance + tokens // newTotalAllowance after the added allowance
+        );
         escrow.approveCollector(users.verifier, tokens);
         (uint256 allowance, uint256 thawEndTimestamp) = escrow.authorizedCollectors(users.gateway, users.verifier);
         assertEq(allowance - beforeAllowance, tokens);


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-14 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-14), applying the recommended fixes.

##

### Title: 
N-14 Event Emission Suggestions

##

### Details: 
Throughout the codebase, multiple instances of events that could emit additional information were identified:

The [AuthorizedCollector event](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/PaymentsEscrow.sol#L74) could emit the amount for which the collector was authorized.
The [TokensRescued event](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/extensions/DataServiceRescuable.sol#L72) could emit the token that was rescued.
Consider updating these events to enhance off-chain tracking and ensure comprehensive event logging.

##

### Key changes

- The AuthorizedCollector event now emits the amount for which the collector was authorized.
- The AuthorizedCollector event now emits the total amount that the collector is authorized.
- The TokensRescued event now emits the token contract of the rescued token.