### PR TITLE
fix: remove redundant getter functions. (OZ N-15)

### DIFF
--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -46,8 +46,9 @@ contract DisputeManager is
     OwnableUpgradeable,
     GraphDirectory,
     AttestationManager,
-    DisputeManagerV1Storage,
-    IDisputeManager
+    IDisputeManager,
+    DisputeManagerV1Storage
+    
 {
     using TokenUtils for IGraphToken;
     using PPMMath for uint256;

--- a/packages/subgraph-service/contracts/DisputeManager.sol
+++ b/packages/subgraph-service/contracts/DisputeManager.sol
@@ -371,14 +371,6 @@ contract DisputeManager is
     }
 
     /**
-     * @notice Get the dispute period.
-     * @return Dispute period in seconds
-     */
-    function getDisputePeriod() external view override returns (uint64) {
-        return disputePeriod;
-    }
-
-    /**
      * @notice Get the stake snapshot for an indexer.
      * @param indexer The indexer address
      */

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -475,11 +475,11 @@ contract SubgraphService is
     /**
      * @notice Getter for the accepted thawing period range for provisions
      * @dev This override ensures {ProvisionManager} uses the thawing period from the {DisputeManager}
-     * @return min The minimum thawing period which is defined by {DisputeManager-getDisputePeriod}
+     * @return min The minimum thawing period which is defined by {DisputeManager-disputePeriod}
      * @return max The maximum is unbounded
      */
     function _getThawingPeriodRange() internal view override returns (uint64 min, uint64 max) {
-        uint64 disputePeriod = _disputeManager().getDisputePeriod();
+        uint64 disputePeriod = _disputeManager().disputePeriod();
         return (disputePeriod, type(uint64).max);
     }
 
@@ -549,7 +549,7 @@ contract SubgraphService is
         if (tokensCollected > 0) {
             // lock stake as economic security for fees
             uint256 tokensToLock = tokensCollected * stakeToFeesRatio;
-            uint256 unlockTimestamp = block.timestamp + _disputeManager().getDisputePeriod();
+            uint256 unlockTimestamp = block.timestamp + _disputeManager().disputePeriod();
             _lockStake(indexer, tokensToLock, unlockTimestamp);
 
             if (tokensCurators > 0) {

--- a/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
+++ b/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
@@ -216,8 +216,6 @@ interface IDisputeManager {
 
     function getVerifierCut() external view returns (uint32);
 
-    function disputePeriod() external view returns (uint64);
-
     function isDisputeCreated(bytes32 disputeId) external view returns (bool);
 
     function encodeReceipt(Attestation.Receipt memory receipt) external view returns (bytes32);

--- a/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
+++ b/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
@@ -216,8 +216,6 @@ interface IDisputeManager {
 
     function getVerifierCut() external view returns (uint32);
 
-    function getDisputePeriod() external view returns (uint64);
-
     function isDisputeCreated(bytes32 disputeId) external view returns (bool);
 
     function encodeReceipt(Attestation.Receipt memory receipt) external view returns (bytes32);

--- a/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
+++ b/packages/subgraph-service/contracts/interfaces/IDisputeManager.sol
@@ -216,6 +216,8 @@ interface IDisputeManager {
 
     function getVerifierCut() external view returns (uint32);
 
+    function disputePeriod() external view returns (uint64);
+
     function isDisputeCreated(bytes32 disputeId) external view returns (bool);
 
     function encodeReceipt(Attestation.Receipt memory receipt) external view returns (bytes32);

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -325,7 +325,7 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
             LinkedList.List memory claimsList = _getClaimList(_indexer);
             bytes32 claimId = _buildStakeClaimId(_indexer, claimsList.nonce - 1);
             IDataServiceFees.StakeClaim memory stakeClaim = _getStakeClaim(claimId);
-            uint64 disputePeriod = disputeManager.getDisputePeriod();
+            uint64 disputePeriod = disputeManager.disputePeriod();
             assertEq(stakeClaim.tokens, tokensToLock);
             assertEq(stakeClaim.createdAt, block.timestamp);
             assertEq(stakeClaim.releaseAt, block.timestamp + disputePeriod);


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-15 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-15), applying the recommended fixes.

##

### Title: 
N-15 Redundant Getter Functions

##

### Details: 
When state variables use public visibility in a contract, a getter function for the variable is automatically included.

Throughout the codebase, multiple instances of redundant getter functions were identified:

Within the ProvisionManager contract, the [getDelegationRatio](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol#L134) and the [_getDelegationRatio](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/data-service/utilities/ProvisionManager.sol#L274) functions are redundant. Consider removing both or combining them into a public getter.
Within the DisputeManager contract, the [getDisputePeriod](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L363-L365) function is redundant.
Within the SubgraphService contract, the [getAllocation](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/SubgraphService.sol#L369-L371) function is redundant.
Within the SubgraphService contract, the [getLegacyAllocation](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/SubgraphService.sol#L425-L427) function is redundant.
Within the Allocation library, the [_get](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/libraries/Allocation.sol#L198) function is redundant and the get function could implement its logic.
To improve the overall clarity and readability of the codebase, and save some gas at deployment, consider removing the redundant getter functions.

##

### Review suggestion

- It might make more sense to look at the induvidual commits instead of the files changed.

##

### Key changes

- Removed redundant getDisputePeriod function.

##

### Ignored Suggestions

- Did not remove the getAllocation function.
- Did not remove the getLegacyAllocationfunction.
- Did not remove the getDelegationRatio or the _getDelegationRatio functions.
- Did not remove the _get function.
