### PR TITLE
fix: update function visibility (OZ N-16) 

### DIFF
--- a/packages/contracts/contracts/disputes/DisputeManager.sol
+++ b/packages/contracts/contracts/disputes/DisputeManager.sol
@@ -579,7 +579,7 @@ contract DisputeManager is DisputeManagerV1Storage, GraphUpgradeable, IDisputeMa
      * @notice Ignore a dispute with ID `_disputeID`
      * @param _disputeID ID of the dispute to be disregarded
      */
-    function drawDispute(bytes32 _disputeID) public override onlyArbitrator onlyPendingDispute(_disputeID) {
+    function drawDispute(bytes32 _disputeID) external override onlyArbitrator onlyPendingDispute(_disputeID) {
         Dispute storage dispute = disputes[_disputeID];
 
         // Return deposit to the fisherman

--- a/packages/horizon/contracts/payments/PaymentsEscrow.sol
+++ b/packages/horizon/contracts/payments/PaymentsEscrow.sol
@@ -232,7 +232,7 @@ contract PaymentsEscrow is Initializable, MulticallUpgradeable, GraphDirectory, 
      * @param _receiver The address of the receiver
      * @param _tokens The amount of tokens to deposit
      */
-    function _deposit(address _payer, address _receiver, uint256 _tokens) internal {
+    function _deposit(address _payer, address _receiver, uint256 _tokens) private {
         escrowAccounts[_payer][_receiver].balance += _tokens;
         _graphToken().pullTokens(msg.sender, _tokens);
         emit Deposit(_payer, _receiver, _tokens);

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -290,7 +290,7 @@ abstract contract HorizonStakingBase is
     /**
      * @notice See {IHorizonStakingBase-getDelegatedTokensAvailable}.
      */
-    function _getDelegatedTokensAvailable(address _serviceProvider, address _verifier) internal view returns (uint256) {
+    function _getDelegatedTokensAvailable(address _serviceProvider, address _verifier) private view returns (uint256) {
         DelegationPoolInternal storage poolInternal = _getDelegationPool(_serviceProvider, _verifier);
         return poolInternal.tokens - poolInternal.tokensThawing;
     }

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -326,7 +326,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizon
     function _receiveIndexerStake(
         uint256 _tokens,
         IL2StakingTypes.ReceiveIndexerStakeData memory _indexerData
-    ) internal {
+    ) private {
         address indexer = _indexerData.indexer;
         // Deposit tokens into the indexer stake
         _stake(indexer, _tokens);
@@ -345,7 +345,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IL2StakingBase, IHorizon
     function _receiveDelegation(
         uint256 _tokens,
         IL2StakingTypes.ReceiveDelegationData memory _delegationData
-    ) internal {
+    ) private {
         require(_provisions[_delegationData.indexer][SUBGRAPH_DATA_SERVICE_ADDRESS].createdAt != 0, "!provision");
         // Get the delegation pool of the indexer
         DelegationPoolInternal storage pool = _legacyDelegationPools[_delegationData.indexer];

--- a/packages/subgraph-service/contracts/utilities/AllocationManager.sol
+++ b/packages/subgraph-service/contracts/utilities/AllocationManager.sol
@@ -465,7 +465,7 @@ abstract contract AllocationManager is EIP712Upgradeable, GraphDirectory, Alloca
      * @param _allocationId The id of the allocation
      * @param _proof The EIP712 proof, an EIP712 signed message of (indexer,allocationId)
      */
-    function _verifyAllocationProof(address _indexer, address _allocationId, bytes memory _proof) internal view {
+    function _verifyAllocationProof(address _indexer, address _allocationId, bytes memory _proof) private view {
         bytes32 digest = _encodeAllocationProof(_indexer, _allocationId);
         address signer = ECDSA.recover(digest, _proof);
         require(signer == _allocationId, AllocationManagerInvalidAllocationProof(signer, _allocationId));


### PR DESCRIPTION
### Motivation:

- This PR addresses the [following N-16 OZ audit issue](https://defender.openzeppelin.com/#/audit/9d56f9fe-e25e-4ac5-acb0-772150889078/issues/N-16), applying the recommended fixes.

##

### Title: 
N-16 Function Visibility Overly Permissive

##

### Details: 
Throughout the codebase, multiple instances of functions with unnecessarily permissive visibility were identified:

The [_verifyAllocationProof](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/utilities/AllocationManager.sol#L455-L459) function in AllocationManager.sol with internal visibility could be limited to private.
The [_getDelegatedTokensAvailable](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingBase.sol#L294-L297) function in HorizonStakingBase.sol with internal visibility could be limited to private.
The [_receiveIndexerStake](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingExtension.sol#L325) and [_receiveDelegation](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/staking/HorizonStakingExtension.sol#L342) functions in HorizonStakingExtension with internal visibility could be made private.
The [_deposit](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/horizon/contracts/payments/PaymentsEscrow.sol#L225) function in PaymentsEscrow.sol with internal visibility could be limited to private.
The [acceptDispute](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L222) and [drawDispute](https://github.com/graphprotocol/contracts/blob/f47cf916c40b1d7aa10204d510ca1364c144736d/packages/subgraph-service/contracts/DisputeManager.sol#L249) functions in DisputeManager.sol with public visibility could be limited to external.
To better convey the intended use of functions, consider changing a function's visibility to be only as permissive as required.

##

### Key changes

- [set _verifyAllocationProof visability private.](https://github.com/graphprotocol/contracts/commit/b721f7254cad577bedb5f7a12495c634e7f7b1df)
- [set _getDelegatedTokensAvailable visability private.](https://github.com/graphprotocol/contracts/commit/fbc6654d755e0ec96a019bf49a47f39c223125b6)
- [set both _receiveIndexerStake and _receiveDelegation function visability private.](https://github.com/graphprotocol/contracts/commit/decde7fbf38d25d42b671c8a6a07aa966c4467e9)
- [set _deposit visability private.](https://github.com/graphprotocol/contracts/commit/b5d3a7d379b65ceaa841fccd760d2a7763537009)
- [set drawDispute visability external.](https://github.com/graphprotocol/contracts/commit/32b39657bb2b462ac4c02068dba688318788ce65)



