### PR TITLE
TRST audit fixes for HorizonStaking contract

### DIFF
--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingBase.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingBase.sol
@@ -25,6 +25,11 @@ interface IHorizonStakingBase {
     event StakeDeposited(address indexed serviceProvider, uint256 tokens);
 
     /**
+     * @notice Thrown when using an invalid thaw request type.
+     */
+    error HorizonStakingInvalidThawRequestType();
+
+    /**
      * @notice Gets the details of a service provider.
      * @param serviceProvider The address of the service provider.
      */

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingBase.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingBase.sol
@@ -134,21 +134,27 @@ interface IHorizonStakingBase {
 
     /**
      * @notice Gets a thaw request.
+     * @param thawRequestType The type of thaw request.
      * @param thawRequestId The id of the thaw request.
      * @return The thaw request details.
      */
-    function getThawRequest(bytes32 thawRequestId) external view returns (IHorizonStakingTypes.ThawRequest memory);
+    function getThawRequest(
+        IHorizonStakingTypes.ThawRequestType thawRequestType,
+        bytes32 thawRequestId
+    ) external view returns (IHorizonStakingTypes.ThawRequest memory);
 
     /**
      * @notice Gets the metadata of a thaw request list.
      * Service provider and delegators each have their own thaw request list per provision.
      * Metadata includes the head and tail of the list, plus the total number of thaw requests.
+     * @param thawRequestType The type of thaw request.
      * @param serviceProvider The address of the service provider.
      * @param verifier The address of the verifier.
      * @param owner The owner of the thaw requests. Use either the service provider or delegator address.
      * @return The thaw requests list metadata.
      */
     function getThawRequestList(
+        IHorizonStakingTypes.ThawRequestType thawRequestType,
         address serviceProvider,
         address verifier,
         address owner
@@ -156,12 +162,18 @@ interface IHorizonStakingBase {
 
     /**
      * @notice Gets the amount of thawed tokens for a given provision.
+     * @param thawRequestType The type of thaw request.
      * @param serviceProvider The address of the service provider.
      * @param verifier The address of the verifier.
      * @param owner The owner of the thaw requests. Use either the service provider or delegator address.
      * @return The amount of thawed tokens.
      */
-    function getThawedTokens(address serviceProvider, address verifier, address owner) external view returns (uint256);
+    function getThawedTokens(
+        IHorizonStakingTypes.ThawRequestType thawRequestType,
+        address serviceProvider,
+        address verifier,
+        address owner
+    ) external view returns (uint256);
 
     /**
      * @notice Gets the maximum allowed thawing period for a provision.

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
@@ -84,11 +84,6 @@ interface IHorizonStakingExtension is IRewardsIssuer {
     event StakeSlashed(address indexed indexer, uint256 tokens, uint256 reward, address beneficiary);
 
     /**
-     * @dev Emitted when `delegator` withdrew delegated `tokens` from `indexer` using `legacyWithdrawDelegated`.
-     */
-    event StakeDelegatedWithdrawn(address indexed indexer, address indexed delegator, uint256 tokens);
-
-    /**
      * @notice Close an allocation and free the staked tokens.
      * To be eligible for rewards a proof of indexing must be presented.
      * Presenting a bad proof is subject to slashable condition.
@@ -169,13 +164,4 @@ interface IHorizonStakingExtension is IRewardsIssuer {
      * @param beneficiary Address of a beneficiary to receive a reward for the slashing
      */
     function legacySlash(address indexer, uint256 tokens, uint256 reward, address beneficiary) external;
-
-    /**
-     * @notice Withdraw undelegated tokens once the unbonding period has passed.
-     * @param _indexer Withdraw available tokens delegated to indexer
-     */
-    function legacyWithdrawDelegated(
-        address _indexer,
-        address /* _newIndexer, deprecated */
-    ) external returns (uint256);
 }

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
@@ -84,6 +84,11 @@ interface IHorizonStakingExtension is IRewardsIssuer {
     event StakeSlashed(address indexed indexer, uint256 tokens, uint256 reward, address beneficiary);
 
     /**
+     * @dev Emitted when `delegator` withdrew delegated `tokens` from `indexer` using `legacyWithdrawDelegated`.
+     */
+    event StakeDelegatedWithdrawn(address indexed indexer, address indexed delegator, uint256 tokens);
+
+    /**
      * @notice Close an allocation and free the staked tokens.
      * To be eligible for rewards a proof of indexing must be presented.
      * Presenting a bad proof is subject to slashable condition.
@@ -164,4 +169,13 @@ interface IHorizonStakingExtension is IRewardsIssuer {
      * @param beneficiary Address of a beneficiary to receive a reward for the slashing
      */
     function legacySlash(address indexer, uint256 tokens, uint256 reward, address beneficiary) external;
+
+    /**
+     * @notice Withdraw undelegated tokens once the unbonding period has passed.
+     * @param _indexer Withdraw available tokens delegated to indexer
+     */
+    function legacyWithdrawDelegated(
+        address _indexer,
+        address /* _newIndexer, deprecated */
+    ) external returns (uint256);
 }

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingExtension.sol
@@ -78,6 +78,12 @@ interface IHorizonStakingExtension is IRewardsIssuer {
     );
 
     /**
+     * @dev Emitted when `indexer` was slashed for a total of `tokens` amount.
+     * Tracks `reward` amount of tokens given to `beneficiary`.
+     */
+    event StakeSlashed(address indexed indexer, uint256 tokens, uint256 reward, address beneficiary);
+
+    /**
      * @notice Close an allocation and free the staked tokens.
      * To be eligible for rewards a proof of indexing must be presented.
      * Presenting a bad proof is subject to slashable condition.
@@ -148,4 +154,14 @@ interface IHorizonStakingExtension is IRewardsIssuer {
      */
     // solhint-disable-next-line func-name-mixedcase
     function __DEPRECATED_getThawingPeriod() external view returns (uint64);
+
+    /**
+     * @notice Slash the indexer stake. Delegated tokens are not subject to slashing.
+     * @dev Can only be called by the slasher role.
+     * @param indexer Address of indexer to slash
+     * @param tokens Amount of tokens to slash from the indexer stake
+     * @param reward Amount of reward tokens to send to a beneficiary
+     * @param beneficiary Address of a beneficiary to receive a reward for the slashing
+     */
+    function legacySlash(address indexer, uint256 tokens, uint256 reward, address beneficiary) external;
 }

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -206,6 +206,15 @@ interface IHorizonStakingMain {
     );
 
     /**
+     * @notice Emitted when `delegator` withdrew delegated `tokens` from `indexer` using `withdrawDelegated`.
+     * @dev This event is for the legacy `withdrawDelegated` function.
+     * @param indexer The address of the indexer
+     * @param delegator The address of the delegator
+     * @param tokens The amount of tokens withdrawn
+     */
+    event StakeDelegatedWithdrawn(address indexed indexer, address indexed delegator, uint256 tokens);
+
+    /**
      * @notice Emitted when tokens are added to a delegation pool's reserve.
      * @param serviceProvider The address of the service provider
      * @param verifier The address of the verifier
@@ -861,13 +870,14 @@ interface IHorizonStakingMain {
     /**
      * @notice Withdraw undelegated tokens from the subgraph data service provision after thawing.
      * This function is for backwards compatibility with the legacy staking contract.
-     * It only allows withdrawing from the subgraph data service and DOES NOT have slippage protection in
-     * case the caller opts for re-delegating.
+     * It only allows withdrawing tokens undelegated before horizon upgrade.
      * @dev See {delegate}.
      * @param serviceProvider The service provider address
-     * @param newServiceProvider The address of a new service provider, if the delegator wants to re-delegate
      */
-    function withdrawDelegated(address serviceProvider, address newServiceProvider) external;
+    function withdrawDelegated(
+        address serviceProvider,
+        address // newServiceProvider, deprecated
+    ) external returns (uint256);
 
     /**
      * @notice Slash a service provider. This can only be called by a verifier to which

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.27;
 
 import { IGraphPayments } from "../../interfaces/IGraphPayments.sol";
+import { IHorizonStakingTypes } from "./IHorizonStakingTypes.sol";
 
 /**
  * @title Inferface for the {HorizonStaking} contract.
@@ -280,13 +281,15 @@ interface IHorizonStakingMain {
      * @param owner The address of the owner of the thaw requests
      * @param thawRequestsFulfilled The number of thaw requests fulfilled
      * @param tokens The total amount of tokens being released
+     * @param requestType The type of thaw request
      */
     event ThawRequestsFulfilled(
         address indexed serviceProvider,
         address indexed verifier,
         address indexed owner,
         uint256 thawRequestsFulfilled,
-        uint256 tokens
+        uint256 tokens,
+        IHorizonStakingTypes.ThawRequestType requestType
     );
 
     // -- Events: governance --

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -424,6 +424,13 @@ interface IHorizonStakingMain {
     error HorizonStakingInvalidDelegationPool(address serviceProvider, address verifier);
 
     /**
+     * @notice Thrown when the minimum token amount required for delegation is not met.
+     * @param tokens The actual token amount
+     * @param minTokens The minimum required token amount
+     */
+    error HorizonStakingInsufficientDelegationTokens(uint256 tokens, uint256 minTokens);
+
+    /**
      * @notice Thrown when attempting to undelegate with a beneficiary that is the zero address.
      */
     error HorizonStakingInvalidBeneficiaryZeroAddress();

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -515,6 +515,8 @@ interface IHorizonStakingMain {
      * - During the transition period it's locked for a period of time before it can be withdrawn
      *   by calling {withdraw}.
      * - After the transition period it's immediately withdrawn.
+     * Note that after the transition period if there are tokens still locked they will have to be
+     * withdrawn by calling {withdraw}.
      * @dev Requirements:
      * - `_tokens` cannot be zero.
      * - `_serviceProvider` must have enough idle stake to cover the staking amount and any

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -434,7 +434,7 @@ interface IHorizonStakingMain {
     error HorizonStakingInsufficientDelegationTokens(uint256 tokens, uint256 minTokens);
 
     /**
-     * @notice Thrown when the minimum token amount required for delegation with beneficiary is not met.
+     * @notice Thrown when the minimum token amount required for undelegation with beneficiary is not met.
      * @param tokens The actual token amount
      * @param minTokens The minimum required token amount
      */

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -303,9 +303,8 @@ interface IHorizonStakingMain {
 
     /**
      * @notice Emitted when the delegation slashing global flag is set.
-     * @param enabled Whether delegation slashing is enabled or disabled.
      */
-    event DelegationSlashingEnabled(bool enabled);
+    event DelegationSlashingEnabled();
 
     // -- Errors: tokens
 

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -747,7 +747,7 @@ interface IHorizonStakingMain {
      * @param beneficiary The address where the tokens will be withdrawn after thawing
      * @return The ID of the thaw request
      */
-    function undelegate(
+    function undelegateWithBeneficiary(
         address serviceProvider,
         address verifier,
         uint256 shares,
@@ -771,6 +771,28 @@ interface IHorizonStakingMain {
      * @param nThawRequests The number of thaw requests to fulfill. Set to 0 to fulfill all thaw requests.
      */
     function withdrawDelegated(address serviceProvider, address verifier, uint256 nThawRequests) external;
+
+    /**
+     * @notice Withdraw undelegated with beneficiary tokens from a provision after thawing.
+     * @dev The parameter `nThawRequests` can be set to a non zero value to fulfill a specific number of thaw
+     * requests in the event that fulfilling all of them results in a gas limit error.
+     * @dev If the delegation pool was completely slashed before withdrawing, calling this function will fulfill
+     * the thaw requests with an amount equal to zero.
+     *
+     * Requirements:
+     * - Must have previously initiated a thaw request using {undelegateWithBeneficiary}.
+     *
+     * Emits {ThawRequestFulfilled}, {ThawRequestsFulfilled} and {DelegatedTokensWithdrawn} events.
+     *
+     * @param serviceProvider The service provider address
+     * @param verifier The verifier address
+     * @param nThawRequests The number of thaw requests to fulfill. Set to 0 to fulfill all thaw requests.
+     */
+    function withdrawDelegatedWithBeneficiary(
+        address serviceProvider,
+        address verifier,
+        uint256 nThawRequests
+    ) external;
 
     /**
      * @notice Re-delegate undelegated tokens from a provision after thawing to a `newServiceProvider` and `newVerifier`.

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -434,6 +434,13 @@ interface IHorizonStakingMain {
     error HorizonStakingInsufficientDelegationTokens(uint256 tokens, uint256 minTokens);
 
     /**
+     * @notice Thrown when the minimum token amount required for delegation with beneficiary is not met.
+     * @param tokens The actual token amount
+     * @param minTokens The minimum required token amount
+     */
+    error HorizonStakingInsufficientUndelegationTokens(uint256 tokens, uint256 minTokens);
+
+    /**
      * @notice Thrown when attempting to undelegate with a beneficiary that is the zero address.
      */
     error HorizonStakingInvalidBeneficiaryZeroAddress();

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
@@ -160,6 +160,7 @@ interface IHorizonStakingTypes {
 
     /**
      * @notice Parameters to fulfill thaw requests.
+     * @dev This struct is used to avoid stack too deep error in the `fulfillThawRequests` function.
      * @param requestType The type of thaw request (Provision or Delegation)
      * @param serviceProvider The address of the service provider
      * @param verifier The address of the verifier

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
@@ -138,7 +138,8 @@ interface IHorizonStakingTypes {
      */
     enum ThawRequestType {
         Provision,
-        Delegation
+        Delegation,
+        DelegationWithBeneficiary
     }
 
     /**

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
@@ -180,4 +180,19 @@ interface IHorizonStakingTypes {
         uint256 nThawRequests;
         uint256 thawingNonce;
     }
+
+    /**
+     * @notice Results of the traversal of thaw requests.
+     * @dev This struct is used to avoid stack too deep error in the `fulfillThawRequests` function.
+     * @param requestsFulfilled The number of thaw requests fulfilled
+     * @param tokensThawed The total amount of tokens thawed
+     * @param tokensThawing The total amount of tokens thawing
+     * @param sharesThawing The total amount of shares thawing
+     */
+    struct TraverseThawRequestsResults {
+        uint256 requestsFulfilled;
+        uint256 tokensThawed;
+        uint256 tokensThawing;
+        uint256 sharesThawing;
+    }
 }

--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingTypes.sol
@@ -132,6 +132,16 @@ interface IHorizonStakingTypes {
     }
 
     /**
+     * @dev Enum to specify the type of thaw request.
+     * @param Provision Represents a thaw request for a provision.
+     * @param Delegation Represents a thaw request for a delegation.
+     */
+    enum ThawRequestType {
+        Provision,
+        Delegation
+    }
+
+    /**
      * @notice Details of a stake thawing operation.
      * @dev ThawRequests are stored in linked lists by service provider/delegator,
      * ordered by creation timestamp.
@@ -144,6 +154,28 @@ interface IHorizonStakingTypes {
         // Id of the next thaw request in the linked list
         bytes32 next;
         // Used to invalidate unfulfilled thaw requests
+        uint256 thawingNonce;
+    }
+
+    /**
+     * @notice Parameters to fulfill thaw requests.
+     * @param requestType The type of thaw request (Provision or Delegation)
+     * @param serviceProvider The address of the service provider
+     * @param verifier The address of the verifier
+     * @param owner The address of the owner of the thaw request
+     * @param tokensThawing The current amount of tokens already thawing
+     * @param sharesThawing The current amount of shares already thawing
+     * @param nThawRequests The number of thaw requests to fulfill. If set to 0, all thaw requests are fulfilled.
+     * @param thawingNonce The current valid thawing nonce. Any thaw request with a different nonce is invalid and should be ignored.
+     */
+    struct FulfillThawRequestsParams {
+        ThawRequestType requestType;
+        address serviceProvider;
+        address verifier;
+        address owner;
+        uint256 tokensThawing;
+        uint256 sharesThawing;
+        uint256 nThawRequests;
         uint256 thawingNonce;
     }
 }

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -585,7 +585,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      */
     function setDelegationSlashingEnabled() external override onlyGovernor {
         _delegationSlashingEnabled = true;
-        emit DelegationSlashingEnabled(_delegationSlashingEnabled);
+        emit DelegationSlashingEnabled();
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -735,7 +735,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     }
 
     /**
-     * @notice See {IHorizonStakingMain-createProvision}.
+     * @notice See {IHorizonStakingMain-provision}.
      */
     function _createProvision(
         address _serviceProvider,

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -1181,7 +1181,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @param _thawRequestId The ID of the thaw request to delete.
      */
     function _deleteProvisionThawRequest(bytes32 _thawRequestId) private {
-        delete _provisionThawRequests[_thawRequestId];
+        delete _thawRequests[ThawRequestType.Provision][_thawRequestId];
     }
 
     /**
@@ -1189,7 +1189,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @param _thawRequestId The ID of the thaw request to delete.
      */
     function _deleteDelegationThawRequest(bytes32 _thawRequestId) private {
-        delete _delegationThawRequests[_thawRequestId];
+        delete _thawRequests[ThawRequestType.Delegation][_thawRequestId];
     }
 
     /**
@@ -1197,7 +1197,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * @param _thawRequestId The ID of the thaw request to delete.
      */
     function _deleteDelegationWithBeneficiaryThawRequest(bytes32 _thawRequestId) private {
-        delete _delegationWithBeneficiaryThawRequests[_thawRequestId];
+        delete _thawRequests[ThawRequestType.DelegationWithBeneficiary][_thawRequestId];
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -783,9 +783,10 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
 
         // Calculate shares to issue
         // Thawing pool is reset/initialized when the pool is empty: prov.tokensThawing == 0
+        // Round thawing shares up to ensure fairness and avoid undervaluing the shares due to rounding down.
         uint256 thawingShares = prov.tokensThawing == 0
             ? _tokens
-            : ((prov.sharesThawing * _tokens) / prov.tokensThawing);
+            : ((prov.sharesThawing * _tokens + prov.tokensThawing - 1) / prov.tokensThawing);
         uint64 thawingUntil = uint64(block.timestamp + uint256(prov.thawingPeriod));
 
         prov.sharesThawing = prov.sharesThawing + thawingShares;
@@ -907,6 +908,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
         // delegation pool shares -> delegation pool tokens -> thawing pool shares
         // Thawing pool is reset/initialized when the pool is empty: prov.tokensThawing == 0
         uint256 tokens = (_shares * (pool.tokens - pool.tokensThawing)) / pool.shares;
+        // Thawing shares are rounded down to protect the pool and avoid taking extra tokens from other participants.
         uint256 thawingShares = pool.tokensThawing == 0 ? tokens : ((tokens * pool.sharesThawing) / pool.tokensThawing);
         uint64 thawingUntil = uint64(block.timestamp + uint256(_provisions[_serviceProvider][_verifier].thawingPeriod));
 

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -867,6 +867,8 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
      * have been done before calling this function.
      */
     function _delegate(address _serviceProvider, address _verifier, uint256 _tokens, uint256 _minSharesOut) private {
+        // Enforces a minimum delegation amount to prevent share manipulation attacks.
+        // This stops attackers from inflating share value and blocking other delegators.
         require(_tokens >= MIN_DELEGATION, HorizonStakingInsufficientTokens(_tokens, MIN_DELEGATION));
         require(
             _provisions[_serviceProvider][_verifier].createdAt != 0,

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -1078,8 +1078,33 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
         );
         require(thawRequestList.count > 0, HorizonStakingNothingThawing());
 
+        TraverseThawRequestsResults memory results = _traverseThawRequests(params, thawRequestList);
+
+        emit ThawRequestsFulfilled(
+            params.serviceProvider,
+            params.verifier,
+            params.owner,
+            results.requestsFulfilled,
+            results.tokensThawed,
+            params.requestType
+        );
+
+        return (results.tokensThawed, results.tokensThawing, results.sharesThawing);
+    }
+
+    /**
+     * @notice Traverses a thaw request list and fulfills expired thaw requests.
+     * @param params The parameters for fulfilling thaw requests
+     * @param thawRequestList The list of thaw requests to traverse
+     * @return The results of the traversal
+     */
+    function _traverseThawRequests(
+        FulfillThawRequestsParams memory params,
+        LinkedList.List storage thawRequestList
+    ) private returns (TraverseThawRequestsResults memory) {
         function(bytes32) view returns (bytes32) getNextItem = _getNextThawRequest(params.requestType);
         function(bytes32) deleteItem = _getDeleteThawRequest(params.requestType);
+
         bytes memory acc = abi.encode(
             params.requestType,
             uint256(0),
@@ -1099,14 +1124,14 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
             data,
             (ThawRequestType, uint256, uint256, uint256)
         );
-        emit ThawRequestsFulfilled(
-            params.serviceProvider,
-            params.verifier,
-            params.owner,
-            thawRequestsFulfilled,
-            tokensThawed
-        );
-        return (tokensThawed, tokensThawing, sharesThawing);
+
+        return
+            TraverseThawRequestsResults({
+                requestsFulfilled: thawRequestsFulfilled,
+                tokensThawed: tokensThawed,
+                tokensThawing: tokensThawing,
+                sharesThawing: sharesThawing
+            });
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -869,7 +869,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     function _delegate(address _serviceProvider, address _verifier, uint256 _tokens, uint256 _minSharesOut) private {
         // Enforces a minimum delegation amount to prevent share manipulation attacks.
         // This stops attackers from inflating share value and blocking other delegators.
-        require(_tokens >= MIN_DELEGATION, HorizonStakingInsufficientTokens(_tokens, MIN_DELEGATION));
+        require(_tokens >= MIN_DELEGATION, HorizonStakingInsufficientDelegationTokens(_tokens, MIN_DELEGATION));
         require(
             _provisions[_serviceProvider][_verifier].createdAt != 0,
             HorizonStakingInvalidProvision(_serviceProvider, _verifier)

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -461,8 +461,8 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
             _graphToken().burnTokens(providerTokensSlashed - tokensVerifier);
 
             // Provision accounting
-            // TODO check for rounding issues
-            uint256 provisionFractionSlashed = (providerTokensSlashed * FIXED_POINT_PRECISION) / prov.tokens;
+            uint256 provisionFractionSlashed = (providerTokensSlashed * FIXED_POINT_PRECISION + prov.tokens - 1) /
+                prov.tokens;
             prov.tokensThawing =
                 (prov.tokensThawing * (FIXED_POINT_PRECISION - provisionFractionSlashed)) /
                 (FIXED_POINT_PRECISION);
@@ -497,7 +497,8 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
                 _graphToken().burnTokens(tokensToSlash);
 
                 // Delegation pool accounting
-                uint256 delegationFractionSlashed = (tokensToSlash * FIXED_POINT_PRECISION) / pool.tokens;
+                uint256 delegationFractionSlashed = (tokensToSlash * FIXED_POINT_PRECISION + pool.tokens - 1) /
+                    pool.tokens;
                 pool.tokens = pool.tokens - tokensToSlash;
                 pool.tokensThawing =
                     (pool.tokensThawing * (FIXED_POINT_PRECISION - delegationFractionSlashed)) /

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -1015,6 +1015,7 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
         uint64 _thawingUntil,
         uint256 _thawingNonce
     ) private returns (bytes32) {
+        require(_shares != 0, HorizonStakingInvalidZeroShares());
         LinkedList.List storage thawRequestList = _getThawRequestList(
             _requestType,
             _serviceProvider,

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -268,11 +268,11 @@ abstract contract HorizonStakingBase is
      * TODO: update the calculation after the transition period.
      */
     function _getIdleStake(address _serviceProvider) internal view returns (uint256) {
-        return
-            _serviceProviders[_serviceProvider].tokensStaked -
-            _serviceProviders[_serviceProvider].tokensProvisioned -
-            _serviceProviders[_serviceProvider].__DEPRECATED_tokensAllocated -
+        uint256 tokensUsed = _serviceProviders[_serviceProvider].tokensProvisioned +
+            _serviceProviders[_serviceProvider].__DEPRECATED_tokensAllocated +
             _serviceProviders[_serviceProvider].__DEPRECATED_tokensLocked;
+        uint256 tokensStaked = _serviceProviders[_serviceProvider].tokensStaked;
+        return tokensStaked > tokensUsed ? tokensStaked - tokensUsed : 0;
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -323,7 +323,7 @@ abstract contract HorizonStakingBase is
      * @return The ID of the next thaw request in the list.
      */
     function _getNextProvisionThawRequest(bytes32 _thawRequestId) internal view returns (bytes32) {
-        return _provisionThawRequests[_thawRequestId].next;
+        return _thawRequests[ThawRequestType.Provision][_thawRequestId].next;
     }
 
     /**
@@ -332,7 +332,7 @@ abstract contract HorizonStakingBase is
      * @return The ID of the next thaw request in the list.
      */
     function _getNextDelegationThawRequest(bytes32 _thawRequestId) internal view returns (bytes32) {
-        return _delegationThawRequests[_thawRequestId].next;
+        return _thawRequests[ThawRequestType.Delegation][_thawRequestId].next;
     }
 
     /**
@@ -341,7 +341,7 @@ abstract contract HorizonStakingBase is
      * @return The ID of the next thaw request in the list.
      */
     function _getNextDelegationWithBeneficiaryThawRequest(bytes32 _thawRequestId) internal view returns (bytes32) {
-        return _delegationWithBeneficiaryThawRequests[_thawRequestId].next;
+        return _thawRequests[ThawRequestType.DelegationWithBeneficiary][_thawRequestId].next;
     }
 
     /**
@@ -360,15 +360,7 @@ abstract contract HorizonStakingBase is
         address _verifier,
         address _owner
     ) internal view returns (LinkedList.List storage) {
-        if (_requestType == ThawRequestType.Provision) {
-            return _provisionThawRequestLists[_serviceProvider][_verifier][_owner];
-        } else if (_requestType == ThawRequestType.Delegation) {
-            return _delegationThawRequestLists[_serviceProvider][_verifier][_owner];
-        } else if (_requestType == ThawRequestType.DelegationWithBeneficiary) {
-            return _delegationWithBeneficiaryThawRequestLists[_serviceProvider][_verifier][_owner];
-        } else {
-            revert HorizonStakingInvalidThawRequestType();
-        }
+        return _thawRequestLists[_requestType][_serviceProvider][_verifier][_owner];
     }
 
     /**
@@ -383,15 +375,7 @@ abstract contract HorizonStakingBase is
         ThawRequestType _requestType,
         bytes32 _thawRequestId
     ) internal view returns (IHorizonStakingTypes.ThawRequest storage) {
-        if (_requestType == ThawRequestType.Provision) {
-            return _provisionThawRequests[_thawRequestId];
-        } else if (_requestType == ThawRequestType.Delegation) {
-            return _delegationThawRequests[_thawRequestId];
-        } else if (_requestType == ThawRequestType.DelegationWithBeneficiary) {
-            return _delegationWithBeneficiaryThawRequests[_thawRequestId];
-        } else {
-            revert("Unknown ThawRequestType");
-        }
+        return _thawRequests[_requestType][_thawRequestId];
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -305,8 +305,10 @@ abstract contract HorizonStakingBase is
             return _getNextProvisionThawRequest;
         } else if (_requestType == ThawRequestType.Delegation) {
             return _getNextDelegationThawRequest;
+        } else if (_requestType == ThawRequestType.DelegationWithBeneficiary) {
+            return _getNextDelegationWithBeneficiaryThawRequest;
         } else {
-            revert("Unknown ThawRequestType");
+            revert HorizonStakingInvalidThawRequestType();
         }
     }
 
@@ -329,6 +331,15 @@ abstract contract HorizonStakingBase is
     }
 
     /**
+     * @notice Retrieves the next thaw request for a delegation with a beneficiary.
+     * @param _thawRequestId The ID of the current thaw request.
+     * @return The ID of the next thaw request in the list.
+     */
+    function _getNextDelegationWithBeneficiaryThawRequest(bytes32 _thawRequestId) internal view returns (bytes32) {
+        return _delegationWithBeneficiaryThawRequests[_thawRequestId].next;
+    }
+
+    /**
      * @notice Retrieves the thaw request list for the given request type.
      * @dev Uses the `ThawRequestType` to determine which mapping to access.
      * Reverts if the request type is unknown.
@@ -348,8 +359,10 @@ abstract contract HorizonStakingBase is
             return _provisionThawRequestLists[_serviceProvider][_verifier][_owner];
         } else if (_requestType == ThawRequestType.Delegation) {
             return _delegationThawRequestLists[_serviceProvider][_verifier][_owner];
+        } else if (_requestType == ThawRequestType.DelegationWithBeneficiary) {
+            return _delegationWithBeneficiaryThawRequestLists[_serviceProvider][_verifier][_owner];
         } else {
-            revert("Unknown ThawRequestType");
+            revert HorizonStakingInvalidThawRequestType();
         }
     }
 
@@ -369,6 +382,8 @@ abstract contract HorizonStakingBase is
             return _provisionThawRequests[_thawRequestId];
         } else if (_requestType == ThawRequestType.Delegation) {
             return _delegationThawRequests[_thawRequestId];
+        } else if (_requestType == ThawRequestType.DelegationWithBeneficiary) {
+            return _delegationWithBeneficiaryThawRequests[_thawRequestId];
         } else {
             revert("Unknown ThawRequestType");
         }

--- a/packages/horizon/contracts/staking/HorizonStakingBase.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingBase.sol
@@ -206,20 +206,25 @@ abstract contract HorizonStakingBase is
             return 0;
         }
 
-        uint256 tokens = 0;
+        uint256 thawedTokens = 0;
         Provision storage prov = _provisions[serviceProvider][verifier];
+        uint256 tokensThawing = prov.tokensThawing;
+        uint256 sharesThawing = prov.sharesThawing;
 
         bytes32 thawRequestId = thawRequestList.head;
         while (thawRequestId != bytes32(0)) {
             ThawRequest storage thawRequest = _getThawRequest(requestType, thawRequestId);
             if (thawRequest.thawingUntil <= block.timestamp) {
-                tokens += (thawRequest.shares * prov.tokensThawing) / prov.sharesThawing;
+                uint256 tokens = (thawRequest.shares * tokensThawing) / sharesThawing;
+                tokensThawing = tokensThawing - tokens;
+                sharesThawing = sharesThawing - thawRequest.shares;
+                thawedTokens = thawedTokens + tokens;
             } else {
                 break;
             }
             thawRequestId = thawRequest.next;
         }
-        return tokens;
+        return thawedTokens;
     }
 
     /**

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -443,8 +443,7 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
         // Anyone is allowed to close ONLY under two concurrent conditions
         // - After maxAllocationEpochs passed
         // - When the allocation is for non-zero amount of tokens
-        bool isIndexerOrOperator = msg.sender == alloc.indexer ||
-            isOperator(alloc.indexer, SUBGRAPH_DATA_SERVICE_ADDRESS);
+        bool isIndexerOrOperator = msg.sender == alloc.indexer || isOperator(msg.sender, alloc.indexer);
         if (epochs <= __DEPRECATED_maxAllocationEpochs || alloc.tokens == 0) {
             require(isIndexerOrOperator, "!auth");
         }

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -286,9 +286,8 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
 
         // Slashing more tokens than freely available (over allocation condition)
         // Unlock locked tokens to avoid the indexer to withdraw them
-        uint256 tokensAvailable = indexerStake.tokensStaked -
-            indexerStake.__DEPRECATED_tokensAllocated -
-            indexerStake.__DEPRECATED_tokensLocked;
+        uint256 tokensUsed = indexerStake.__DEPRECATED_tokensAllocated + indexerStake.__DEPRECATED_tokensLocked;
+        uint256 tokensAvailable = tokensUsed > indexerStake.tokensStaked ? 0 : indexerStake.tokensStaked - tokensUsed;
         if (tokens > tokensAvailable && indexerStake.__DEPRECATED_tokensLocked > 0) {
             uint256 tokensOverAllocated = tokens - tokensAvailable;
             uint256 tokensToUnlock = MathUtils.min(tokensOverAllocated, indexerStake.__DEPRECATED_tokensLocked);

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -19,8 +19,8 @@ import { HorizonStakingBase } from "./HorizonStakingBase.sol";
  * to the Horizon Staking contract. It allows indexers to close allocations and collect pending query fees, but it
  * does not allow for the creation of new allocations. This should allow indexers to migrate to a subgraph data service
  * without losing rewards or having service interruptions.
- * @dev TODO: Once the transition period passes this contract can be removed. It's expected the transition period to
- * last for a full allocation cycle (28 epochs).
+ * @dev TODO: Once the transition period passes this contract can be removed (note that an upgrade to the RewardsManager
+ * will also be required). It's expected the transition period to last for a full allocation cycle (28 epochs).
  * @custom:security-contact Please email security+contracts@thegraph.com if you find any
  * bugs. We may have an active bug bounty program.
  */

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -313,43 +313,6 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
     }
 
     /**
-     * @notice Withdraw undelegated tokens once the unbonding period has passed.
-     * @param indexer Withdraw available tokens delegated to indexer
-     */
-    function legacyWithdrawDelegated(
-        address indexer,
-        address // newIndexer, deprecated
-    ) external override notPaused returns (uint256) {
-        // Get the delegation pool of the indexer
-        address delegator = msg.sender;
-        DelegationPoolInternal storage pool = _legacyDelegationPools[indexer];
-        DelegationInternal storage delegation = pool.delegators[delegator];
-
-        // Validation
-        uint256 tokensToWithdraw = 0;
-        uint256 currentEpoch = _graphEpochManager().currentEpoch();
-        if (
-            delegation.__DEPRECATED_tokensLockedUntil > 0 && currentEpoch >= delegation.__DEPRECATED_tokensLockedUntil
-        ) {
-            tokensToWithdraw = delegation.__DEPRECATED_tokensLocked;
-        }
-        require(tokensToWithdraw > 0, "!tokens");
-
-        // Reset lock
-        delegation.__DEPRECATED_tokensLocked = 0;
-        delegation.__DEPRECATED_tokensLockedUntil = 0;
-
-        emit StakeDelegatedWithdrawn(indexer, delegator, tokensToWithdraw);
-
-        // -- Interactions --
-
-        // Return tokens to the delegator
-        _graphToken().pushTokens(delegator, tokensToWithdraw);
-
-        return tokensToWithdraw;
-    }
-
-    /**
      * @notice (Legacy) Return true if operator is allowed for the service provider on the subgraph data service.
      * @dev TODO: Delete after the transition period
      * @param operator Address of the operator

--- a/packages/horizon/contracts/staking/HorizonStakingStorage.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingStorage.sol
@@ -148,32 +148,14 @@ abstract contract HorizonStakingV1Storage {
         internal _delegationFeeCut;
 
     /// @dev Thaw requests
-    /// Details for each thawing operation in the staking contract for both service providers.
-    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _provisionThawRequests;
+    /// Details for each thawing operation in the staking contract (for both service providers and delegators).
+    mapping(IHorizonStakingTypes.ThawRequestType thawRequestType => mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest))
+        internal _thawRequests;
 
     /// @dev Thaw request lists
-    /// Metadata defining linked lists of thaw requests for each service provider (owner).
-    mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
-        internal _provisionThawRequestLists;
-
-    /// @dev Thaw requests
-    /// Details for each thawing operation in the staking contract for delegators.
-    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _delegationThawRequests;
-
-    /// @dev Thaw request lists
-    /// Metadata defining linked lists of thaw requests for each delegator (owner).
-    mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
-        internal _delegationThawRequestLists;
-
-    /// @dev Thaw requests
-    /// Details for each thawing operation in the staking contract for both delegators undelegating to a beneficiary.
-    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest)
-        internal _delegationWithBeneficiaryThawRequests;
-
-    /// @dev Thaw request lists
-    /// Metadata defining linked lists of thaw requests for each delegator (owner) undelegating to a beneficiary.
-    mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
-        internal _delegationWithBeneficiaryThawRequestLists;
+    /// Metadata defining linked lists of thaw requests for each service provider or delegator (owner)
+    mapping(IHorizonStakingTypes.ThawRequestType thawRequestType => mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list))))
+        internal _thawRequestLists;
 
     /// @dev Operator allow list
     /// Used for all verifiers except the subgraph data service.

--- a/packages/horizon/contracts/staking/HorizonStakingStorage.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingStorage.sol
@@ -149,12 +149,21 @@ abstract contract HorizonStakingV1Storage {
 
     /// @dev Thaw requests
     /// Details for each thawing operation in the staking contract (for both service providers and delegators).
-    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _thawRequests;
+    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _provisionThawRequests;
 
     /// @dev Thaw request lists
     /// Metadata defining linked lists of thaw requests for each service provider or delegator (owner)
     mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
-        internal _thawRequestLists;
+        internal _provisionThawRequestLists;
+
+    /// @dev Thaw requests
+    /// Details for each thawing operation in the staking contract (for both service providers and delegators).
+    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _delegationThawRequests;
+
+    /// @dev Thaw request lists
+    /// Metadata defining linked lists of thaw requests for each service provider or delegator (owner)
+    mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
+        internal _delegationThawRequestLists;
 
     /// @dev Operator allow list
     /// Used for all verifiers except the subgraph data service.

--- a/packages/horizon/contracts/staking/HorizonStakingStorage.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingStorage.sol
@@ -148,22 +148,32 @@ abstract contract HorizonStakingV1Storage {
         internal _delegationFeeCut;
 
     /// @dev Thaw requests
-    /// Details for each thawing operation in the staking contract (for both service providers and delegators).
+    /// Details for each thawing operation in the staking contract for both service providers.
     mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _provisionThawRequests;
 
     /// @dev Thaw request lists
-    /// Metadata defining linked lists of thaw requests for each service provider or delegator (owner)
+    /// Metadata defining linked lists of thaw requests for each service provider (owner).
     mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
         internal _provisionThawRequestLists;
 
     /// @dev Thaw requests
-    /// Details for each thawing operation in the staking contract (for both service providers and delegators).
+    /// Details for each thawing operation in the staking contract for delegators.
     mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest) internal _delegationThawRequests;
 
     /// @dev Thaw request lists
-    /// Metadata defining linked lists of thaw requests for each service provider or delegator (owner)
+    /// Metadata defining linked lists of thaw requests for each delegator (owner).
     mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
         internal _delegationThawRequestLists;
+
+    /// @dev Thaw requests
+    /// Details for each thawing operation in the staking contract for both delegators undelegating to a beneficiary.
+    mapping(bytes32 thawRequestId => IHorizonStakingTypes.ThawRequest thawRequest)
+        internal _delegationWithBeneficiaryThawRequests;
+
+    /// @dev Thaw request lists
+    /// Metadata defining linked lists of thaw requests for each delegator (owner) undelegating to a beneficiary.
+    mapping(address serviceProvider => mapping(address verifier => mapping(address owner => LinkedList.List list)))
+        internal _delegationWithBeneficiaryThawRequestLists;
 
     /// @dev Operator allow list
     /// Used for all verifiers except the subgraph data service.

--- a/packages/horizon/test/GraphBase.t.sol
+++ b/packages/horizon/test/GraphBase.t.sol
@@ -71,7 +71,8 @@ abstract contract GraphBaseTest is IHorizonStakingTypes, Utils, Constants {
             operator: createUser("operator"),
             gateway: createUser("gateway"),
             verifier: createUser("verifier"),
-            delegator: createUser("delegator")
+            delegator: createUser("delegator"),
+            legacySlasher: createUser("legacySlasher")
         });
 
         // Deploy protocol contracts

--- a/packages/horizon/test/escrow/collect.t.sol
+++ b/packages/horizon/test/escrow/collect.t.sol
@@ -101,7 +101,7 @@ contract GraphEscrowCollectTest is GraphEscrowTest {
         uint256 tokensDelegatoion = tokens * delegationFeeCut / MAX_PPM;
         vm.assume(tokensDataService < tokens - tokensProtocol - tokensDelegatoion);
 
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
         resetPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, delegationTokens, 0);
 

--- a/packages/horizon/test/payments/GraphPayments.t.sol
+++ b/packages/horizon/test/payments/GraphPayments.t.sol
@@ -119,7 +119,7 @@ contract GraphPaymentsTest is HorizonStakingSharedTest {
         address escrowAddress = address(escrow);
 
         // Delegate tokens
-        tokensDelegate = bound(tokensDelegate, 1, MAX_STAKING_TOKENS);
+        tokensDelegate = bound(tokensDelegate, MIN_DELEGATION, MAX_STAKING_TOKENS);
         vm.startPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, tokensDelegate, 0);
 

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -1852,7 +1852,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         address operator,
         bool legacy
     ) internal view returns (bool) {
-        uint256 slotNumber = legacy ? 21 : 35;
+        uint256 slotNumber = legacy ? 21 : 31;
         uint256 slot;
 
         if (legacy) {
@@ -1934,7 +1934,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         address verifier,
         bool legacy
     ) internal view returns (DelegationPoolInternalTest memory) {
-        uint256 slotNumber = legacy ? 20 : 37;
+        uint256 slotNumber = legacy ? 20 : 33;
         uint256 baseSlot;
         if (legacy) {
             baseSlot = uint256(keccak256(abi.encode(serviceProvider, slotNumber)));
@@ -1966,7 +1966,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
         address delegator,
         bool legacy
     ) internal view returns (DelegationInternal memory) {
-        uint256 slotNumber = legacy ? 20 : 37;
+        uint256 slotNumber = legacy ? 20 : 33;
         uint256 baseSlot;
 
         // DelegationPool

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -1046,7 +1046,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             newVerifier: address(0),
             minSharesForNewProvider: 0,
             nThawRequests: nThawRequests,
-            legacy: false
+            legacy: verifier == subgraphDataServiceLegacyAddress
         });
         __withdrawDelegated(params);
     }
@@ -1086,20 +1086,6 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             minSharesForNewProvider: minSharesForNewProvider,
             nThawRequests: nThawRequests,
             legacy: false
-        });
-        __withdrawDelegated(params);
-    }
-
-    function _withdrawDelegated(address serviceProvider, address newServiceProvider) internal {
-        Params_WithdrawDelegated memory params = Params_WithdrawDelegated({
-            thawRequestType: IHorizonStakingTypes.ThawRequestType.Delegation,
-            serviceProvider: serviceProvider,
-            verifier: subgraphDataServiceLegacyAddress,
-            newServiceProvider: newServiceProvider,
-            newVerifier: subgraphDataServiceLegacyAddress,
-            minSharesForNewProvider: 0,
-            nThawRequests: 0,
-            legacy: true
         });
         __withdrawDelegated(params);
     }
@@ -1197,9 +1183,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             msgSender,
             calcValues.tokensThawed
         );
-        if (params.legacy) {
-            staking.withdrawDelegated(params.serviceProvider, params.newServiceProvider);
-        } else if (reDelegate) {
+        if (reDelegate) {
             staking.redelegate(
                 params.serviceProvider,
                 params.verifier,

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -1367,7 +1367,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
     function _setDelegationSlashingEnabled() internal {
         // setDelegationSlashingEnabled
         vm.expectEmit();
-        emit IHorizonStakingMain.DelegationSlashingEnabled(true);
+        emit IHorizonStakingMain.DelegationSlashingEnabled();
         staking.setDelegationSlashingEnabled();
 
         // after

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -504,7 +504,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             verifier,
             serviceProvider,
             calcValues.thawRequestsFulfilledList.length,
-            calcValues.tokensThawed
+            calcValues.tokensThawed,
+            IHorizonStakingTypes.ThawRequestType.Provision
         );
         vm.expectEmit(address(staking));
         emit IHorizonStakingMain.TokensDeprovisioned(serviceProvider, verifier, calcValues.tokensThawed);
@@ -617,7 +618,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             verifier,
             serviceProvider,
             calcValues.thawRequestsFulfilledList.length,
-            calcValues.tokensThawed
+            calcValues.tokensThawed,
+            IHorizonStakingTypes.ThawRequestType.Provision
         );
         vm.expectEmit(address(staking));
         emit IHorizonStakingMain.TokensDeprovisioned(serviceProvider, verifier, calcValues.tokensThawed);
@@ -1160,7 +1162,8 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             params.verifier,
             msgSender,
             calcValues.thawRequestsFulfilledList.length,
-            calcValues.tokensThawed
+            calcValues.tokensThawed,
+            params.thawRequestType
         );
         if (calcValues.tokensThawed != 0) {
             vm.expectEmit();

--- a/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
+++ b/packages/horizon/test/shared/horizon-staking/HorizonStakingShared.t.sol
@@ -1488,7 +1488,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
             uint256 tokensSlashed = calcValues.providerTokensSlashed +
                 (isDelegationSlashingEnabled ? calcValues.delegationTokensSlashed : 0);
             uint256 provisionThawingTokens = (before.provision.tokensThawing *
-                (1e18 - ((calcValues.providerTokensSlashed * 1e18) / before.provision.tokens))) / (1e18);
+                (1e18 - ((calcValues.providerTokensSlashed * 1e18 + before.provision.tokens - 1) / before.provision.tokens))) / (1e18);
 
             // assert
             assertEq(afterProvision.tokens + calcValues.providerTokensSlashed, before.provision.tokens);
@@ -1506,7 +1506,7 @@ abstract contract HorizonStakingSharedTest is GraphBaseTest {
                 (before.provision.sharesThawing != 0 && afterProvision.sharesThawing == 0) ? before.provision.thawingNonce + 1 : before.provision.thawingNonce);
             if (isDelegationSlashingEnabled) {
                 uint256 poolThawingTokens = (before.pool.tokensThawing *
-                    (1e18 - ((calcValues.delegationTokensSlashed * 1e18) / before.pool.tokens))) / (1e18);
+                    (1e18 - ((calcValues.delegationTokensSlashed * 1e18 + before.pool.tokens - 1) / before.pool.tokens))) / (1e18);
                 assertEq(afterPool.tokens + calcValues.delegationTokensSlashed, before.pool.tokens);
                 assertEq(afterPool.shares, before.pool.shares);
                 assertEq(afterPool.tokensThawing, poolThawingTokens);

--- a/packages/horizon/test/staking/allocation/close.t.sol
+++ b/packages/horizon/test/staking/allocation/close.t.sol
@@ -13,10 +13,32 @@ contract HorizonStakingCloseAllocationTest is HorizonStakingTest {
     bytes32 internal constant _poi = keccak256("poi");
 
     /*
+     * MODIFIERS
+     */
+
+    modifier useLegacyOperator() {
+        resetPrank(users.indexer);
+        _setOperator(subgraphDataServiceLegacyAddress, users.operator, true);
+        vm.startPrank(users.operator);
+        _;
+        vm.stopPrank();
+    }
+
+    /*
      * TESTS
      */
 
     function testCloseAllocation(uint256 tokens) public useIndexer useAllocation(1 ether) {
+        tokens = bound(tokens, 1, MAX_STAKING_TOKENS);
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+
+        // Skip 15 epochs
+        vm.roll(15);
+
+        _closeAllocation(_allocationId, _poi);
+    }
+
+    function testCloseAllocation_Operator(uint256 tokens) public useLegacyOperator() useAllocation(1 ether) {
         tokens = bound(tokens, 1, MAX_STAKING_TOKENS);
         _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
 

--- a/packages/horizon/test/staking/delegation/addToPool.t.sol
+++ b/packages/horizon/test/staking/delegation/addToPool.t.sol
@@ -10,6 +10,7 @@ contract HorizonStakingDelegationAddToPoolTest is HorizonStakingTest {
 
     modifier useValidDelegationAmount(uint256 tokens) {
         vm.assume(tokens <= MAX_STAKING_TOKENS);
+        vm.assume(tokens >= MIN_DELEGATION);
         _;
     }
 
@@ -93,7 +94,7 @@ contract HorizonStakingDelegationAddToPoolTest is HorizonStakingTest {
         uint256 recoverAmount
     ) public useIndexer useProvision(tokens, 0, 0) useDelegationSlashing() {
         recoverAmount = bound(recoverAmount, 1, MAX_STAKING_TOKENS);
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
 
         // create delegation pool
         resetPrank(users.delegator);
@@ -116,7 +117,7 @@ contract HorizonStakingDelegationAddToPoolTest is HorizonStakingTest {
         uint256 recoverAmount
     ) public useIndexer useProvision(tokens, 0, 0) useDelegationSlashing() {
         recoverAmount = bound(recoverAmount, 1, MAX_STAKING_TOKENS);
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
 
         // create delegation pool
         resetPrank(users.delegator);

--- a/packages/horizon/test/staking/delegation/delegate.t.sol
+++ b/packages/horizon/test/staking/delegation/delegate.t.sol
@@ -59,9 +59,25 @@ contract HorizonStakingDelegateTest is HorizonStakingTest {
         staking.delegate(users.indexer, subgraphDataServiceAddress, 0, 0);
     }
 
+    function testDelegate_RevertWhen_UnderMinDelegation(
+        uint256 amount,
+        uint256 delegationAmount
+    ) public useIndexer useProvision(amount, 0, 0) {
+        delegationAmount = bound(delegationAmount, 1, MIN_DELEGATION - 1);
+        vm.startPrank(users.delegator);
+        token.approve(address(staking), delegationAmount);
+        bytes memory expectedError = abi.encodeWithSelector(
+            IHorizonStakingMain.HorizonStakingInsufficientTokens.selector,
+            delegationAmount,
+            MIN_DELEGATION
+        );
+        vm.expectRevert(expectedError);
+        staking.delegate(users.indexer, subgraphDataServiceAddress, delegationAmount, 0);
+    }
+
     function testDelegate_LegacySubgraphService(uint256 amount, uint256 delegationAmount) public useIndexer {
         amount = bound(amount, 1 ether, MAX_STAKING_TOKENS);
-        delegationAmount = bound(delegationAmount, 1, MAX_STAKING_TOKENS);
+        delegationAmount = bound(delegationAmount, MIN_DELEGATION, MAX_STAKING_TOKENS);
         _createProvision(users.indexer, subgraphDataServiceLegacyAddress, amount, 0, 0);
 
         resetPrank(users.delegator);
@@ -72,7 +88,7 @@ contract HorizonStakingDelegateTest is HorizonStakingTest {
         uint256 tokens,
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, 0, 0) useDelegationSlashing() {
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
 
         resetPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, delegationTokens, 0);
@@ -96,7 +112,7 @@ contract HorizonStakingDelegateTest is HorizonStakingTest {
         uint256 tokens,
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, 0, 0) useDelegationSlashing() {
-        delegationTokens = bound(delegationTokens, 2, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION * 2, MAX_STAKING_TOKENS);
 
         resetPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, delegationTokens, 0);
@@ -126,7 +142,7 @@ contract HorizonStakingDelegateTest is HorizonStakingTest {
         uint256 recoverAmount
     ) public useIndexer useProvision(tokens, 0, 0) useDelegationSlashing() {
         recoverAmount = bound(recoverAmount, 1, MAX_STAKING_TOKENS);
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
 
         // create delegation pool
         resetPrank(users.delegator);

--- a/packages/horizon/test/staking/delegation/delegate.t.sol
+++ b/packages/horizon/test/staking/delegation/delegate.t.sol
@@ -67,7 +67,7 @@ contract HorizonStakingDelegateTest is HorizonStakingTest {
         vm.startPrank(users.delegator);
         token.approve(address(staking), delegationAmount);
         bytes memory expectedError = abi.encodeWithSelector(
-            IHorizonStakingMain.HorizonStakingInsufficientTokens.selector,
+            IHorizonStakingMain.HorizonStakingInsufficientDelegationTokens.selector,
             delegationAmount,
             MIN_DELEGATION
         );

--- a/packages/horizon/test/staking/delegation/legacyWithdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/legacyWithdraw.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import "forge-std/Test.sol";
+
+import { IHorizonStakingMain } from "../../../contracts/interfaces/internal/IHorizonStakingMain.sol";
+import { IHorizonStakingTypes } from "../../../contracts/interfaces/internal/IHorizonStakingTypes.sol";
+import { IHorizonStakingExtension } from "../../../contracts/interfaces/internal/IHorizonStakingExtension.sol";
+import { LinkedList } from "../../../contracts/libraries/LinkedList.sol";
+
+import { HorizonStakingTest } from "../HorizonStaking.t.sol";
+
+contract HorizonStakingLegacyWithdrawDelegationTest is HorizonStakingTest {
+    /*
+     * MODIFIERS
+     */
+
+    modifier useDelegator() {
+        resetPrank(users.delegator);
+        _;
+    }
+
+    /*
+     * HELPERS
+     */
+
+    function _setLegacyDelegation(
+        address _indexer,
+        address _delegator,
+        uint256 _shares,
+        uint256 __DEPRECATED_tokensLocked,
+        uint256 __DEPRECATED_tokensLockedUntil
+    ) public {
+        // Calculate the base storage slot for the serviceProvider in the mapping
+        bytes32 baseSlot = keccak256(abi.encode(_indexer, uint256(20)));
+
+        // Calculate the slot for the delegator's DelegationInternal struct
+        bytes32 delegatorSlot = keccak256(abi.encode(_delegator, bytes32(uint256(baseSlot) + 4)));
+
+        // Use vm.store to set each field of the struct
+        vm.store(address(staking), bytes32(uint256(delegatorSlot)), bytes32(_shares));
+        vm.store(address(staking), bytes32(uint256(delegatorSlot) + 1), bytes32(__DEPRECATED_tokensLocked));
+        vm.store(address(staking), bytes32(uint256(delegatorSlot) + 2), bytes32(__DEPRECATED_tokensLockedUntil));
+    }
+
+    /*
+     * ACTIONS
+     */
+
+    function _legacyWithdrawDelegated(address _indexer) internal {
+        (, address delegator, ) = vm.readCallers();
+        IHorizonStakingTypes.DelegationPool memory pool = staking.getDelegationPool(_indexer, subgraphDataServiceLegacyAddress);
+        uint256 beforeStakingBalance = token.balanceOf(address(staking));
+        uint256 beforeDelegatorBalance = token.balanceOf(users.delegator);
+
+        vm.expectEmit(address(staking));
+        emit IHorizonStakingExtension.StakeDelegatedWithdrawn(_indexer, delegator, pool.tokens);
+        staking.legacyWithdrawDelegated(users.indexer, address(0));
+
+        uint256 afterStakingBalance = token.balanceOf(address(staking));
+        uint256 afterDelegatorBalance = token.balanceOf(users.delegator);
+
+        assertEq(afterStakingBalance, beforeStakingBalance - pool.tokens);
+        assertEq(afterDelegatorBalance - pool.tokens, beforeDelegatorBalance);
+
+        DelegationInternal memory delegation = _getStorage_Delegation(
+            _indexer,
+            subgraphDataServiceLegacyAddress,
+            delegator,
+            true
+        );
+        assertEq(delegation.shares, 0);
+        assertEq(delegation.__DEPRECATED_tokensLocked, 0);
+        assertEq(delegation.__DEPRECATED_tokensLockedUntil, 0);
+    }
+
+    /*
+     * TESTS
+     */
+
+    function testWithdraw_Legacy(uint256 tokensLocked) public useDelegator {
+        vm.assume(tokensLocked > 0);
+
+        _setStorage_DelegationPool(users.indexer, tokensLocked, 0, 0);
+        _setLegacyDelegation(users.indexer, users.delegator, 0, tokensLocked, 1);
+        token.transfer(address(staking), tokensLocked);
+
+        _legacyWithdrawDelegated(users.indexer);
+    }
+
+    function testWithdraw_Legacy_RevertWhen_NoTokens() public useDelegator {
+        _setStorage_DelegationPool(users.indexer, 0, 0, 0);
+        _setLegacyDelegation(users.indexer, users.delegator, 0, 0, 0);
+
+        vm.expectRevert("!tokens");
+        staking.legacyWithdrawDelegated(users.indexer, address(0));
+    }
+}

--- a/packages/horizon/test/staking/delegation/legacyWithdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/legacyWithdraw.t.sol
@@ -54,8 +54,8 @@ contract HorizonStakingLegacyWithdrawDelegationTest is HorizonStakingTest {
         uint256 beforeDelegatorBalance = token.balanceOf(users.delegator);
 
         vm.expectEmit(address(staking));
-        emit IHorizonStakingExtension.StakeDelegatedWithdrawn(_indexer, delegator, pool.tokens);
-        staking.legacyWithdrawDelegated(users.indexer, address(0));
+        emit IHorizonStakingMain.StakeDelegatedWithdrawn(_indexer, delegator, pool.tokens);
+        staking.withdrawDelegated(users.indexer, address(0));
 
         uint256 afterStakingBalance = token.balanceOf(address(staking));
         uint256 afterDelegatorBalance = token.balanceOf(users.delegator);
@@ -93,6 +93,6 @@ contract HorizonStakingLegacyWithdrawDelegationTest is HorizonStakingTest {
         _setLegacyDelegation(users.indexer, users.delegator, 0, 0, 0);
 
         vm.expectRevert("!tokens");
-        staking.legacyWithdrawDelegated(users.indexer, address(0));
+        staking.withdrawDelegated(users.indexer, address(0));
     }
 }

--- a/packages/horizon/test/staking/delegation/redelegate.t.sol
+++ b/packages/horizon/test/staking/delegation/redelegate.t.sol
@@ -10,19 +10,6 @@ import { HorizonStakingTest } from "../HorizonStaking.t.sol";
 contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
 
     /*
-     * MODIFIERS
-     */
-
-    modifier useUndelegate(uint256 shares) {
-        resetPrank(users.delegator);
-        DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
-        shares = bound(shares, 1, delegation.shares);
-
-        _undelegate(users.indexer, subgraphDataServiceAddress, shares);
-        _;
-    }
-
-    /*
      * HELPERS
      */
 

--- a/packages/horizon/test/staking/delegation/undelegate.t.sol
+++ b/packages/horizon/test/staking/delegation/undelegate.t.sol
@@ -63,6 +63,7 @@ contract HorizonStakingUndelegateTest is HorizonStakingTest {
         address beneficiary
     ) public useIndexer useProvision(amount, 0, 0) useDelegation(delegationAmount) {
         vm.assume(beneficiary != address(0));
+        vm.assume(delegationAmount >= MIN_UNDELEGATION_WITH_BENEFICIARY);
         resetPrank(users.delegator);
         DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
         _undelegateWithBeneficiary(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
@@ -95,7 +96,7 @@ contract HorizonStakingUndelegateTest is HorizonStakingTest {
         public
         useIndexer
         useProvision(1000 ether, 0, 0)
-        useDelegation(1000 ether)
+        useDelegation(10000 ether)
     {
         resetPrank(users.delegator);
 

--- a/packages/horizon/test/staking/delegation/undelegate.t.sol
+++ b/packages/horizon/test/staking/delegation/undelegate.t.sol
@@ -57,7 +57,7 @@ contract HorizonStakingUndelegateTest is HorizonStakingTest {
         vm.assume(beneficiary != address(0));
         resetPrank(users.delegator);
         DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
-        _undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
+        _undelegateWithBeneficiary(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
     }
 
     function testUndelegate_RevertWhen_TooManyUndelegations()
@@ -232,6 +232,6 @@ contract HorizonStakingUndelegateTest is HorizonStakingTest {
         DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
         bytes memory expectedError = abi.encodeWithSelector(IHorizonStakingMain.HorizonStakingInvalidBeneficiaryZeroAddress.selector);
         vm.expectRevert(expectedError);
-        staking.undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, address(0));
+        staking.undelegateWithBeneficiary(users.indexer, subgraphDataServiceAddress, delegation.shares, address(0));
     }
 }

--- a/packages/horizon/test/staking/delegation/withdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/withdraw.t.sol
@@ -87,7 +87,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
 
         skip(thawRequest.thawingUntil + 1);
 
-        _withdrawDelegated(users.indexer, address(0));
+        _withdrawDelegated(users.indexer, subgraphDataServiceLegacyAddress, 0);
     }
 
     function testWithdrawDelegation_RevertWhen_InvalidPool(

--- a/packages/horizon/test/staking/delegation/withdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/withdraw.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.27;
 import "forge-std/Test.sol";
 
 import { IHorizonStakingMain } from "../../../contracts/interfaces/internal/IHorizonStakingMain.sol";
+import { IHorizonStakingTypes } from "../../../contracts/interfaces/internal/IHorizonStakingTypes.sol";
 import { LinkedList } from "../../../contracts/libraries/LinkedList.sol";
 
 import { HorizonStakingTest } from "../HorizonStaking.t.sol";
@@ -42,11 +43,12 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         useUndelegate(withdrawShares)
     {
         LinkedList.List memory thawingRequests = staking.getThawRequestList(
+            IHorizonStakingTypes.ThawRequestType.Delegation,
             users.indexer,
             subgraphDataServiceAddress,
             users.delegator
         );
-        ThawRequest memory thawRequest = staking.getThawRequest(thawingRequests.tail);
+        ThawRequest memory thawRequest = staking.getThawRequest(IHorizonStakingTypes.ThawRequestType.Delegation, thawingRequests.tail);
 
         skip(thawRequest.thawingUntil + 1);
 
@@ -93,11 +95,12 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         _undelegate(users.indexer, delegation.shares);
 
         LinkedList.List memory thawingRequests = staking.getThawRequestList(
+            IHorizonStakingTypes.ThawRequestType.Delegation,
             users.indexer,
             subgraphDataServiceLegacyAddress,
             users.delegator
         );
-        ThawRequest memory thawRequest = staking.getThawRequest(thawingRequests.tail);
+        ThawRequest memory thawRequest = staking.getThawRequest(IHorizonStakingTypes.ThawRequestType.Delegation, thawingRequests.tail);
 
         skip(thawRequest.thawingUntil + 1);
 
@@ -180,6 +183,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         useDelegation(delegationAmount)
      {
         vm.assume(beneficiary != address(0));
+        vm.assume(beneficiary != address(staking));
         // Skip beneficiary if balance will overflow
         vm.assume(token.balanceOf(beneficiary) < type(uint256).max - delegationAmount);
 
@@ -189,8 +193,8 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         _undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
         
         // Thawing period ends
-        LinkedList.List memory thawingRequests = staking.getThawRequestList(users.indexer, subgraphDataServiceAddress, beneficiary);
-        ThawRequest memory thawRequest = staking.getThawRequest(thawingRequests.tail);
+        LinkedList.List memory thawingRequests = staking.getThawRequestList(IHorizonStakingTypes.ThawRequestType.Delegation, users.indexer, subgraphDataServiceAddress, beneficiary);
+        ThawRequest memory thawRequest = staking.getThawRequest(IHorizonStakingTypes.ThawRequestType.Delegation, thawingRequests.tail);
         skip(thawRequest.thawingUntil + 1);
 
         // Beneficiary withdraws delegated tokens
@@ -216,8 +220,8 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         _undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
 
         // Thawing period ends
-        LinkedList.List memory thawingRequests = staking.getThawRequestList(users.indexer, subgraphDataServiceAddress, users.delegator);
-        ThawRequest memory thawRequest = staking.getThawRequest(thawingRequests.tail);
+        LinkedList.List memory thawingRequests = staking.getThawRequestList(IHorizonStakingTypes.ThawRequestType.Delegation, users.indexer, subgraphDataServiceAddress, users.delegator);
+        ThawRequest memory thawRequest = staking.getThawRequest(IHorizonStakingTypes.ThawRequestType.Delegation, thawingRequests.tail);
         skip(thawRequest.thawingUntil + 1);
 
         // Delegator attempts to withdraw delegated tokens, should revert since beneficiary is the thaw request owner

--- a/packages/horizon/test/staking/delegation/withdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/withdraw.t.sol
@@ -167,6 +167,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
      {
         vm.assume(beneficiary != address(0));
         vm.assume(beneficiary != address(staking));
+        vm.assume(delegationAmount >= MIN_UNDELEGATION_WITH_BENEFICIARY);
         // Skip beneficiary if balance will overflow
         vm.assume(token.balanceOf(beneficiary) < type(uint256).max - delegationAmount);
 
@@ -196,6 +197,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
     {
         vm.assume(beneficiary != address(0));
         vm.assume(beneficiary != users.delegator);
+        vm.assume(delegationAmount >= MIN_UNDELEGATION_WITH_BENEFICIARY);
 
         // Delegator undelegates to beneficiary
         resetPrank(users.delegator);

--- a/packages/horizon/test/staking/delegation/withdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/withdraw.t.sol
@@ -190,7 +190,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         // Delegator undelegates to beneficiary
         resetPrank(users.delegator);
         DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
-        _undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
+        _undelegateWithBeneficiary(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
         
         // Thawing period ends
         LinkedList.List memory thawingRequests = staking.getThawRequestList(IHorizonStakingTypes.ThawRequestType.Delegation, users.indexer, subgraphDataServiceAddress, beneficiary);
@@ -199,7 +199,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
 
         // Beneficiary withdraws delegated tokens
         resetPrank(beneficiary);
-        _withdrawDelegated(users.indexer, subgraphDataServiceAddress, 1);
+        _withdrawDelegatedWithBeneficiary(users.indexer, subgraphDataServiceAddress, 1);
     }
 
     function testWithdrawDelegation_RevertWhen_PreviousOwnerAttemptsToWithdraw(
@@ -217,7 +217,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         // Delegator undelegates to beneficiary
         resetPrank(users.delegator);
         DelegationInternal memory delegation = _getStorage_Delegation(users.indexer, subgraphDataServiceAddress, users.delegator, false);
-        _undelegate(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
+        _undelegateWithBeneficiary(users.indexer, subgraphDataServiceAddress, delegation.shares, beneficiary);
 
         // Thawing period ends
         LinkedList.List memory thawingRequests = staking.getThawRequestList(IHorizonStakingTypes.ThawRequestType.Delegation, users.indexer, subgraphDataServiceAddress, users.delegator);

--- a/packages/horizon/test/staking/delegation/withdraw.t.sol
+++ b/packages/horizon/test/staking/delegation/withdraw.t.sol
@@ -10,23 +10,6 @@ import { LinkedList } from "../../../contracts/libraries/LinkedList.sol";
 import { HorizonStakingTest } from "../HorizonStaking.t.sol";
 
 contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
-    /*
-     * MODIFIERS
-     */
-
-    modifier useUndelegate(uint256 shares) {
-        resetPrank(users.delegator);
-        DelegationInternal memory delegation = _getStorage_Delegation(
-            users.indexer,
-            subgraphDataServiceAddress,
-            users.delegator,
-            false
-        );
-        shares = bound(shares, 1, delegation.shares);
-
-        _undelegate(users.indexer, subgraphDataServiceAddress, shares);
-        _;
-    }
 
     /*
      * TESTS
@@ -81,7 +64,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
     }
 
     function testWithdrawDelegation_LegacySubgraphService(uint256 delegationAmount) public useIndexer {
-        delegationAmount = bound(delegationAmount, 1, MAX_STAKING_TOKENS);
+        delegationAmount = bound(delegationAmount, MIN_DELEGATION, MAX_STAKING_TOKENS);
         _createProvision(users.indexer, subgraphDataServiceLegacyAddress, 10_000_000 ether, 0, MAX_THAWING_PERIOD);
 
         resetPrank(users.delegator);
@@ -111,7 +94,7 @@ contract HorizonStakingWithdrawDelegationTest is HorizonStakingTest {
         uint256 tokens,
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, 0, MAX_THAWING_PERIOD) useDelegationSlashing() {
-        delegationTokens = bound(delegationTokens, 2, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION * 2, MAX_STAKING_TOKENS);
 
         resetPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, delegationTokens, 0);

--- a/packages/horizon/test/staking/provision/deprovision.t.sol
+++ b/packages/horizon/test/staking/provision/deprovision.t.sol
@@ -17,7 +17,7 @@ contract HorizonStakingDeprovisionTest is HorizonStakingTest {
         uint256 thawCount,
         uint256 deprovisionCount
     ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
-        thawCount = bound(thawCount, 1, MAX_THAW_REQUESTS);
+        thawCount = bound(thawCount, 1, 100);
         deprovisionCount = bound(deprovisionCount, 0, thawCount);
         vm.assume(amount >= thawCount); // ensure the provision has at least 1 token for each thaw step
         uint256 individualThawAmount = amount / thawCount;
@@ -37,7 +37,7 @@ contract HorizonStakingDeprovisionTest is HorizonStakingTest {
         uint64 thawingPeriod,
         uint256 thawCount
     ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
-        thawCount = bound(thawCount, 2, MAX_THAW_REQUESTS);
+        thawCount = bound(thawCount, 2, 100);
         vm.assume(amount >= thawCount); // ensure the provision has at least 1 token for each thaw step
         uint256 individualThawAmount = amount / thawCount;
 

--- a/packages/horizon/test/staking/provision/thaw.t.sol
+++ b/packages/horizon/test/staking/provision/thaw.t.sol
@@ -26,7 +26,7 @@ contract HorizonStakingThawTest is HorizonStakingTest {
         uint64 thawingPeriod,
         uint256 thawCount
     ) public useIndexer useProvision(amount, 0, thawingPeriod) {
-        thawCount = bound(thawCount, 1, MAX_THAW_REQUESTS);
+        thawCount = bound(thawCount, 1, 100);
         vm.assume(amount >= thawCount); // ensure the provision has at least 1 token for each thaw step
         uint256 individualThawAmount = amount / thawCount;
 
@@ -72,13 +72,8 @@ contract HorizonStakingThawTest is HorizonStakingTest {
         staking.thaw(users.indexer, subgraphDataServiceAddress, thawAmount);
     }
 
-    function testThaw_RevertWhen_OverMaxThawRequests(
-        uint256 amount,
-        uint64 thawingPeriod,
-        uint256 thawAmount
-    ) public useIndexer useProvision(amount, 0, thawingPeriod) {
-        vm.assume(amount >= MAX_THAW_REQUESTS + 1);
-        thawAmount = bound(thawAmount, 1, amount / (MAX_THAW_REQUESTS + 1));
+    function testThaw_RevertWhen_OverMaxThawRequests() public useIndexer useProvision(10000 ether, 0, 0) {
+        uint256 thawAmount = 1 ether;
 
         for (uint256 i = 0; i < MAX_THAW_REQUESTS; i++) {
             _thaw(users.indexer, subgraphDataServiceAddress, thawAmount);

--- a/packages/horizon/test/staking/provision/thaw.t.sol
+++ b/packages/horizon/test/staking/provision/thaw.t.sol
@@ -139,4 +139,28 @@ contract HorizonStakingThawTest is HorizonStakingTest {
         resetPrank(users.indexer);
         _thaw(users.indexer, subgraphDataServiceAddress, thawAmount);
     }
+
+    function testThaw_GetThawedTokens(
+        uint256 amount,
+        uint64 thawingPeriod,
+        uint256 thawSteps
+    ) public useIndexer useProvision(amount, 0, thawingPeriod) {
+        thawSteps = bound(thawSteps, 1, 10);
+
+        uint256 thawAmount = amount / thawSteps;
+        vm.assume(thawAmount > 0);
+        for (uint256 i = 0; i < thawSteps; i++) {
+            _thaw(users.indexer, subgraphDataServiceAddress, thawAmount);
+        }
+
+        skip(thawingPeriod + 1);
+
+        uint256 thawedTokens = staking.getThawedTokens(
+            ThawRequestType.Provision,
+            users.indexer,
+            subgraphDataServiceAddress,
+            users.indexer
+        );
+        vm.assertEq(thawedTokens, thawAmount * thawSteps);
+    }
 }

--- a/packages/horizon/test/staking/slash/legacySlash.t.sol
+++ b/packages/horizon/test/staking/slash/legacySlash.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import "forge-std/Test.sol";
+
+import { IHorizonStakingExtension } from "../../../contracts/interfaces/internal/IHorizonStakingExtension.sol";
+
+import { HorizonStakingTest } from "../HorizonStaking.t.sol";
+
+contract HorizonStakingLegacySlashTest is HorizonStakingTest {
+
+    /*
+     * MODIFIERS
+     */
+
+    modifier useLegacySlasher(address slasher) {
+        bytes32 storageKey = keccak256(abi.encode(slasher, 18));
+        vm.store(address(staking), storageKey, bytes32(uint256(1)));
+        _;
+    }
+
+    /*
+     * HELPERS
+     */
+
+    function _setIndexer(
+        address _indexer,
+        uint256 _tokensStaked,
+        uint256 _tokensAllocated,
+        uint256 _tokensLocked,
+        uint256 _tokensLockedUntil
+    ) public {
+        bytes32 baseSlot = keccak256(abi.encode(_indexer, 14));
+
+        vm.store(address(staking), bytes32(uint256(baseSlot)), bytes32(_tokensStaked));
+        vm.store(address(staking), bytes32(uint256(baseSlot) + 1), bytes32(_tokensAllocated));
+        vm.store(address(staking), bytes32(uint256(baseSlot) + 2), bytes32(_tokensLocked));
+        vm.store(address(staking), bytes32(uint256(baseSlot) + 3), bytes32(_tokensLockedUntil));
+    }
+
+    /*
+     * ACTIONS
+     */
+
+    function _legacySlash(address _indexer, uint256 _tokens, uint256 _rewards, address _beneficiary) internal {
+        // before
+        uint256 beforeStakingBalance = token.balanceOf(address(staking));
+        uint256 beforeRewardsDestinationBalance = token.balanceOf(_beneficiary);
+
+        // slash
+        vm.expectEmit(address(staking));
+        emit IHorizonStakingExtension.StakeSlashed(_indexer, _tokens, _rewards, _beneficiary);
+        staking.slash(_indexer, _tokens, _rewards, _beneficiary);
+
+        // after
+        uint256 afterStakingBalance = token.balanceOf(address(staking));
+        uint256 afterRewardsDestinationBalance = token.balanceOf(_beneficiary);
+
+        assertEq(beforeStakingBalance - _tokens, afterStakingBalance);
+        assertEq(beforeRewardsDestinationBalance, afterRewardsDestinationBalance - _rewards);
+    }
+
+    /*
+     * TESTS
+     */
+
+    function testSlash_Legacy(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 1);
+        slashTokens = bound(slashTokens, 1, tokens);
+        reward = bound(reward, 0, slashTokens);
+
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+        
+        resetPrank(users.legacySlasher);
+        _legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_UsingLockedTokens(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 1);
+        slashTokens = bound(slashTokens, 1, tokens);
+        reward = bound(reward, 0, slashTokens);
+
+        _setIndexer(users.indexer, tokens, 0, tokens, block.timestamp + 1);
+        // Send tokens manually to staking
+        token.transfer(address(staking), tokens);
+
+        resetPrank(users.legacySlasher);
+        _legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_UsingAllocatedTokens(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 1);
+        slashTokens = bound(slashTokens, 1, tokens);
+        reward = bound(reward, 0, slashTokens);
+
+        _setIndexer(users.indexer, tokens, 0, tokens, 0);
+        // Send tokens manually to staking
+        token.transfer(address(staking), tokens);
+
+        resetPrank(users.legacySlasher);
+        staking.legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_RevertWhen_CallerNotSlasher(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer {
+        vm.assume(tokens > 0);
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+        
+        vm.expectRevert("!slasher");
+        staking.legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_RevertWhen_RewardsOverSlashTokens(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 0);
+        vm.assume(slashTokens > 0);
+        vm.assume(reward > slashTokens);
+
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+        
+        resetPrank(users.legacySlasher);
+        vm.expectRevert("rewards>slash");
+        staking.legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_RevertWhen_NoStake(
+        uint256 slashTokens,
+        uint256 reward
+    ) public useLegacySlasher(users.legacySlasher) {
+        vm.assume(slashTokens > 0);
+        reward = bound(reward, 0, slashTokens);
+
+        resetPrank(users.legacySlasher);
+        vm.expectRevert("!stake");
+        staking.legacySlash(users.indexer, slashTokens, reward, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_RevertWhen_ZeroTokens(
+        uint256 tokens
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 0);
+
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+        
+        resetPrank(users.legacySlasher);
+        vm.expectRevert("!tokens");
+        staking.legacySlash(users.indexer, 0, 0, makeAddr("fisherman"));
+    }
+
+    function testSlash_Legacy_RevertWhen_NoBeneficiary(
+        uint256 tokens,
+        uint256 slashTokens,
+        uint256 reward
+    ) public useIndexer useLegacySlasher(users.legacySlasher) {
+        vm.assume(tokens > 0);
+        slashTokens = bound(slashTokens, 1, tokens);
+        reward = bound(reward, 0, slashTokens);
+
+        _createProvision(users.indexer, subgraphDataServiceLegacyAddress, tokens, 0, 0);
+        
+        resetPrank(users.legacySlasher);
+        vm.expectRevert("!beneficiary");
+        staking.legacySlash(users.indexer, slashTokens, reward, address(0));
+    }
+}

--- a/packages/horizon/test/staking/slash/legacySlash.t.sol
+++ b/packages/horizon/test/staking/slash/legacySlash.t.sol
@@ -180,4 +180,29 @@ contract HorizonStakingLegacySlashTest is HorizonStakingTest {
         vm.expectRevert("!beneficiary");
         staking.legacySlash(users.indexer, slashTokens, reward, address(0));
     }
+
+    function test_LegacySlash_WhenTokensAllocatedGreaterThanStake()
+        public
+        useIndexer
+        useLegacySlasher(users.legacySlasher)
+    {
+        // Setup indexer with:
+        // - tokensStaked = 1000 GRT
+        // - tokensAllocated = 800 GRT
+        // - tokensLocked = 300 GRT
+        // This means tokensUsed (1100 GRT) > tokensStaked (1000 GRT)
+        _setIndexer(
+            users.indexer,
+            1000 ether,    // tokensStaked
+            800 ether,     // tokensAllocated
+            300 ether,     // tokensLocked
+            0              // tokensLockedUntil
+        );
+
+        // Send tokens manually to staking
+        token.transfer(address(staking), 1100 ether);
+
+        resetPrank(users.legacySlasher);
+        _legacySlash(users.indexer, 1000 ether, 500 ether, makeAddr("fisherman"));
+    }
 }

--- a/packages/horizon/test/staking/slash/slash.t.sol
+++ b/packages/horizon/test/staking/slash/slash.t.sol
@@ -54,7 +54,7 @@ contract HorizonStakingSlashTest is HorizonStakingTest {
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, MAX_PPM, 0) {
         vm.assume(slashTokens > tokens);
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
         verifierCutAmount = bound(verifierCutAmount, 0, MAX_PPM);
         vm.assume(verifierCutAmount <= tokens);
 
@@ -71,7 +71,7 @@ contract HorizonStakingSlashTest is HorizonStakingTest {
         uint256 verifierCutAmount,
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, MAX_PPM, 0) useDelegationSlashing() {
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
         slashTokens = bound(slashTokens, tokens + 1, tokens + 1 + delegationTokens);
         verifierCutAmount = bound(verifierCutAmount, 0, tokens);
 
@@ -110,7 +110,7 @@ contract HorizonStakingSlashTest is HorizonStakingTest {
         uint256 tokens,
         uint256 delegationTokens
     ) public useIndexer useProvision(tokens, MAX_PPM, 0) useDelegationSlashing {
-        delegationTokens = bound(delegationTokens, 1, MAX_STAKING_TOKENS);
+        delegationTokens = bound(delegationTokens, MIN_DELEGATION, MAX_STAKING_TOKENS);
 
         resetPrank(users.delegator);
         _delegate(users.indexer, subgraphDataServiceAddress, delegationTokens, 0);

--- a/packages/horizon/test/utils/Constants.sol
+++ b/packages/horizon/test/utils/Constants.sol
@@ -14,6 +14,7 @@ abstract contract Constants {
     uint256 internal constant MAX_THAW_REQUESTS = 100;
     uint64 internal constant MAX_THAWING_PERIOD = 28 days;
     uint32 internal constant THAWING_PERIOD_IN_BLOCKS = 300;
+    uint256 internal constant MIN_DELEGATION = 1e18;
     // Epoch manager
     uint256 internal constant EPOCH_LENGTH = 1;
     // Rewards manager

--- a/packages/horizon/test/utils/Constants.sol
+++ b/packages/horizon/test/utils/Constants.sol
@@ -11,10 +11,11 @@ abstract contract Constants {
     // GraphPayments parameters
     uint256 internal constant protocolPaymentCut = 10000;
     // Staking constants
-    uint256 internal constant MAX_THAW_REQUESTS = 100;
+    uint256 internal constant MAX_THAW_REQUESTS = 1_000;
     uint64 internal constant MAX_THAWING_PERIOD = 28 days;
     uint32 internal constant THAWING_PERIOD_IN_BLOCKS = 300;
     uint256 internal constant MIN_DELEGATION = 1e18;
+    uint256 internal constant MIN_UNDELEGATION_WITH_BENEFICIARY = 10e18;
     // Epoch manager
     uint256 internal constant EPOCH_LENGTH = 1;
     // Rewards manager

--- a/packages/horizon/test/utils/Users.sol
+++ b/packages/horizon/test/utils/Users.sol
@@ -9,4 +9,5 @@ struct Users {
     address gateway;
     address verifier;
     address delegator;
+    address legacySlasher;
 }


### PR DESCRIPTION
This PR fixes the following issues:
- `TRST-H-2 Core thawing logic of Horizon staking can be broken due to collision in data
structures`
- `TRST-H-3 An attacker could prevent a delegator from ever withdrawing their tokens`
- `TRST-H-4 The last withdrawal from a provision or delegation could permanently revert
due to accounting flaw in slashing`
- `TRST-H-6 During the transition period, legacy allocations cannot be slashed`
- `TRST-H-7 Delegators that began undelegation before the transition would not be able
to withdraw them`
- `TRST-M-3 An attacker could make the minimum delegation amount arbitrarily large
and prevent competing delegations`
- `TRST-M-11 After the transition period, locked amount would still not be available for
use`
- `TRST-M-12 The operator check in closeAllocations() will not work, indexers must close
by themselves`
- `TRST-L-3 The getThawedTokens() function could return a wrong amount leading to
integration risks`
- `TRST-R-1 Improve event structure`
- `TRST-R-7 Thawing shares should be rounded up to protect from early unlocking of
tokens`
- `TRST-R-9 Documentation errors`