### PR TITLE
fix: cleanup TAPCollectorAuthorizationAlreadyRevoked

### DIFF
--- a/packages/horizon/contracts/interfaces/ITAPCollector.sol
+++ b/packages/horizon/contracts/interfaces/ITAPCollector.sol
@@ -125,10 +125,10 @@ interface ITAPCollector is IPaymentsCollector {
     error TAPCollectorSignerNotAuthorizedByPayer(address payer, address signer);
 
     /**
-     * Thrown when the attempting to revoke a signer that was already revoked
+     * Thrown when attempting to thaw a signer that is already revoked
      * @param signer The address of the signer
      */
-    error TAPCollectorAuthorizationAlreadyRevoked(address payer, address signer);
+    error TAPCollectorAuthorizationAlreadyRevoked(address signer);
 
     /**
      * Thrown when attempting to thaw a signer that is already thawing

--- a/packages/horizon/contracts/payments/collectors/TAPCollector.sol
+++ b/packages/horizon/contracts/payments/collectors/TAPCollector.sol
@@ -81,7 +81,7 @@ contract TAPCollector is EIP712, GraphDirectory, ITAPCollector {
         PayerAuthorization storage authorization = authorizedSigners[signer];
 
         require(authorization.payer == msg.sender, TAPCollectorSignerNotAuthorizedByPayer(msg.sender, signer));
-        require(!authorization.revoked, TAPCollectorAuthorizationAlreadyRevoked(msg.sender, signer));
+        require(!authorization.revoked, TAPCollectorAuthorizationAlreadyRevoked(signer));
         require(
             authorization.thawEndTimestamp == 0,
             TAPCollectorSignerAlreadyThawing(signer, authorization.thawEndTimestamp)

--- a/packages/horizon/test/payments/tap-collector/signer/thawSigner.t.sol
+++ b/packages/horizon/test/payments/tap-collector/signer/thawSigner.t.sol
@@ -34,7 +34,6 @@ contract TAPCollectorThawSignerTest is TAPCollectorTest {
 
         bytes memory expectedError = abi.encodeWithSelector(
             ITAPCollector.TAPCollectorAuthorizationAlreadyRevoked.selector,
-            users.gateway,
             signer
         );
         vm.expectRevert(expectedError);


### PR DESCRIPTION
This PR simply cleans up what's already there, but if you would consider a slightly bigger re-write, maybe the collector would benefit from a `modifier onlyAuthorized(address _signer)` for `thawSigner`, `cancelThawSigner` and `revokeAuthorizedSigner` like what's proposed by #1085 -> [here](https://github.com/graphprotocol/contracts/pull/1085/files#diff-d5870b8cb11b87807ea66ca4948b55b9c847d3ad74734a25331574ce54be011dR27).