### PR TITLE
fix: Fix incorrect path for solhint-graph-config Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository is a Yarn workspaces monorepo containing the following packages:
 | [eslint-graph-config](./packages/eslint-graph-config) | - | Shared linting and formatting rules for TypeScript projects. |
 | [token-distribution](./packages/token-distribution) | [![npm version](https://badge.fury.io/js/@graphprotocol%2Ftoken-distribution.svg)](https://badge.fury.io/js/@graphprotocol%2Ftoken-distribution) | Contracts managing token locks for network participants |
 | [sdk](./packages/sdk) | [![npm version](https://badge.fury.io/js/@graphprotocol%2Fsdk.svg)](https://badge.fury.io/js/@graphprotocol%2Fsdk) | TypeScript based SDK to interact with the protocol contracts |
-| [solhint-graph-config](./packages/eslint-graph-config) | - | Shared linting and formatting rules for Solidity projects. |
+| [solhint-graph-config](./packages/solhint-graph-config) | - | Shared linting and formatting rules for Solidity projects. |
 
 
 ## Development


### PR DESCRIPTION
I noticed a typo in the packages table where the path for `solhint-graph-config` was incorrectly pointing to `./packages/eslint-graph-config`.
I’ve updated it to the correct path: `./packages/solhint-graph-config`.
This ensures the documentation accurately reflects the package location.