### PR TITLE
feat: dont issue rewards to allos less than one epoch old

### DIFF
--- a/packages/contracts/contracts/rewards/IRewardsIssuer.sol
+++ b/packages/contracts/contracts/rewards/IRewardsIssuer.sol
@@ -31,11 +31,4 @@ interface IRewardsIssuer {
      * @return Total tokens allocated to subgraph
      */
     function getSubgraphAllocatedTokens(bytes32 _subgraphDeploymentId) external view returns (uint256);
-
-    /**
-     * @notice Whether or not an allocation is active (i.e open)
-     * @param _allocationId Allocation Id
-     * @return Whether or not the allocation is active
-     */
-    function isActiveAllocation(address _allocationId) external view returns (bool);
 }

--- a/packages/contracts/contracts/rewards/IRewardsManager.sol
+++ b/packages/contracts/contracts/rewards/IRewardsManager.sol
@@ -39,7 +39,7 @@ interface IRewardsManager {
 
     function getAccRewardsPerAllocatedToken(bytes32 _subgraphDeploymentID) external view returns (uint256, uint256);
 
-    function getRewards(address _allocationID) external view returns (uint256);
+    function getRewards(address _rewardsIssuer, address _allocationID) external view returns (uint256);
 
     function calcRewards(uint256 _tokens, uint256 _accRewardsPerAllocatedToken) external pure returns (uint256);
 

--- a/packages/contracts/contracts/rewards/RewardsManager.sol
+++ b/packages/contracts/contracts/rewards/RewardsManager.sol
@@ -322,24 +322,11 @@ contract RewardsManager is RewardsManagerV5Storage, GraphUpgradeable, IRewardsMa
      * @param _allocationID Allocation
      * @return Rewards amount for an allocation
      */
-    function getRewards(address _allocationID) external view override returns (uint256) {
-        address rewardsIssuer = address(0);
-
-        // Check both the legacy and new allocations
-        address[2] memory rewardsIssuers = [address(staking()), address(subgraphService)];
-        for (uint256 i = 0; i < rewardsIssuers.length; i++) {
-            if (rewardsIssuers[i] != address(0)) {
-                if (IRewardsIssuer(rewardsIssuers[i]).isActiveAllocation(_allocationID)) {
-                    rewardsIssuer = address(rewardsIssuers[i]);
-                    break;
-                }
-            }
-        }
-
-        // Bail if allo does not exist
-        if (rewardsIssuer == address(0)) {
-            return 0;
-        }
+    function getRewards(address _rewardsIssuer, address _allocationID) external view override returns (uint256) {
+        require(
+            _rewardsIssuer == address(staking()) || _rewardsIssuer == address(subgraphService),
+            "Not a rewards issuer"
+        );
 
         (
             ,
@@ -347,7 +334,7 @@ contract RewardsManager is RewardsManagerV5Storage, GraphUpgradeable, IRewardsMa
             uint256 tokens,
             uint256 alloAccRewardsPerAllocatedToken,
             uint256 accRewardsPending
-        ) = IRewardsIssuer(rewardsIssuer).getAllocationData(_allocationID);
+        ) = IRewardsIssuer(_rewardsIssuer).getAllocationData(_allocationID);
 
         (uint256 accRewardsPerAllocatedToken, ) = getAccRewardsPerAllocatedToken(subgraphDeploymentId);
         return

--- a/packages/contracts/test/unit/rewards/rewards.test.ts
+++ b/packages/contracts/test/unit/rewards/rewards.test.ts
@@ -466,7 +466,7 @@ describe('Rewards', () => {
         await helpers.mine(ISSUANCE_RATE_PERIODS)
 
         // Rewards
-        const contractRewards = await rewardsManager.getRewards(allocationID1)
+        const contractRewards = await rewardsManager.getRewards(staking.address, allocationID1)
 
         // We trust using this function in the test because we tested it
         // standalone in a previous test
@@ -504,12 +504,12 @@ describe('Rewards', () => {
         await staking.connect(indexer1).closeAllocation(allocationID1, randomHexBytes())
 
         // Rewards
-        const contractRewards = await rewardsManager.getRewards(allocationID1)
+        const contractRewards = await rewardsManager.getRewards(staking.address, allocationID1)
         expect(contractRewards).eq(BigNumber.from(0))
       })
       it('rewards should be zero if the allocation does not exist', async function () {
         // Rewards
-        const contractRewards = await rewardsManager.getRewards(allocationIDNull)
+        const contractRewards = await rewardsManager.getRewards(staking.address, allocationIDNull)
         expect(contractRewards).eq(BigNumber.from(0))
       })
     })
@@ -1026,7 +1026,7 @@ describe('Rewards', () => {
       await staking.connect(assetHolder).collect(tokensToCollect, allocationID1)
 
       // check rewards diff
-      await rewardsManager.getRewards(allocationID1).then(formatGRT)
+      await rewardsManager.getRewards(staking.address, allocationID1).then(formatGRT)
 
       await helpers.mine()
       const accrual = await getRewardsAccrual(subgraphs)

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -275,15 +275,6 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
     }
 
     /**
-     * @notice Return true if allocation is active.
-     * @param allocationID Allocation identifier
-     * @return True if allocation is active
-     */
-    function isActiveAllocation(address allocationID) external view override returns (bool) {
-        return _getAllocationState(allocationID) == AllocationState.Active;
-    }
-
-    /**
      * @notice Get the total amount of tokens staked by the indexer.
      * @param indexer Address of the indexer
      * @return Amount of tokens staked by the indexer

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -450,18 +450,6 @@ contract SubgraphService is
     }
 
     /**
-     * @notice Check if an allocation is open
-     * @dev Implements {IRewardsIssuer.isAllocationActive}
-     * @dev To be used by the {RewardsManager}.
-     *
-     * @param allocationId The allocation Id
-     * @return Wether or not the allocation is active
-     */
-    function isActiveAllocation(address allocationId) external view override returns (bool) {
-        return _allocations[allocationId].isOpen();
-    }
-
-    /**
      * @notice See {ISubgraphService.getLegacyAllocation}
      */
     function getLegacyAllocation(address allocationId) external view override returns (LegacyAllocation.State memory) {
@@ -473,13 +461,6 @@ contract SubgraphService is
      */
     function encodeAllocationProof(address indexer, address allocationId) external view override returns (bytes32) {
         return _encodeAllocationProof(indexer, allocationId);
-    }
-
-    /**
-     * @notice See {ISubgraphService.isStaleAllocation}
-     */
-    function isStaleAllocation(address allocationId) external view override returns (bool) {
-        return _allocations.get(allocationId).isStale(maxPOIStaleness);
     }
 
     /**

--- a/packages/subgraph-service/contracts/interfaces/ISubgraphService.sol
+++ b/packages/subgraph-service/contracts/interfaces/ISubgraphService.sol
@@ -242,13 +242,6 @@ interface ISubgraphService is IDataServiceFees {
     function encodeAllocationProof(address indexer, address allocationId) external view returns (bytes32);
 
     /**
-     * @notice Checks if an allocation is stale
-     * @param allocationId The id of the allocation
-     * @return True if the allocation is stale, false otherwise
-     */
-    function isStaleAllocation(address allocationId) external view returns (bool);
-
-    /**
      * @notice Checks if an indexer is over-allocated
      * @param allocationId The id of the allocation
      * @return True if the indexer is over-allocated, false otherwise

--- a/packages/subgraph-service/contracts/libraries/Allocation.sol
+++ b/packages/subgraph-service/contracts/libraries/Allocation.sol
@@ -30,6 +30,8 @@ library Allocation {
         uint256 accRewardsPerAllocatedToken;
         // Accumulated rewards that are pending to be claimed due allocation resize
         uint256 accRewardsPending;
+        // Epoch when the allocation was created
+        uint256 createdAtEpoch;
     }
 
     /**
@@ -68,7 +70,8 @@ library Allocation {
         address allocationId,
         bytes32 subgraphDeploymentId,
         uint256 tokens,
-        uint256 accRewardsPerAllocatedToken
+        uint256 accRewardsPerAllocatedToken,
+        uint256 createdAtEpoch
     ) internal returns (State memory) {
         require(!self[allocationId].exists(), AllocationAlreadyExists(allocationId));
 
@@ -80,7 +83,8 @@ library Allocation {
             closedAt: 0,
             lastPOIPresentedAt: 0,
             accRewardsPerAllocatedToken: accRewardsPerAllocatedToken,
-            accRewardsPending: 0
+            accRewardsPending: 0,
+            createdAtEpoch: createdAtEpoch
         });
 
         self[allocationId] = allocation;

--- a/packages/subgraph-service/hardhat.config.ts
+++ b/packages/subgraph-service/hardhat.config.ts
@@ -17,6 +17,15 @@ if (process.env.BUILD_RUN !== 'true') {
 
 const config: HardhatUserConfig = {
   ...hardhatBaseConfig,
+  solidity: {
+    version: '0.8.27',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 50,
+      },
+    },
+  },
   graph: {
     deployments: {
       ...hardhatBaseConfig.graph?.deployments,

--- a/packages/subgraph-service/test/mocks/MockRewardsManager.sol
+++ b/packages/subgraph-service/test/mocks/MockRewardsManager.sol
@@ -61,7 +61,7 @@ contract MockRewardsManager is IRewardsManager {
 
     function getAccRewardsPerAllocatedToken(bytes32) external view returns (uint256, uint256) {}
 
-    function getRewards(address) external view returns (uint256) {}
+    function getRewards(address,address) external view returns (uint256) {}
 
     function calcRewards(uint256, uint256) external pure returns (uint256) {}
 

--- a/packages/subgraph-service/test/shared/SubgraphServiceShared.t.sol
+++ b/packages/subgraph-service/test/shared/SubgraphServiceShared.t.sol
@@ -11,6 +11,8 @@ import { ISubgraphService } from "../../contracts/interfaces/ISubgraphService.so
 import { HorizonStakingSharedTest } from "./HorizonStakingShared.t.sol";
 
 abstract contract SubgraphServiceSharedTest is HorizonStakingSharedTest {
+    using Allocation for Allocation.State;
+
     /*
      * VARIABLES
      */
@@ -101,13 +103,7 @@ abstract contract SubgraphServiceSharedTest is HorizonStakingSharedTest {
 
         vm.expectEmit(address(subgraphService));
         emit IDataService.ServiceStarted(_indexer, _data);
-        emit AllocationManager.AllocationCreated(
-            _indexer,
-            allocationId,
-            subgraphDeploymentId,
-            tokens,
-            currentEpoch
-        );
+        emit AllocationManager.AllocationCreated(_indexer, allocationId, subgraphDeploymentId, tokens, currentEpoch);
 
         // TODO: improve this
         uint256 accRewardsPerAllocatedToken = 0;
@@ -137,9 +133,9 @@ abstract contract SubgraphServiceSharedTest is HorizonStakingSharedTest {
 
     function _stopService(address _indexer, bytes memory _data) internal {
         address allocationId = abi.decode(_data, (address));
-        assertTrue(subgraphService.isActiveAllocation(allocationId));
 
         Allocation.State memory allocation = subgraphService.getAllocation(allocationId);
+        assertTrue(allocation.isOpen());
         uint256 previousSubgraphAllocatedTokens = subgraphService.getSubgraphAllocatedTokens(
             allocation.subgraphDeploymentId
         );

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -302,6 +302,9 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
         // Calculate the payment collected by the indexer for this transaction
         paymentCollected = accRewardsPerTokens - allocation.accRewardsPerAllocatedToken;
 
+        uint256 currentEpoch = epochManager.currentEpoch();
+        paymentCollected = currentEpoch > allocation.createdAtEpoch ? paymentCollected : 0;
+
         uint256 delegatorCut = staking.getDelegationFeeCut(
             allocation.indexer,
             address(subgraphService),

--- a/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
+++ b/packages/subgraph-service/test/subgraphService/SubgraphService.t.sol
@@ -149,9 +149,8 @@ contract SubgraphServiceTest is SubgraphServiceSharedTest {
     }
 
     function _closeStaleAllocation(address _allocationId) internal {
-        assertTrue(subgraphService.isActiveAllocation(_allocationId));
-
         Allocation.State memory allocation = subgraphService.getAllocation(_allocationId);
+        assertTrue(allocation.isOpen());
         uint256 previousSubgraphAllocatedTokens = subgraphService.getSubgraphAllocatedTokens(
             allocation.subgraphDeploymentId
         );

--- a/packages/subgraph-service/test/subgraphService/allocation/resize.t.sol
+++ b/packages/subgraph-service/test/subgraphService/allocation/resize.t.sol
@@ -29,6 +29,10 @@ contract SubgraphServiceAllocationResizeTest is SubgraphServiceTest {
         vm.assume(resizeTokens != tokens);
 
         mint(users.indexer, resizeTokens);
+
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory data = abi.encode(allocationID, bytes32("POI1"));
         _collect(users.indexer, paymentType, data);

--- a/packages/subgraph-service/test/subgraphService/collect/indexing/indexing.t.sol
+++ b/packages/subgraph-service/test/subgraphService/collect/indexing/indexing.t.sol
@@ -19,6 +19,10 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
     ) public useIndexer useAllocation(tokens) {
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory data = abi.encode(allocationID, bytes32("POI"));
+
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         _collect(users.indexer, paymentType, data);
     }
 
@@ -34,6 +38,11 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
             IGraphPayments.PaymentTypes.IndexingRewards,
             delegationFeeCut
         );
+
+
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory data = abi.encode(allocationID, bytes32("POI"));
         _collect(users.indexer, paymentType, data);
@@ -54,6 +63,10 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
         // Undelegate
         resetPrank(users.delegator);
         staking.undelegate(users.indexer, address(subgraphService), delegationTokens);
+
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         resetPrank(users.indexer);
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory data = abi.encode(allocationID, bytes32("POI"));
@@ -63,6 +76,9 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
     function test_SubgraphService_Collect_Indexing_RewardsDestination(
         uint256 tokens
     ) public useIndexer useAllocation(tokens) useRewardsDestination {
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory data = abi.encode(allocationID, bytes32("POI"));
         _collect(users.indexer, paymentType, data);
@@ -121,6 +137,9 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
         // thaw some tokens to become over allocated
         staking.thaw(users.indexer, address(subgraphService), tokens / 2);
 
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         // this collection should close the allocation
         IGraphPayments.PaymentTypes paymentType = IGraphPayments.PaymentTypes.IndexingRewards;
         bytes memory collectData = abi.encode(allocationID, bytes32("POI"));
@@ -135,6 +154,10 @@ contract SubgraphServiceCollectIndexingTest is SubgraphServiceTest {
         address newIndexer = makeAddr("newIndexer");
         _createAndStartAllocation(newIndexer, tokens);
         bytes memory data = abi.encode(allocationID, bytes32("POI"));
+
+        // skip time to ensure allocation gets rewards
+        vm.roll(block.number + EPOCH_LENGTH);
+
         // Attempt to collect from other indexer's allocation
         vm.expectRevert(
             abi.encodeWithSelector(ISubgraphService.SubgraphServiceAllocationNotAuthorized.selector, newIndexer, allocationID)


### PR DESCRIPTION
Changes:
- Added an additional condition to qualify for indexing rewards, the allocation must be at least 1 epoch old.
- Bit of magic to ensure contract is less than 24kB
   - Removed `isStaleAllocation()` functionality (to be added back after transition period)
   - Removed `isActiveAllocation()` requirement from `IRewardsIssuer` 