### PR TITLE
fix: prevent provision validity grief attack (OZ M-03)

### DIFF
--- a/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
+++ b/packages/horizon/contracts/interfaces/internal/IHorizonStakingMain.sol
@@ -541,10 +541,10 @@ interface IHorizonStakingMain {
      */
     function stakeTo(address serviceProvider, uint256 tokens) external;
 
-    // can be called by anyone if the service provider has provisioned stake to this verifier
     /**
      * @notice Deposit tokens on the service provider stake, on behalf of the service provider,
      * provisioned to a specific verifier.
+     * @dev This function can be called by the service provider, by an authorized operator or by the verifier itself.
      * @dev Requirements:
      * - The `serviceProvider` must have previously provisioned stake to `verifier`.
      * - `_tokens` cannot be zero.

--- a/packages/horizon/contracts/staking/HorizonStaking.sol
+++ b/packages/horizon/contracts/staking/HorizonStaking.sol
@@ -58,6 +58,19 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     }
 
     /**
+     * @notice Checks that the caller is authorized to operate over a provision or it is the verifier.
+     * @param serviceProvider The address of the service provider.
+     * @param verifier The address of the verifier.
+     */
+    modifier onlyAuthorizedOrVerifier(address serviceProvider, address verifier) {
+        require(
+            _isAuthorized(serviceProvider, verifier, msg.sender) || msg.sender == verifier,
+            HorizonStakingNotAuthorized(serviceProvider, verifier, msg.sender)
+        );
+        _;
+    }
+
+    /**
      * @dev The staking contract is upgradeable however we still use the constructor to set
      * a few immutable variables.
      * @param controller The address of the Graph controller contract.
@@ -121,7 +134,11 @@ contract HorizonStaking is HorizonStakingBase, IHorizonStakingMain {
     }
 
     /// @inheritdoc IHorizonStakingMain
-    function stakeToProvision(address serviceProvider, address verifier, uint256 tokens) external override notPaused {
+    function stakeToProvision(
+        address serviceProvider,
+        address verifier,
+        uint256 tokens
+    ) external override notPaused onlyAuthorizedOrVerifier(serviceProvider, verifier) {
         _stakeTo(serviceProvider, tokens);
         _addToProvision(serviceProvider, verifier, tokens);
     }

--- a/packages/horizon/test/staking/provision/provision.t.sol
+++ b/packages/horizon/test/staking/provision/provision.t.sol
@@ -80,19 +80,6 @@ contract HorizonStakingProvisionTest is HorizonStakingTest {
         staking.provision(users.indexer, subgraphDataServiceAddress, amount / 2, maxVerifierCut, thawingPeriod);
     }
 
-    function testProvision_OperatorAddTokensToProvision(
-        uint256 amount,
-        uint32 maxVerifierCut,
-        uint64 thawingPeriod,
-        uint256 tokensToAdd
-    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) useOperator {
-        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
-
-        // Add more tokens to the provision
-        _stakeTo(users.indexer, tokensToAdd);
-        _addToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
-    }
-
     function testProvision_RevertWhen_OperatorNotAuthorized(
         uint256 amount,
         uint32 maxVerifierCut,
@@ -123,5 +110,114 @@ contract HorizonStakingProvisionTest is HorizonStakingTest {
         );
         vm.expectRevert(expectedError);
         staking.provision(users.indexer, subgraphDataServiceAddress, amount, 0, 0);
+    }
+
+    function testProvision_AddTokensToProvision(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        _stakeTo(users.indexer, tokensToAdd);
+        _addToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
+    }
+
+    function testProvision_OperatorAddTokensToProvision(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) useOperator {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        _stakeTo(users.indexer, tokensToAdd);
+        _addToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
+    }
+
+    function testProvision_AddTokensToProvision_RevertWhen_NotAuthorized(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        _stakeTo(users.indexer, tokensToAdd);
+
+        // use delegator as a non authorized operator
+        vm.startPrank(users.delegator);
+        bytes memory expectedError = abi.encodeWithSignature(
+            "HorizonStakingNotAuthorized(address,address,address)",
+            users.indexer,
+            subgraphDataServiceAddress,
+            users.delegator
+        );
+        vm.expectRevert(expectedError);
+        staking.addToProvision(users.indexer, subgraphDataServiceAddress, amount);
+    }
+
+    function testProvision_StakeToProvision(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        _stakeToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
+    }
+
+    function testProvision_Operator_StakeToProvision(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) useOperator {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        _stakeToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
+    }
+
+    function testProvision_Verifier_StakeToProvision(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Ensure the verifier has enough tokens to then stake to the provision
+        token.transfer(subgraphDataServiceAddress, tokensToAdd);
+
+        // Add more tokens to the provision
+        resetPrank(subgraphDataServiceAddress);
+        _stakeToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
+    }
+
+    function testProvision_StakeToProvision_RevertWhen_NotAuthorized(
+        uint256 amount,
+        uint32 maxVerifierCut,
+        uint64 thawingPeriod,
+        uint256 tokensToAdd
+    ) public useIndexer useProvision(amount, maxVerifierCut, thawingPeriod) {
+        tokensToAdd = bound(tokensToAdd, 1, MAX_STAKING_TOKENS);
+
+        // Add more tokens to the provision
+        vm.startPrank(users.delegator);
+        bytes memory expectedError = abi.encodeWithSignature(
+            "HorizonStakingNotAuthorized(address,address,address)",
+            users.indexer,
+            subgraphDataServiceAddress,
+            users.delegator
+        );
+        vm.expectRevert(expectedError);
+        staking.stakeToProvision(users.indexer, subgraphDataServiceAddress, tokensToAdd);
     }
 }


### PR DESCRIPTION
M-03 was previously L-03, that's why the branch name says `l03`