### PR TITLE
fix: ensure getRewards and takeRewards return 0 for closed allos (L-11)

### DIFF
--- a/packages/contracts/contracts/rewards/IRewardsIssuer.sol
+++ b/packages/contracts/contracts/rewards/IRewardsIssuer.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.7.6 || 0.8.27;
 interface IRewardsIssuer {
     /**
      * @dev Get allocation data to calculate rewards issuance
+     * 
      * @param allocationId The allocation Id
+     * @return isActive Whether the allocation is active or not
      * @return indexer The indexer address
      * @return subgraphDeploymentId Subgraph deployment id for the allocation
      * @return tokens Amount of allocated tokens
@@ -18,6 +20,7 @@ interface IRewardsIssuer {
         external
         view
         returns (
+            bool isActive,
             address indexer,
             bytes32 subgraphDeploymentId,
             uint256 tokens,

--- a/packages/contracts/contracts/staking/IStakingBase.sol
+++ b/packages/contracts/contracts/staking/IStakingBase.sol
@@ -368,7 +368,7 @@ interface IStakingBase is IStakingData {
      */
     function getAllocationData(
         address _allocationID
-    ) external view returns (address, bytes32, uint256, uint256, uint256);
+    ) external view returns (bool, address, bytes32, uint256, uint256, uint256);
 
     /**
      * @dev New function to get the allocation active status for the rewards manager

--- a/packages/contracts/contracts/staking/Staking.sol
+++ b/packages/contracts/contracts/staking/Staking.sol
@@ -819,7 +819,6 @@ abstract contract Staking is StakingV4Storage, GraphUpgradeable, IStakingBase, M
             require(isIndexerOrOperator, "!auth");
         }
 
-
         // -- Rewards Distribution --
 
         // Process non-zero-allocation rewards tracking
@@ -844,6 +843,8 @@ abstract contract Staking is StakingV4Storage, GraphUpgradeable, IStakingBase, M
         }
 
         // Close the allocation
+        // Note that this breaks CEI pattern. We update after the rewards distribution logic as it expects the allocation
+        // to still be active. There shouldn't be reentrancy risk here as all internal calls are to trusted contracts.
         __allocations[_allocationID].closedAtEpoch = alloc.closedAtEpoch;
 
         emit AllocationClosed(

--- a/packages/contracts/scripts/build
+++ b/packages/contracts/scripts/build
@@ -10,8 +10,8 @@ yarn compile
 tsc
 
 # Copy types and abis to distribution folder
-cp -R build/types/* dist/build/types
-cp -R build/abis/ dist/abis
+cp -R build/types/* dist/contracts/build/types
+cp -R build/abis/ dist/contracts/build/abis
 
 # Move compiled types ts
-mv dist/build/types dist/types
+mv dist/contracts/build/types dist/types

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -376,6 +376,8 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
         }
 
         // Close the allocation
+        // Note that this breaks CEI pattern. We update after the rewards distribution logic as it expects the allocation
+        // to still be active. There shouldn't be reentrancy risk here as all internal calls are to trusted contracts.
         __DEPRECATED_allocations[_allocationID].closedAtEpoch = alloc.closedAtEpoch;
 
         emit AllocationClosed(

--- a/packages/horizon/contracts/staking/HorizonStakingExtension.sol
+++ b/packages/horizon/contracts/staking/HorizonStakingExtension.sol
@@ -223,9 +223,10 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
     /// @inheritdoc IRewardsIssuer
     function getAllocationData(
         address allocationID
-    ) external view override returns (address, bytes32, uint256, uint256, uint256) {
+    ) external view override returns (bool, address, bytes32, uint256, uint256, uint256) {
         Allocation memory allo = __DEPRECATED_allocations[allocationID];
-        return (allo.indexer, allo.subgraphDeploymentID, allo.tokens, allo.accRewardsPerAllocatedToken, 0);
+        bool isActive = _getAllocationState(allocationID) == AllocationState.Active;
+        return (isActive, allo.indexer, allo.subgraphDeploymentID, allo.tokens, allo.accRewardsPerAllocatedToken, 0);
     }
 
     /// @inheritdoc IHorizonStakingExtension
@@ -351,9 +352,6 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
             require(isIndexerOrOperator, "!auth");
         }
 
-        // Close the allocation
-        __DEPRECATED_allocations[_allocationID].closedAtEpoch = alloc.closedAtEpoch;
-
         // -- Rewards Distribution --
 
         // Process non-zero-allocation rewards tracking
@@ -376,6 +374,9 @@ contract HorizonStakingExtension is HorizonStakingBase, IHorizonStakingExtension
                 __DEPRECATED_subgraphAllocations[alloc.subgraphDeploymentID] -
                 alloc.tokens;
         }
+
+        // Close the allocation
+        __DEPRECATED_allocations[_allocationID].closedAtEpoch = alloc.closedAtEpoch;
 
         emit AllocationClosed(
             alloc.indexer,

--- a/packages/subgraph-service/contracts/SubgraphService.sol
+++ b/packages/subgraph-service/contracts/SubgraphService.sol
@@ -382,9 +382,10 @@ contract SubgraphService is
     /// @inheritdoc IRewardsIssuer
     function getAllocationData(
         address allocationId
-    ) external view override returns (address, bytes32, uint256, uint256, uint256) {
+    ) external view override returns (bool, address, bytes32, uint256, uint256, uint256) {
         Allocation.State memory allo = _allocations[allocationId];
         return (
+            allo.isOpen(),
             allo.indexer,
             allo.subgraphDeploymentId,
             allo.tokens,

--- a/packages/subgraph-service/test/mocks/MockRewardsManager.sol
+++ b/packages/subgraph-service/test/mocks/MockRewardsManager.sol
@@ -14,7 +14,7 @@ interface IRewardsIssuer {
     )
         external
         view
-        returns (address indexer, bytes32 subgraphDeploymentId, uint256 tokens, uint256 accRewardsPerAllocatedToken);
+        returns (bool isActive, address indexer, bytes32 subgraphDeploymentId, uint256 tokens, uint256 accRewardsPerAllocatedToken);
 }
 
 contract MockRewardsManager is IRewardsManager {
@@ -71,9 +71,13 @@ contract MockRewardsManager is IRewardsManager {
 
     function takeRewards(address _allocationID) external returns (uint256) {
         address rewardsIssuer = msg.sender;
-        (, , uint256 tokens, uint256 accRewardsPerAllocatedToken) = IRewardsIssuer(rewardsIssuer).getAllocationData(
+        (bool isActive, , , uint256 tokens, uint256 accRewardsPerAllocatedToken) = IRewardsIssuer(rewardsIssuer).getAllocationData(
             _allocationID
         );
+
+        if (!isActive) {
+            return 0;
+        }   
 
         uint256 accRewardsPerTokens = tokens.mulPPM(rewardsPerSignal);
         uint256 rewards = accRewardsPerTokens - accRewardsPerAllocatedToken;


### PR DESCRIPTION
Tricky bit in `HorizonStakingExtension.sol` is moving the `closedAtEpoch` storage update after the `RewardsManager` internal calls, here: https://github.com/graphprotocol/contracts/pull/1149/files#diff-f0ca33d417ab44fd34813873b594fcfb2dcb852a3bf77c8c3b8ccb88130d9797R378-R380
