### PR TITLE
[audit-10] document: [TRST-L-7] update()

### DIFF
--- a/packages/horizon/contracts/payments/collectors/RecurringCollector.sol
+++ b/packages/horizon/contracts/payments/collectors/RecurringCollector.sol
@@ -184,6 +184,8 @@ contract RecurringCollector is EIP712, GraphDirectory, Authorizable, IRecurringC
      * @notice Update an indexing agreement.
      * See {IRecurringCollector.update}.
      * @dev Caller must be the data service for the agreement.
+     * @dev Note: Updated pricing terms apply immediately and will affect the next collection
+     * for the entire period since lastCollectionAt.
      */
     function update(SignedRCAU calldata signedRCAU) external {
         require(


### PR DESCRIPTION
<img width="670" height="803" alt="Screenshot 2025-07-24 at 11 09 21" src="https://github.com/user-attachments/assets/d5714b93-b25d-44ce-8e21-52b5b6b9541f" />

This patch is NOT A FIX but rather adding some docs. Here's the rationale:

  1. **Limited Impact**: Opportunity for gain is limited to the last collection period.

  2. **Mutual Agreement Required**: The update() function requires a signed RCAU (Recurring Collection Agreement Update) from the payer. This means any pricing changes are explicitly
  agreed upon by both parties, not a unilateral action by the service provider. Both parties are aware of and consent to the new terms.

  3. **Implementation Complexity**: The suggested mitigation of updating lastCollectionAt to the current timestamp would  create periods where no fees can be collected if indexers forget to collect in the same tx before updating. Forcing this collection would also complicate the code.

  4. **Existing Safeguards**: The protocol already has multiple safeguards:
     - Minimum and maximum collection windows (minSecondsPerCollection, maxSecondsPerCollection)
     - The requirement for authorized signatures on updates
     - Natural bounds on the affected time period

This PR adds a small bit of documentation to make this behavior explicit in the contract comments, ensuring all integrators understand the timing implications when implementing update strategies.