### PR TITLE
fix: add missing Ignition dependency for HorizonStaking

### DIFF
--- a/packages/horizon/ignition/modules/core/HorizonStaking.ts
+++ b/packages/horizon/ignition/modules/core/HorizonStaking.ts
@@ -15,12 +15,12 @@ export default buildModule('HorizonStaking', (m) => {
   const subgraphServiceAddress = m.getParameter('subgraphServiceAddress')
   const maxThawingPeriod = m.getParameter('maxThawingPeriod')
 
-  // Deploy HorizonStaking implementation
+  // Deploy HorizonStaking implementation - requires periphery and proxies to be registered in the controller
   const HorizonStakingImplementation = deployImplementation(m, {
     name: 'HorizonStaking',
     artifact: HorizonStakingArtifact,
     constructorArgs: [Controller, subgraphServiceAddress],
-  })
+  }, { after: [GraphPeripheryModule, HorizonProxiesModule] })
 
   // Upgrade proxy to implementation contract
   const HorizonStaking = upgradeGraphProxy(m, GraphProxyAdmin, HorizonStakingProxy, HorizonStakingImplementation, {


### PR DESCRIPTION
## Motivation

During local-network testing with fresh contract deployments, `HorizonStaking` deployment intermittently fails with `GraphDirectoryInvalidZeroAddress("GraphToken")`. The failure is nondeterministic -- it depends on the order Ignition schedules module execution.

## Summary

HorizonStaking's constructor extends `GraphDirectory`, which queries the Controller for GraphToken, EpochManager, RewardsManager, and other periphery contracts. These addresses are registered in the Controller by `GraphPeripheryModule`. Without an explicit `after` dependency, Ignition may schedule HorizonStaking before the periphery registrations complete, causing the constructor to read `address(0)` and revert.

Every other core module (`GraphPayments`, `PaymentsEscrow`, `GraphTallyCollector`, `RecurringCollector`) already declares `{ after: [GraphPeripheryModule, HorizonProxiesModule] }`. HorizonStaking was the only one missing it.

The fix adds the same dependency declaration to `HorizonStaking.ts`. This only affects fresh deployments (new chains, testnets, local environments) -- on mainnet, the Controller already has all addresses registered so the ordering is irrelevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)