### PR TITLE
Npm trusted publish

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
         cache: 'pnpm'
     - name: Set up pnpm via Corepack
       shell: bash
-      run: corepack prepare pnpm@10.17.0 --activate
+      run: corepack prepare pnpm@10.28.0 --activate
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,10 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Upgrade npm for OIDC trusted publishing
-        # pnpm publish delegates registry auth to the underlying npm CLI;
-        # npm >= 11.5.1 is required to support OIDC trusted publishing.
-        run: npm install -g npm@latest
+        # pnpm publish delegates registry auth to the underlying npm CLI.
+        # OIDC trusted publishing requires npm >= 11.5.1; pinned to a known-good
+        # version for reproducibility — safe to bump as long as it stays >= 11.5.1.
+        run: npm install -g npm@11.13.0
       - name: Read package info
         id: pkg
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
   publish:
     name: Publish package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,8 +38,6 @@ jobs:
           submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Set npm token for publishing
-        run: pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.GRAPHPROTOCOL_NPM_TOKEN }}
       - name: Read package info
         id: pkg
         shell: bash
@@ -48,7 +49,7 @@ jobs:
         shell: bash
         run: |
           pushd packages/${{ inputs.package }}
-          pnpm publish --tag ${{ inputs.tag }} --access public --no-git-checks ${{ inputs.dry_run && '--dry-run' || '' }}
+          pnpm publish --provenance --tag ${{ inputs.tag }} --access public --no-git-checks ${{ inputs.dry_run && '--dry-run' || '' }}
       - name: Tag release
         if: ${{ !inputs.dry_run }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,10 @@ jobs:
           submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Upgrade npm for OIDC trusted publishing
+        # pnpm publish delegates registry auth to the underlying npm CLI;
+        # npm >= 11.5.1 is required to support OIDC trusted publishing.
+        run: npm install -g npm@latest
       - name: Read package info
         id: pkg
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,21 @@ on:
         required: true
         type: choice
         options:
+          - address-book
           - contracts
+          - interfaces
           - sdk
+          - toolshed
       tag:
         description: 'Tag to publish'
         required: true
         type: string
         default: latest
+      dry_run:
+        description: 'Dry-run (validate only, no publish or git tag)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -29,8 +37,20 @@ jobs:
         uses: ./.github/actions/setup
       - name: Set npm token for publishing
         run: pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.GRAPHPROTOCOL_NPM_TOKEN }}
+      - name: Read package info
+        id: pkg
+        shell: bash
+        run: |
+          PKG_NAME=$(node -p "require('./packages/${{ inputs.package }}/package.json').name")
+          PKG_VERSION=$(node -p "require('./packages/${{ inputs.package }}/package.json').version")
+          echo "tag=${PKG_NAME}@${PKG_VERSION}" >> $GITHUB_OUTPUT
       - name: Publish 🚀
         shell: bash
         run: |
           pushd packages/${{ inputs.package }}
-          pnpm publish --tag ${{ inputs.tag }} --access public --no-git-checks
+          pnpm publish --tag ${{ inputs.tag }} --access public --no-git-checks ${{ inputs.dry_run && '--dry-run' || '' }}
+      - name: Tag release
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag ${{ steps.pkg.outputs.tag }}
+          git push origin ${{ steps.pkg.outputs.tag }}


### PR DESCRIPTION
Token-based auth using `GRAPHPROTOCOL_NPM_TOKEN` is no longer working and we need to migrate to NPM OIDC trusted publishing.

## Changes

- OIDC trusted publishing ([a8ccc177d](#)): Drop the npm token and authenticate via GitHub's OIDC. Adds `id-token: write` permission and `--provenance` to the publish command, which also attaches a sigstore attestation tying each tarball to this commit.
- npm CLI upgrade ([82cc38c77](#)): `pnpm publish` shells out to npm for registry auth; npm ≥ 11.5.1 is required for OIDC trusted publishing, so we `npm install -g npm@latest` before publishing.
- Workflow coverage ([dcde8641a](#)): Add `address-book`, `interfaces`, and `toolshed` to the package dropdown; add a `dry_run` input that runs `pnpm publish --dry-run` and skips the git tag step; on real runs, push a `<pkg>@<version>` git tag (requires `contents: write`).
- pnpm version sync ([9c1c689b8](#)): Bump the corepack-activated pnpm in the setup action from 10.17.0 to 10.28.0 to match the repo's `packageManager` field, avoiding a version mismatch warning.

## Enabling trusted publishing

Trusted publishing needs to be enabled per package on npmjs.com **before** the first run, otherwise auth will fail:

- [ ] `@graphprotocol/contracts` — Settings → Trusted Publisher → GitHub Actions, repo `graphprotocol/contracts`, workflow `publish.yml`, env (none)
- [ ] `@graphprotocol/sdk`
- [ ] `@graphprotocol/interfaces`
- [ ] `@graphprotocol/toolshed`
- [ ] `@graphprotocol/address-book`

Existing 2FA / publish-token settings can stay; trusted publishing is additive.

## Testing

Local validation with `act` was attempted but doesn't exercise the meaningful steps (no real OIDC token, npm self-upgrade breaks under act's tool cache). Plan post-merge:

- [ ] Run workflow with `package=toolshed`, `dry_run=true` from the Actions tab — expect setup → npm upgrade → `pnpm publish --dry-run` to succeed, no tag pushed.
- [ ] If green, run again with `dry_run=false` for a real publish of one package.
- [ ] Verify the `<pkg>@<version>` tag lands on the repo and the published tarball shows a provenance badge on npmjs.com.
- [ ] Repeat for the remaining packages as they're cut.