### PR TITLE
refactor(address-book): consolidate publish source list to one place

### DIFF
--- a/packages/address-book/package.json
+++ b/packages/address-book/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/address-book"
   },
   "exports": {
-    "./horizon/addresses.json": "./src/horizon/addresses.json",
-    "./issuance/addresses.json": "./src/issuance/addresses.json",
-    "./subgraph-service/addresses.json": "./src/subgraph-service/addresses.json"
+    "./*/addresses.json": "./src/*/addresses.json"
   },
   "files": [
     "src/**/*.json",

--- a/packages/address-book/scripts/copy-addresses-for-publish.js
+++ b/packages/address-book/scripts/copy-addresses-for-publish.js
@@ -3,67 +3,52 @@
 /**
  * Copy Addresses for Publishing
  *
- * This script copies the actual addresses.json files from horizon and subgraph-service
- * packages to replace the symlinks before npm publish.
- *
- * Why we need this:
- * - Development uses symlinks (committed to git) for convenience
- * - npm publish doesn't include symlinks in the published package
- * - We need actual files in the published package for consumers
- *
- * The postpublish script will restore the symlinks after publishing.
+ * Replaces the dev-time symlinks under src/<name>/addresses.json with real
+ * file copies before npm publish — npm does not include symlinks in the
+ * published tarball. restore-symlinks.js puts the symlinks back afterwards.
  */
 
 const fs = require('fs')
 const path = require('path')
+const SOURCES = require('./sources')
 
-const FILES_TO_COPY = [
-  {
-    source: '../../../horizon/addresses.json',
-    target: 'src/horizon/addresses.json',
-  },
-  {
-    source: '../../../issuance/addresses.json',
-    target: 'src/issuance/addresses.json',
-  },
-  {
-    source: '../../../subgraph-service/addresses.json',
-    target: 'src/subgraph-service/addresses.json',
-  },
-]
+const ROOT = path.resolve(__dirname, '..')
+const SRC = path.join(ROOT, 'src')
 
-function copyFileForPublish(source, target) {
-  const targetPath = path.resolve(__dirname, '..', target)
-  const sourcePath = path.resolve(path.dirname(targetPath), source)
+function copyOne(name) {
+  const sourcePath = path.resolve(ROOT, '..', name, 'addresses.json')
+  const targetDir = path.join(SRC, name)
+  const targetPath = path.join(targetDir, 'addresses.json')
 
-  // Ensure source exists
   if (!fs.existsSync(sourcePath)) {
     console.error(`❌ Source file ${sourcePath} does not exist`)
     process.exit(1)
   }
 
-  // Remove existing symlink
-  if (fs.existsSync(targetPath)) {
-    fs.unlinkSync(targetPath)
-  }
+  fs.mkdirSync(targetDir, { recursive: true })
+  fs.rmSync(targetPath, { force: true })
+  fs.copyFileSync(sourcePath, targetPath)
+  console.log(`✅ Copied for publish: src/${name}/addresses.json`)
+}
 
-  // Copy actual file
-  try {
-    fs.copyFileSync(sourcePath, targetPath)
-    console.log(`✅ Copied for publish: ${target} <- ${source}`)
-  } catch (error) {
-    console.error(`❌ Failed to copy ${source} to ${target}:`, error.message)
+function checkDrift() {
+  const dirs = fs
+    .readdirSync(SRC)
+    .filter((d) => fs.statSync(path.join(SRC, d)).isDirectory())
+    .sort()
+  const expected = [...SOURCES].sort()
+  if (JSON.stringify(dirs) !== JSON.stringify(expected)) {
+    console.error(`❌ Drift between SOURCES and src/`)
+    console.error(`   SOURCES: [${expected.join(', ')}]`)
+    console.error(`   src/   : [${dirs.join(', ')}]`)
     process.exit(1)
   }
 }
 
 function main() {
   console.log('📦 Copying address files for npm publish...')
-
-  for (const { source, target } of FILES_TO_COPY) {
-    copyFileForPublish(source, target)
-  }
-
+  for (const name of SOURCES) copyOne(name)
+  checkDrift()
   console.log('✅ Address files copied for publish!')
 }
 

--- a/packages/address-book/scripts/restore-symlinks.js
+++ b/packages/address-book/scripts/restore-symlinks.js
@@ -3,54 +3,32 @@
 /**
  * Restore Symlinks After Publishing
  *
- * This script restores the symlinks after npm publish completes.
- * The prepublishOnly script replaces symlinks with actual files for publishing,
- * and this script puts the symlinks back for development.
+ * Restores the dev-time symlinks under src/<name>/addresses.json after
+ * npm publish. copy-addresses-for-publish.js replaces them with real files
+ * for the publish step; this puts them back.
  */
 
 const fs = require('fs')
 const path = require('path')
+const SOURCES = require('./sources')
 
-const SYMLINKS_TO_RESTORE = [
-  {
-    target: '../../../horizon/addresses.json',
-    link: 'src/horizon/addresses.json',
-  },
-  {
-    target: '../../../issuance/addresses.json',
-    link: 'src/issuance/addresses.json',
-  },
-  {
-    target: '../../../subgraph-service/addresses.json',
-    link: 'src/subgraph-service/addresses.json',
-  },
-]
+const ROOT = path.resolve(__dirname, '..')
+const SRC = path.join(ROOT, 'src')
 
-function restoreSymlink(target, link) {
-  const linkPath = path.resolve(__dirname, '..', link)
+function restoreOne(name) {
+  const linkTarget = `../../../${name}/addresses.json`
+  const linkDir = path.join(SRC, name)
+  const linkPath = path.join(linkDir, 'addresses.json')
 
-  // Remove the copied file
-  if (fs.existsSync(linkPath)) {
-    fs.unlinkSync(linkPath)
-  }
-
-  // Restore symlink
-  try {
-    fs.symlinkSync(target, linkPath)
-    console.log(`✅ Restored symlink: ${link} -> ${target}`)
-  } catch (error) {
-    console.error(`❌ Failed to restore symlink ${link}:`, error.message)
-    process.exit(1)
-  }
+  fs.mkdirSync(linkDir, { recursive: true })
+  fs.rmSync(linkPath, { force: true })
+  fs.symlinkSync(linkTarget, linkPath)
+  console.log(`✅ Restored symlink: src/${name}/addresses.json -> ${linkTarget}`)
 }
 
 function main() {
   console.log('🔗 Restoring symlinks after publish...')
-
-  for (const { target, link } of SYMLINKS_TO_RESTORE) {
-    restoreSymlink(target, link)
-  }
-
+  for (const name of SOURCES) restoreOne(name)
   console.log('✅ Symlinks restored!')
 }
 

--- a/packages/address-book/scripts/sources.js
+++ b/packages/address-book/scripts/sources.js
@@ -1,0 +1,4 @@
+// Source packages exported from @graphprotocol/address-book.
+// Each name corresponds to packages/<name>/addresses.json (source of truth)
+// and packages/address-book/src/<name>/addresses.json (publish symlink).
+module.exports = ['horizon', 'issuance', 'subgraph-service']


### PR DESCRIPTION
The set of packages exported by @graphprotocol/address-book was duplicated three times: the exports map in package.json, FILES_TO_COPY in copy-addresses-for-publish.js, and SYMLINKS_TO_RESTORE in restore-symlinks.js. Drift had already crept in -- issuance was referenced everywhere but src/issuance/ was missing on disk, which would break prepublishOnly.

Collapse to a single SOURCES array in scripts/sources.js consumed by both scripts. Use a subpath pattern in package.json exports ("./*/addresses.json": "./src/*/addresses.json") so the exports map no longer enumerates names.

Both scripts now mkdir src/<name>/ recursively and use rmSync({ force: true }) in place of the existsSync/unlinkSync dance, so a missing dir or stale entry is handled silently. The copy step ends with a drift check that catches src/<name>/ dirs not listed in SOURCES (stale leftovers from removed entries).

Verified end-to-end: pnpm pack produces a tarball containing real files under src/{horizon,issuance,subgraph-service}/addresses.json, and restore-symlinks puts the symlinks back at the original relative targets.