### PR TITLE
fix: add recurring collector parameter to deploy configs

### DIFF
--- a/packages/subgraph-service/ignition/configs/protocol.default.json5
+++ b/packages/subgraph-service/ignition/configs/protocol.default.json5
@@ -23,7 +23,8 @@
     "disputeManagerProxyAdminAddress": "",
     "subgraphServiceProxyAddress": "",
     "subgraphServiceProxyAdminAddress": "",
-    "graphTallyCollectorAddress": ""
+    "graphTallyCollectorAddress": "",
+    "recurringCollectorAddress": ""
   },
   "DisputeManager": {
     "disputePeriod": 2419200,

--- a/packages/subgraph-service/ignition/configs/protocol.localNetwork.json5
+++ b/packages/subgraph-service/ignition/configs/protocol.localNetwork.json5
@@ -23,7 +23,8 @@
     "disputeManagerProxyAdminAddress": "",
     "subgraphServiceProxyAddress": "",
     "subgraphServiceProxyAdminAddress": "",
-    "graphTallyCollectorAddress": ""
+    "graphTallyCollectorAddress": "",
+    "recurringCollectorAddress": ""
   },
   "DisputeManager": {
     "disputePeriod": 7200, // 2 hours = 7200 seconds


### PR DESCRIPTION
## TL;DR

Adds the missing `recurringCollectorAddress` slot to two deployment config files. Two lines per file, no logic changes.

## Motivation

Ignition deploys contracts by reading parameter files keyed by network — each file lists every input the deployment module expects. The SubgraphService module asks for a recurring collector address when wiring up its implementation, but neither the default file nor the local-network file declares that key. Any deployment using either of these files aborts before any contract is touched. This blocks the local-network end-to-end DIPs testing pipeline and any other deployment that inherits from the default config.

## Summary

- Add `recurringCollectorAddress` entry to `protocol.default.json5`
- Add `recurringCollectorAddress` entry to `protocol.localNetwork.json5`
